### PR TITLE
Add appropriate options to the SC generator

### DIFF
--- a/architecture/supercollider.cpp
+++ b/architecture/supercollider.cpp
@@ -293,9 +293,9 @@ static std::string normalizeClassName(const std::string& name)
 extern "C"
 {
 #ifdef SC_API_EXPORT
-    int api_version(void);
+    FAUST_EXPORT int api_version(void);
 #endif
-    void load(InterfaceTable*);
+    FAUST_EXPORT void load(InterfaceTable*);
     void Faust_next(Faust*, int);
     void Faust_next_copy(Faust*, int);
     void Faust_next_clear(Faust*, int);


### PR DESCRIPTION
It seems like some options that were required for SuperCollider, and that were reported had not been properly added. This PR should fix this.