### PR TITLE
adding the -noprefix option to faust2supercollider script

### DIFF
--- a/architecture/supercollider.cpp
+++ b/architecture/supercollider.cpp
@@ -18,9 +18,9 @@
 // 02111-1307 USA
 //-------------------------------------------------------------------
 
-// If other than 'faust2sc --prefix Faust' is used, sed this as well:
+// The prefix is set to "Faust" in the faust2supercollider script, otherwise set empty
 #if !defined(SC_FAUST_PREFIX)
-#define SC_FAUST_PREFIX "Faust"
+#define SC_FAUST_PREFIX ""
 #endif
 
 #include <map>

--- a/tools/faust2appls/faust2supercollider
+++ b/tools/faust2appls/faust2supercollider
@@ -65,7 +65,7 @@ INCLUDE="-I$SC/plugin_interface/ -I$SC/common/ -I$SC/server/ -I$FAUSTLIB"
 
 if [ $# = 0 ]; then
     echo USAGE:
-    echo "$0 [-d[ebug]] [-dm] [-icc] [-omp] [-sd] [-ks] file1.dsp [file2.dsp ...]"
+    echo "$0 [-d[ebug]] [-dm] [-icc] [-omp] [-sd] [-ks] [-sn] [-noprefix] file1.dsp [file2.dsp ...]"
     exit 1
 fi
 
@@ -76,7 +76,9 @@ fi
 # if -d or -debug               -> F2SC_DEBUG
 # if -dm                        -> F2SC_DEBUG_MES
 # if -ks                        -> KEEP_SRC
+# if -noprefix                  -> NO_FAUST_PREFIX
 # if -sd or -synthdef           -> SYNTHDEF
+# if -sn                        -> SUPERNOVA_FLAG
 # existing *.dsp files          -> FILES
 #
 
@@ -95,6 +97,7 @@ F2SC_DEBUG_MES=0
 SUPERNOVA_FLAG=0
 KEEP_SRC=0
 SYNTHDEF=""
+NO_FAUST_PREFIX=0
 
 for p in $@; do
 
@@ -112,6 +115,8 @@ for p in $@; do
         F2SC_DEBUG_MES=1
     elif [ "$p" = -ks ]; then
         KEEP_SRC=1
+    elif [ "$p" = -noprefix ]; then
+        NO_FAUST_PREFIX=1
     elif [ "$p" = -sd ] || [ "$p" = -synthdef ]; then
         SYNTHDEF="--synthdef"
     elif [ "$p" = -sn ] || [ "$p" = -supernova ]; then
@@ -181,9 +186,14 @@ for p in $FILES; do
 
     # compile c++ to binary; --prefix should be same as in ../../examples/Makefile.sccompile
     (
+	SC_FAUST_PREFIX="Faust"
+	if [ $NO_FAUST_PREFIX = 1 ]; then
+            SC_FAUST_PREFIX=""
+	fi
+
         cd "$TMP"
-        faust2sc --prefix=Faust $SYNTHDEF $f.xml > "${f%.dsp}.sc" 2>$OUTDEV
-        BUILDFLAGS="-O3 $FAUSTTOOLSFLAGS $SCFLAGS -I$CUR $INCLUDE $CXXFLAGS $OMP"
+        faust2sc --prefix=$SC_FAUST_PREFIX $SYNTHDEF $f.xml > "${f%.dsp}.sc" 2>$OUTDEV
+        BUILDFLAGS="-O3 $FAUSTTOOLSFLAGS $SCFLAGS -I$CUR $INCLUDE $CXXFLAGS $OMP -DSC_FAUST_PREFIX=\"$SC_FAUST_PREFIX\""
         
         #build for build scsynth
         ${CXX=g++} $BUILDFLAGS -Dmydsp=${f%.dsp} -o ${f%.dsp}.$EXT ${f%.dsp}.cpp

--- a/tools/faust2sc-1.0.0/faust2sc
+++ b/tools/faust2sc-1.0.0/faust2sc
@@ -311,12 +311,11 @@ module Faust
     def make_class_name(unit_name, prefix)
       # The SuperCollider UGen class name generated here must match 
       # that generated in the Faust architecture file supercollider.cpp
-      if prefix == ""
-        prefix = "Faust"
-      end
       class_name = unit_name
       class_name = class_name.sub(/^#{prefix}/i, '')
-      class_name = prefix + '_' + class_name
+      if prefix != ""
+        class_name = prefix + '_' + class_name
+      end
       cna = class_name.split(/[^0-9a-z]/i)
       cna.each_index { |i| cna[i] = cna[i].encapitalize } # SC name convention
       class_name = cna.join
@@ -472,6 +471,8 @@ EOF
           generate_synthdef(io)
         end
         io.print("\n  name { ^\"#{@class_name}\" }\n")
+        io.print("\n")
+        io.print("\n  info { ^\"Generated with Faust\" }\n")
         io.print("}\n")
       end
       def generate_outputs(io)


### PR DESCRIPTION
We added the option -noprefix to the faust2supercollider script. Default behavior remains the same as previous: "Faust" is used as prefix. 

With the -noprefix option, the resulting UGen class name comply with supercollider3 naming conventions. 

This follows the discussion #131 