### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/compiler/documentator/doc_lang.cpp
+++ b/compiler/documentator/doc_lang.cpp
@@ -54,7 +54,7 @@ static const string			gDocTextsDefaultFile = "mathdoctexts-default.txt";
 
 static void			importDocStrings(const string& filename);
 static void			getKey(string& s, string& key, size_t& pt1);
-static void			getText(string& s, size_t& pt1, string& text);
+static void			getText(const string& s, size_t pt1, string& text);
 static void			storePair(const string& key, const string& text);
 
 static void			printStringMapContent(map<string,string>& map, const string& name);

--- a/compiler/documentator/doc_lang.cpp
+++ b/compiler/documentator/doc_lang.cpp
@@ -161,7 +161,7 @@ static void getKey(string& s, string& key, size_t& pt1)
 }
 
 
-static void getText(string& s, size_t& pt1, string& text)
+static void getText(const string& s, size_t pt1, string& text)
 {
 	/* Capture the text on the current line. */
 	size_t pt2;

--- a/compiler/documentator/lateq.cpp
+++ b/compiler/documentator/lateq.cpp
@@ -248,9 +248,9 @@ vector<list<string> > Lateq::makeUISignamesVector(const multimap<string,string>&
 		} else {
 			++vIndex;
 			uiTypesMap.insert(pair<char,unsigned int>(type, vIndex));
-			list<string>* tmpList = new(list<string>);
-			tmpList->push_back(signame);
-			uiSignamesVector.push_back(*tmpList);
+			list<string> tmpList;
+			tmpList.push_back(signame);
+			uiSignamesVector.push_back(tmpList);
 		}
 	}
 	

--- a/compiler/draw/schema/schema.h
+++ b/compiler/draw/schema/schema.h
@@ -42,6 +42,7 @@ struct point
     double  x;
     double  y;
 
+    point() : x(0.0), y(0.0) {}
     point(double u, double v) : x(u), y(v) {}
     point(const point& p) : x(p.x), y(p.y) {}
 

--- a/compiler/extended/fmodprim.cpp
+++ b/compiler/extended/fmodprim.cpp
@@ -39,7 +39,7 @@ class FmodPrim : public xtended
 	virtual Tree	computeSigOutput (const vector<Tree>& args) {
 		num n,m;
 		assert (args.size() == arity());
-		if (isNum(args[0],n) & isNum(args[1],m)) {
+		if (isNum(args[0],n) && isNum(args[1],m)) {
 			return tree(fmod(double(n), double(m)));
 		} else {
 			return tree(symbol(), args[0], args[1]);

--- a/compiler/extended/powprim.cpp
+++ b/compiler/extended/powprim.cpp
@@ -38,7 +38,7 @@ class PowPrim : public xtended
 	virtual Tree	computeSigOutput (const vector<Tree>& args) {
 		num n,m;
 		assert (args.size() == arity());
-		if (isNum(args[0],n) & isNum(args[1],m)) {
+		if (isNum(args[0],n) && isNum(args[1],m)) {
 			return tree(pow(double(n), double(m)));
 		} else {
 			return tree(symbol(), args[0], args[1]);

--- a/compiler/extended/remainderprim.cpp
+++ b/compiler/extended/remainderprim.cpp
@@ -33,7 +33,7 @@ class RemainderPrim : public xtended
 	virtual Tree	computeSigOutput (const vector<Tree>& args) {
 		num n,m;
 		assert (args.size() == arity());
-		if (isNum(args[0],n) & isNum(args[1],m)) {
+		if (isNum(args[0],n) && isNum(args[1],m)) {
 			return tree(remainder(double(n), double(m)));
 		} else {
 			return tree(symbol(), args[0], args[1]);

--- a/compiler/generator/Text.cpp
+++ b/compiler/generator/Text.cpp
@@ -197,7 +197,7 @@ string T(double n)
         do { snprintf(c, 32, "%.*g", p++, v); endp=0; } while (strtof(c, &endp) != v);
     } else if (gFloatSize==2) {
         do { snprintf(c, 32, "%.*g", p++, n); endp=0; } while (strtod(c, &endp) != n);
-    } if (gFloatSize==3) {
+    } else if (gFloatSize==3) {
         long double q = n;
         do { snprintf(c, 32, "%.*Lg", p++, q); endp=0; } while (strtold(c, &endp) != q);
     }

--- a/compiler/normalize/mterm.cpp
+++ b/compiler/normalize/mterm.cpp
@@ -476,7 +476,7 @@ Tree mterm::normalizedTree(bool signatureMode, bool negativeMode) const
 		#endif
 		
 		// we only use a coeficient if it differes from 1 and if we are not in signature mode
-		if (! (signatureMode | isOne(fCoef))) {
+		if (! (signatureMode || isOne(fCoef))) {
 			A[0] = (negativeMode) ? minusNum(fCoef) : fCoef;
 		}
 		

--- a/compiler/parser/enrobage.cpp
+++ b/compiler/parser/enrobage.cpp
@@ -307,6 +307,7 @@ static FILE* fopenat(string& fullpath, const char* dir, const char* filename)
 	    char* newdir = getcwd(newdirbuffer, FAUST_PATH_MAX);
         if (!newdir) {
             cerr << "ERROR : getcwd '" << strerror(errno) << endl;
+            fclose(f);
             return 0;
         }
 		fullpath = newdir;

--- a/compiler/parser/sourcefetcher.cpp
+++ b/compiler/parser/sourcefetcher.cpp
@@ -504,7 +504,7 @@ int http_setUserAgent(const char *newAgent)
 		userAgent = NULL;
 		hideUserAgent = 1;
 	} else {
-		tmp = (char *)malloc(strlen(newAgent));
+		tmp = (char *)malloc(strlen(newAgent) + 1);
 		if (tmp == NULL) {
 			errorSource = ERRNO;
 			return -1;
@@ -535,7 +535,7 @@ int http_setReferer(const char *newReferer)
 		referer = NULL;
 		hideReferer = 1;
 	} else {
-		tmp = (char *)malloc(strlen(newReferer));
+		tmp = (char *)malloc(strlen(newReferer) + 1);
 		if (tmp == NULL) {
 			errorSource = ERRNO;
 			return -1;
@@ -598,7 +598,7 @@ int http_parseFilename(const char *url, char **filename)
 	if (*ptr == '\0')
 		return 1;
 
-	*filename = (char *)malloc(strlen(ptr));
+	*filename = (char *)malloc(strlen(ptr) + 1);
 	if (*filename == NULL) {
 		errorSource = ERRNO;
 		return -1;

--- a/compiler/parser/sourcefetcher.hh
+++ b/compiler/parser/sourcefetcher.hh
@@ -47,7 +47,7 @@
 	 
 #define REQUEST_BUF_SIZE 		1024
 #define HEADER_BUF_SIZE 		1024
-#define DEFAULT_PAGE_BUF_SIZE 	1024 * 200	/* 200K should hold most things */
+#define DEFAULT_PAGE_BUF_SIZE 	(1024 * 200)	/* 200K should hold most things */
 #define DEFAULT_REDIRECTS       3           /* Number of HTTP redirects to follow */
 
 #ifdef _WIN32


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

- [V730 ](https://www.viva64.com/en/w/v730/)Not all members of a class are initialized inside the constructor. Consider inspecting: hasRealInput, hasRealOutput. schema.h 63 (fixed by point() constructor introduction)
- [V773 ](https://www.viva64.com/en/w/v773/)Visibility scope of the 'tmpList' pointer was exited without releasing the memory. A memory leak is possible. lateq.cpp 254
- [V792 ](https://www.viva64.com/en/w/v792/)The 'isNum' function located to the right of the operator '&' will be called regardless of the value of the left operand. Perhaps, it is better to use '&&'. fmodprim.cpp 42
- [V792 ](https://www.viva64.com/en/w/v792/)The 'isNum' function located to the right of the operator '&' will be called regardless of the value of the left operand. Perhaps, it is better to use '&&'. powprim.cpp 41
- [V792 ](https://www.viva64.com/en/w/v792/)The 'isNum' function located to the right of the operator '&' will be called regardless of the value of the left operand. Perhaps, it is better to use '&&'. remainderprim.cpp 36
- [V646 ](https://www.viva64.com/en/w/v646/)Consider inspecting the application's logic. It's possible that 'else' keyword is missing. text.cpp 201
- [V792 ](https://www.viva64.com/en/w/v792/)The 'isOne' function located to the right of the operator '|' will be called regardless of the value of the left operand. Perhaps, it is better to use '||'. mterm.cpp 479
- [V518 ](https://www.viva64.com/en/w/v518/)The 'malloc' function allocates strange amount of memory calculated by 'strlen(expr)'. Perhaps the correct variant is 'strlen(expr) + 1'. sourcefetcher.cpp 507
- [V518 ](https://www.viva64.com/en/w/v518/)The 'malloc' function allocates strange amount of memory calculated by 'strlen(expr)'. Perhaps the correct variant is 'strlen(expr) + 1'. sourcefetcher.cpp 538
- [V518](https://www.viva64.com/en/w/v518/) The 'malloc' function allocates strange amount of memory calculated by 'strlen(expr)'. Perhaps the correct variant is 'strlen(expr) + 1'. sourcefetcher.cpp 601
- [V773 ](https://www.viva64.com/en/w/v773/)The function was exited without releasing the 'f' handle. A resource leak is possible. enrobage.cpp 310
- [V669 ](https://www.viva64.com/en/w/v669/)The 'pt1' argument is a non-constant reference. The analyzer is unable to determine the position at which this argument is being modified. It is possible that the function contains an error. doc_lang.cpp 164
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'DEFAULT_PAGE_BUF_SIZE' is a dangerous expression. The expression must be surrounded by parentheses. sourcefetcher.hh 50

Not fixed but take a look at it:
- [V523 ](https://www.viva64.com/en/w/v523/)The 'then' statement is equivalent to the 'else' statement. doc_compile.cpp 1221
- [V501 ](https://www.viva64.com/en/w/v501/)There are identical sub-expressions to the left and to the right of the '/' operator: (x * p) / (x * p) compatibility.cpp 190

There are actually more warnings were found but they are not so interesting.