### PR TITLE
Minimum dataspace array sizes of 1 for Microsoft C++ compiler.

### DIFF
--- a/architecture/csound.cpp
+++ b/architecture/csound.cpp
@@ -1,8 +1,8 @@
 /************************************************************************
- 
- IMPORTANT NOTE : this file contains two clearly delimited sections : 
- the ARCHITECTURE section (in two parts) and the USER section. Each section 
- is governed by its own copyright and license. Please check individually 
+
+ IMPORTANT NOTE : this file contains two clearly delimited sections :
+ the ARCHITECTURE section (in two parts) and the USER section. Each section
+ is governed by its own copyright and license. Please check individually
  each section for license and copyright information.
  *************************************************************************/
 
@@ -12,24 +12,24 @@
  FAUST Architecture File
  Copyright (C) 2010-2011 V. Lazzarini and GRAME
  ---------------------------------------------------------------------
- This Architecture section is free software; you can redistribute it 
- and/or modify it under the terms of the GNU General Public License 
- as published by the Free Software Foundation; either version 3 of 
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
  the License, or (at your option) any later version.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
- You should have received a copy of the GNU General Public License 
+
+ You should have received a copy of the GNU General Public License
  along with this program; If not, see <http://www.gnu.org/licenses/>.
- 
- EXCEPTION : As a special exception, you may create a larger work 
- that contains this FAUST architecture section and distribute  
- that work under terms of your choice, so long as this FAUST 
- architecture section is not modified. 
- 
+
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+
  ************************************************************************
  ************************************************************************/
 
@@ -37,7 +37,7 @@
 //
 //          CSOUND6 architecture file for FAUST
 //          Y. Orlarey & V. Lazzarini
-//          
+//
 //          Usage : faust -uim -a csound.cpp <myfx>.dsp -o <myfx>.cpp
 //                  g++ -O3 -DOPCODE_NAME=<myfx> -c <myfx>.cpp -o <myfx>.o
 //                  ld -E --shared <myfx>.o -o <myfx>.so
@@ -63,7 +63,7 @@
 // we require macro declarations
 #define FAUST_UIMACROS
 
-// but we will ignore most of them 
+// but we will ignore most of them
 #define FAUST_ADDBUTTON(l,f)
 #define FAUST_ADDCHECKBOX(l,f)
 #define FAUST_ADDVERTICALSLIDER(l,f,i,a,b,s)
@@ -79,9 +79,9 @@
 
 /******************************************************************************
  *******************************************************************************
- 
+
  VECTOR INTRINSICS
- 
+
  *******************************************************************************
  *******************************************************************************/
 
@@ -94,35 +94,35 @@
 class CSUI : public UI
 {
     std::vector<FAUSTFLOAT*>  vZone;
-    
+
 public:
-    
+
     // -- widget's layouts
-    
+
     virtual void openTabBox(const char* label)                                                          {}
     virtual void openHorizontalBox(const char* label)                                                   {}
     virtual void openVerticalBox(const char* label)                                                     {}
     virtual void closeBox()                                                                             {}
-    
+
     // -- active widgets
-    
+
     virtual void addButton(const char* label, FAUSTFLOAT* zone)                                                          { vZone.push_back(zone); }
     virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)                                                     { vZone.push_back(zone); }
     virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)    { vZone.push_back(zone); }
     virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)  { vZone.push_back(zone); }
     virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)          { vZone.push_back(zone); }
-    
+
     // -- passive widgets
-    
+
     virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)            {}
     virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)              {}
-    
+
     virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-    
+
     void copyfrom(MYFLT* mem[]) {
         for (unsigned int i=0; i<vZone.size(); i++) { *vZone[i] = *(mem[i]); }
     }
-    
+
     int size()                  { return vZone.size(); }
 };
 
@@ -138,9 +138,9 @@ public:
 
 struct dataspace {
     OPDS      h;                          /* basic attributes */
-    MYFLT*    aout[FAUST_OUTPUTS];        /* output buffers   */
-    MYFLT*    ain[FAUST_INPUTS];          /* input buffers    */
-    MYFLT*    ktl[FAUST_ACTIVES];         /* controls         */
+    MYFLT*    aout[1+FAUST_OUTPUTS];      /* output buffers   */
+    MYFLT*    ain[1+FAUST_INPUTS];        /* input buffers    */
+    MYFLT*    ktl[1+FAUST_ACTIVES];       /* controls         */
     dsp*      DSP;                        /* the Faust generated object */
     CSUI*     interface;                  /* do the mapping between CSound controls and DSP fields */
     AUXCH     dspmem;                     /* aux memory allocated once to store the DSP object */
@@ -170,18 +170,18 @@ static int init(CSOUND *csound, dataspace *p)
 {
     if (p->dspmem.auxp == NULL)
         csound->AuxAlloc(csound, sizeof(mydsp), &p->dspmem);
-    
+
     if(p->intmem.auxp == NULL)
         csound->AuxAlloc(csound, sizeof(CSUI), &p->intmem);
-    
+
     p->DSP = new (p->dspmem.auxp) mydsp;
     p->interface = new (p->intmem.auxp) CSUI;
-    
+
     if ((p->DSP == 0) | (p->interface == 0)) return NOTOK;
-    
-    p->DSP->init((int)csound->GetSr(csound));   
+
+    p->DSP->init((int)csound->GetSr(csound));
     p->DSP->buildUserInterface(p->interface);
-    
+
     return OK;
 }
 
@@ -193,10 +193,10 @@ static int init(CSOUND *csound, dataspace *p)
 static int process32bits(CSOUND *csound, dataspace *p)
 {
     AVOIDDENORMALS;
-    
+
     // update all the control values
     p->interface->copyfrom(p->ktl);
-    
+
     p->DSP->compute(csound->GetKsmps(csound), p->ain, p->aout);
     return OK;
 }


### PR DESCRIPTION
The Microsoft compiler does not permit the declaration of zero size arrays. This commit makes each array in the dataspace struct for the Csound template have a minimum size of 1.