### PR TITLE
Changed the coefficient of lip filter according to original STK's way.

### DIFF
--- a/libraries/physmodels.lib
+++ b/libraries/physmodels.lib
@@ -1404,9 +1404,9 @@ brassLipsTable(tubeLength,lipsTension) = *(0.03) : lipFilter <: * : clipping
 with{
   clipping = min(1) : max(-1);
   freq = (tubeLength : l2f)*pow(4,(2*lipsTension)-1);
-  filterR = 0.994009;
+  filterR = 0.997;
   a1 = -2*filterR*cos(ma.PI*2*freq/ma.SR);
-  lipFilter = fi.tf2(1,0,0,a1,filterR); // resonance with same freq as tube
+  lipFilter = fi.tf2(1,0,0,a1,pow(filterR,2)); // resonance with same freq as tube
 };
 
 //-------`clarinetReed`----------


### PR DESCRIPTION
In original STK source,coefficient a1 is not squared (https://github.com/thestk/stk/blob/master/src/BiQuad.cpp & https://github.com/thestk/stk/blob/master/src/Brass.cpp).

 Or, Should it be written by using `fi.resonlp`?