### PR TITLE
LLVM 3.4 support

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -131,9 +131,11 @@ macro (llvm_config)
 	string ( STRIP ${LLVM_LDFLAGS_TMP} LLVM_LD_FLAGS )
 	execute_process (COMMAND ${LLVM_CONFIG}  --libs OUTPUT_VARIABLE LLVM_LIBS_TMP)
 	string ( STRIP ${LLVM_LIBS_TMP} LLVM_LIBS )
+	if (${LLVM_VERSION} STRGREATER_EQUAL "3.5")
 	execute_process (COMMAND ${LLVM_CONFIG}  --system-libs OUTPUT_VARIABLE LLVM_SYS_LIBS_TMP)
 	string ( STRIP ${LLVM_SYS_LIBS_TMP} LLVM_SYS_LIBS)
 	set (LLVM_LIBS ${LLVM_LIBS} ${LLVM_SYS_LIBS})
+	endif()
 endmacro()
 
 ####################################


### PR DESCRIPTION
Add back support for LLVM 3.4 where `llvm-config` doesn't have `--system-libs`.

Yes, that's a really old version, but still required to build some LLVM applications (including Pure) in MacPorts, because reportedly it works better than LLVM 3.5 there. And adding back support for this version is trivial, it's just a minor configuration issue.