### PR TITLE
fix bitcode compile for pure-lang/pd-faust

### DIFF
--- a/architecture/pure.c
+++ b/architecture/pure.c
@@ -85,7 +85,7 @@ typedef struct {
 typedef void (* metaDeclareFun) (void*, const char* key, const char* value);
 
 typedef struct {
-  void *mInterface;
+  void *metaInterface;
   metaDeclareFun declare;
 } MetaGlue;
 


### PR DESCRIPTION
this change required in order to successfully run "make bitcode" for pure-lang's pd-faust framework

(@agraef - still haven't managed to get pd-faust compiling/working correctly against recent faust, pd & pure-lang repositories but this is surely a step in the right direction)