### PR TITLE
support supernova

### DIFF
--- a/architecture/supercollider.cpp
+++ b/architecture/supercollider.cpp
@@ -531,4 +531,10 @@ FAUST_EXPORT void load(InterfaceTable* inTable)
 #endif // NDEBUG
 }
 
+#ifdef SUPERNOVA 
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_supernova; }
+#else
+extern "C" FAUST_EXPORT int server_type(void) { return sc_server_scsynth; }
+#endif
+
 // EOF


### PR DESCRIPTION
These definitions are required to support supernova, the  multiprocessor SuperCollider server. They have no effect outside of Supercollider build scripts with Supernova enabled.

@LFSaw asked me to take my supernova enabler for his JPverb upstream to you.

https://github.com/supercollider/sc3-plugins/pull/149
