### PR TITLE
Fixes for LLVM 3.4 compatibility.

### DIFF
--- a/compiler/Makefile.unix
+++ b/compiler/Makefile.unix
@@ -46,8 +46,17 @@ else
 endif
 endif
 
-LLVM_STATIC_LIBS = $(shell $(LLVM_CONFIG) --libs --system-libs)
+LLVM_STATIC_LIBS = $(shell $(LLVM_CONFIG) --libs) $(LLVM_SYS_LIBS)
 LLVM_VERSION = $(shell $(LLVM_CONFIG) --version)
+
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.1 3.2 3.3 3.4 3.4.1 3.4.2))
+# Legacy LLVM versions <= 3.4 don't have the llvm-config --system-libs flag,
+# so we use a reasonable default set of libs instead. The following seems to
+# work with LLVM 3.4 on the Mac at least.
+LLVM_SYS_LIBS = -lz -lm
+else
+LLVM_SYS_LIBS = $(shell $(LLVM_CONFIG) --system-libs)
+endif
 
 ## On Windows (mingw32) we must link against the socket library.
 ifneq ($(findstring MINGW32, $(system)),)
@@ -74,7 +83,6 @@ endif
 #            -lclangStaticAnalyzerCheckers -lclangStaticAnalyzerCore \
 #            -lclangAnalysis -lclangRewriteCore -lclangRewriteFrontend \
 #            -lclangEdit -lclangLex
-
 
 ifeq ($(LLVM_VERSION), 3.1)
     LLVM_VERSION = LLVM_31
@@ -142,7 +150,7 @@ ifneq ($(LLVMSHLIB),)
     LLVMLIBS = -l$(patsubst lib%,%,$(notdir $(basename $(LLVMSHLIB))))
 endif
 
-LLVMLIBS += $(shell $(LLVM_CONFIG) --libs --system-libs)
+LLVMLIBS += $(shell $(LLVM_CONFIG) --libs) $(LLVM_SYS_LIBS)
 
 all : faust libfaust.a
 


### PR DESCRIPTION
Hi Stéphane, can you please review this and merge? I need this to build faust2 against LLVM 3.4 for MacPorts. Compilation is currently broken for LLVM < 3.5 because these don't have the `llvm-config --system-libs` option yet.

This shouldn't cause any changes with any of the newer versions (3.5+). I tested with LLVM 3.4.2, 3.5.2 and 3.9.1 from MacPorts and it works fine with each of these.