### PR TITLE
replacing NDEBUG macro with the more specific F2SC_DEBUG_MES...

### DIFF
--- a/architecture/supercollider.cpp
+++ b/architecture/supercollider.cpp
@@ -437,7 +437,7 @@ void Faust_Ctor(Faust* unit)  // module constructor
                 }
                 SETCALC(Faust_next_copy);
             }
-    #if !defined(NDEBUG)
+    #if defined(F2SC_DEBUG_MES)
             Print("Faust[%s]:\n", g_unitName);
             Print("    Inputs:   %d\n"
                   "    Outputs:  %d\n"
@@ -500,7 +500,7 @@ FAUST_EXPORT void load(InterfaceTable* inTable)
   
     name = normalizeClassName(name);
 
-#if !defined(NDEBUG) & defined(SC_API_EXPORT)
+#if defined(F2SC_DEBUG_MES) & defined(SC_API_EXPORT)
     Print("Faust: supercollider.cpp: sc_api_version = %d\n", sc_api_version);
 #endif
 
@@ -529,9 +529,9 @@ FAUST_EXPORT void load(InterfaceTable* inTable)
         kUnitDef_CantAliasInputsToOutputs
         );
 
-#if !defined(NDEBUG)
+#if defined(F2SC_DEBUG_MES)
     Print("Faust: %s numControls=%d\n", name.c_str(), g_numControls);
-#endif // NDEBUG
+#endif // F2SC_DEBUG_MES
 }
 
 #ifdef SUPERNOVA 

--- a/tools/faust2appls/faust2supercollider
+++ b/tools/faust2appls/faust2supercollider
@@ -135,7 +135,7 @@ fi
 
 if [ $F2SC_DEBUG_MES = 1 ]; then
     echo "Activate debug messages in the generated plugin"
-    DNDEBUG=""
+    DNDEBUG="-DF2SC_DEBUG_MES"
 else
     DNDEBUG="-DNDEBUG"
 fi


### PR DESCRIPTION
… in the supercollider cpp file and in faust2supercollider script.

This PR is motivated by the need for inclusion off faust generated cpp files into the official sc3-plugins repository, which is often compiled in debug mode. Without this patch, the Faust prints are distracting the supercollider console, while not debugging the faust related development. This could pave the way to seamless integration of faust generated UGens.

The change proposed here makes the `Print` invocation in the cpp file very specific and controllable through the `-dm` option in the faut2supercollider script.

