### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stable-slim
+MAINTAINER Vincent Giersch <vincent@flat.io>
+
+RUN mkdir /faust
+WORKDIR /faust
+COPY . /faust
+
+RUN \
+  apt-get update && \
+  apt-get install -y build-essential libssl-dev llvm libncurses5-dev libssl1.0.0 libncurses5 && \
+  rm -rf /var/lib/apt/lists/* && \
+  make && make install && \
+  make -C tools/faust2appls install && \
+  make clean && \
+  apt-get purge -y build-essential libssl-dev llvm libncurses5-dev && apt-get autoremove -y
+
+ENTRYPOINT ["/usr/local/bin/faust"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ The second solution is to download and install the QT4.6 SDK :
 	[QT4.6 SDK](http://qt.nokia.com/downloads/sdk-windows-cpp)
 and use the project file 'compiler.pro' in the compiler folder.
 
+#### Build & Use FAUST with Docker :
+
+	docker build -t faust
+	docker run faust [args...]
+
+For example to display the help:
+
+	docker run faust -h
+
+To use an additional tool, for example faust2pdf:
+
+	docker run --entrypoint faust2pdf faust [args...]
 
 #### Compilation of the examples
 


### PR DESCRIPTION
We initially made this Dockerfile in [December 2014](https://github.com/FlatIO/faudiostream/commit/8b275c203356aa3ea05ca6e1aa915befb80ffd1b) and @mbylstra recently [asked us to make a PR](https://github.com/FlatIO/faudiostream/issues/1) here. I added some doc & updated it for the occasion.

We have the image as an [automated build in our own Docker Hub profile](https://hub.docker.com/r/flat/faust/), it may be interesting to have an automated build from this repository, so the image will always be up-to-date and ready to use.

ref: FlatIO/faudiostream#1