### PR TITLE
World target fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,23 @@ native :
 	@echo "### Universal mode is OFF"
 	@echo "### You need to recompile"
 
-# make world: This builds all the common targets for a fairly complete Faust
-# installation: Faust compiler and library, sound2faust utility, OSC and HTTPD
-# libraries (both static and dynamic). Most of the extra targets require
-# additional dependencies and hence aren't built by default; please check the
-# Faust README for details. This target may be built in parallel (make -j).
-# NOTE: Once the remote target is readily supported on most platforms, it
-# should be added here. This requires Jack2 1.9.10 or later which isn't
-# usually installed on most systems, so we skip this target for now.
+# make world (MAINTAINERS TARGET): This builds all the common targets for a
+# fairly complete Faust installation: Faust compiler (including the LLVM
+# backend) and library, sound2faust utility, OSC and HTTPD libraries (both
+# static and dynamic).
+
+# CAVEAT: END USERS should note that this target requires a substantial amount
+# of additional dependencies (in particular, LLVM) which aren't readily
+# pre-installed on most systems, hence you should NOT use this target (which
+# is mostly aimed at package maintainers) unless you KNOW WHAT YOU'RE DOING.
+# Don't complain if the target doesn't build for you, use one of the standard
+# build targets instead. You have been warned! :)
+
+# MAINTAINERS: Once the "remote" target is readily supported on most
+# platforms, it should be added here. This requires Jack2 1.9.10 or later
+# which isn't regularly installed on most systems at present, so we skip this
+# target for now.
+
 world :
 	$(MAKE) -C $(BUILDLOCATION) configall configoscdynamic confighttpdynamic BACKENDS=world.cmake
 	$(MAKE) -C $(BUILDLOCATION)

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ native :
 # should be added here. This requires Jack2 1.9.10 or later which isn't
 # usually installed on most systems, so we skip this target for now.
 world :
-	$(MAKE) -C $(BUILDLOCATION) configall
+	$(MAKE) -C $(BUILDLOCATION) configall BACKENDS=world.cmake
 	$(MAKE) -C $(BUILDLOCATION)
 	$(MAKE) -C tools/sound2faust
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ native :
 # should be added here. This requires Jack2 1.9.10 or later which isn't
 # usually installed on most systems, so we skip this target for now.
 world :
-	$(MAKE) -C $(BUILDLOCATION) configall BACKENDS=world.cmake
+	$(MAKE) -C $(BUILDLOCATION) configall configoscdynamic confighttpdynamic BACKENDS=world.cmake
 	$(MAKE) -C $(BUILDLOCATION)
 	$(MAKE) -C tools/sound2faust
 

--- a/build/backends/world.cmake
+++ b/build/backends/world.cmake
@@ -1,0 +1,23 @@
+# this file may be used to select different backends
+# it's always read by the default makefile target
+# values are among: 
+#    OFF       don't include the backend
+#    COMPILER  embed the backend in the faust compiler
+#    STATIC    embed the backend in the faust static library
+#    DYNAMIC   embed the backend in the faust dynamic library
+#    ASMJS     embed the backend in the faust asmjs library
+#    WASM      embed the backend in the faust wasm library
+
+
+set ( ASMJS_BACKEND  COMPILER STATIC DYNAMIC ASMJS  CACHE STRING  "Include ASMJS backend" FORCE )
+set ( C_BACKEND      COMPILER STATIC DYNAMIC        CACHE STRING  "Include C backend"         FORCE )
+set ( CPP_BACKEND    COMPILER STATIC DYNAMIC        CACHE STRING  "Include CPP backend"       FORCE )
+set ( FIR_BACKEND    COMPILER STATIC DYNAMIC        CACHE STRING  "Include FIR backend"       FORCE )
+set ( INTERP_BACKEND OFF                            CACHE STRING  "Include INTERPRETER backend" FORCE )
+set ( JAVA_BACKEND   COMPILER STATIC DYNAMIC        CACHE STRING  "Include JAVA backend"      FORCE )
+set ( JS_BACKEND     COMPILER STATIC DYNAMIC        CACHE STRING  "Include JAVASCRIPT backend" FORCE )
+set ( LLVM_BACKEND   COMPILER STATIC DYNAMIC        CACHE STRING  "Include LLVM backend"      FORCE )
+set ( OLDCPP_BACKEND COMPILER STATIC DYNAMIC        CACHE STRING  "Include old CPP backend"   FORCE )
+set ( RUST_BACKEND   COMPILER STATIC DYNAMIC        CACHE STRING  "Include RUST backend"      FORCE )
+set ( WASM_BACKEND   COMPILER STATIC DYNAMIC WASM   CACHE STRING  "Include WASM backend"  FORCE )
+


### PR DESCRIPTION
This makes `make world` do what it's supposed to do again.

@dfober, this does what I need now, thanks for the many explanations in pm. I'll merge this right away (as soon as CI finishes)  so that I can go on with my package builds. I think that I didn't accidentally break any of the other targets, but if you notice anything dubious in my changes, please let me know, so that I can fix any remaining issues.