### PR TITLE
Unity: add support for Windows Store Apps

### DIFF
--- a/architecture/unity/FaustUtilities_template.cs
+++ b/architecture/unity/FaustUtilities_template.cs
@@ -245,7 +245,7 @@ namespace FaustUtilities_MODEL {
 
 		private IntPtr _context;
 
-        #if UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_EDITOR || UNITY_STANDALONE_LINUX
+        #if UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_EDITOR || UNITY_STANDALONE_LINUX || UNITY_WSA || UNITY_WSA_10_0
         const string _dllName = "PLUGNAME";
         #elif UNITY_IOS
         const string _dllName = "__Internal";


### PR DESCRIPTION
This is required for deploying to Unity WSA apps, e.g. for HoloLens and mixed reality