### PR TITLE
Unity: fix lib prefix for binaries

### DIFF
--- a/tools/faust2appls/faust2linuxunity
+++ b/tools/faust2appls/faust2linuxunity
@@ -66,6 +66,7 @@ for p in $FILES; do
     f=$(basename "$p")
     NAME=${f%.dsp}
     FNAME=FaustPlugin_$NAME
+    LIBNAME=lib$FNAME$EXT
     SRCDIR=$(dirname "$p")
     FIN=$FNAME/Linux
 
@@ -85,13 +86,13 @@ for p in $FILES; do
     # compile c++ to binary
     (
         cd "$TMP"
-		$CXX $CXXFLAGS $LIB -Dmydsp=$NAME -o $FNAME$EXT $NAME.cpp
+		$CXX $CXXFLAGS $LIB -Dmydsp=$NAME -o $LIBNAME $NAME.cpp
 
     ) > /dev/null || (echo "$f : C++ to linux library compilation failed in Faust2linuxunity"; exit 1)
 
     # moves binary to final dir
-    rm -rf "$SRCDIR/$FNAME$EXT"
-    mv "$TMP/$FNAME$EXT" "$FIN/$FNAME$EXT"
+    rm -rf "$SRCDIR/$LIBNAME"
+    mv "$TMP/$LIBNAME" "$FIN/$LIBNAME"
     rm -rf "$TDR"
 
     echo "$f : linux compilation completed"

--- a/tools/faust2appls/faust2w32unity
+++ b/tools/faust2appls/faust2w32unity
@@ -62,6 +62,7 @@ for p in $FILES; do
     f=$(basename "$p")
     NAME=${f%.dsp}
     FNAME=FaustPlugin_$NAME
+    LIBNAME=lib$FNAME$EXT
     SRCDIR=$(dirname "$p")
     FIN=$FNAME/x86
 
@@ -81,13 +82,13 @@ for p in $FILES; do
     # compile c++ to binary
     (
         cd "$TMP"
-		$CXX $CXXFLAGS $PROCARCH $LIB $OMP -static-libstdc++ -static-libgcc -Dmydsp=$NAME -o $FNAME$EXT $NAME.cpp
+		$CXX $CXXFLAGS $PROCARCH $LIB $OMP -static-libstdc++ -static-libgcc -Dmydsp=$NAME -o $LIBNAME $NAME.cpp
 
     ) > /dev/null || (echo "$f : C++ to w32 library compilation failed in Faust2w32unity"; exit 1)
 
     # moves binary to final dir
-    rm -rf "$SRCDIR/$FNAME$EXT"
-    mv "$TMP/$FNAME$EXT" "$FIN/$FNAME$EXT"
+    rm -rf "$SRCDIR/$LIBNAME"
+    mv "$TMP/$LIBNAME" "$FIN/$LIBNAME"
     rm -rf "$TDR"
 
     echo "$f : w32 compilation completed"

--- a/tools/faust2appls/faust2w64unity
+++ b/tools/faust2appls/faust2w64unity
@@ -64,6 +64,7 @@ for p in $FILES; do
     f=$(basename "$p")
     NAME=${f%.dsp}
     FNAME=FaustPlugin_$NAME
+    LIBNAME=lib$FNAME$EXT
     SRCDIR=$(dirname "$p")
     FIN=$FNAME/x64
 
@@ -83,13 +84,13 @@ for p in $FILES; do
     # compile c++ to binary
     (
         cd "$TMP"
-		$CXX $CXXFLAGS $PROCARCH $LIB $OMP -static-libstdc++ -static-libgcc -Dmydsp=$NAME -o $FNAME$EXT $NAME.cpp
+		$CXX $CXXFLAGS $PROCARCH $LIB $OMP -static-libstdc++ -static-libgcc -Dmydsp=$NAME -o $LIBNAME $NAME.cpp
     ) > /dev/null || (echo "$f : C++ to w64 library compilation failed in faust2w64unity"; exit 1)
 
-    rm -rf "$SRCDIR/$FNAME$EXT"
+    rm -rf "$SRCDIR/$LIBNAME"
 
     # moves binary to final dir 
-    mv "$TMP/$FNAME$EXT" "$FIN/$FNAME$EXT"
+    mv "$TMP/$LIBNAME" "$FIN/$LIBNAME"
     rm -rf "$TDR"
 
 echo "$f : w64 compilation completed"


### PR DESCRIPTION
This fixes a problem with generated dlls not being found in Unity.

The compiled dlls should have the `lib` prefix, as replaced by sed in
`faust2unity`

`sed -e "s/MODEL/$NAME/g;s/PLUGNAME/lib$FNAME/`

Currently they just use $FNAME, this adds the `lib` prefix