### PR TITLE
Fixed struct type declaration

### DIFF
--- a/compiler/global.hh
+++ b/compiler/global.hh
@@ -58,7 +58,7 @@ struct DispatchVisitor;
 class ASMJAVAScriptInstVisitor;
 class WASTInstVisitor;
 class WASMInstVisitor;
-class DeclareStructTypeInst;
+struct DeclareStructTypeInst;
 
 struct Typed;
 struct BasicTyped;


### PR DESCRIPTION
Fixed a type declaration warning: the variable `DeclareStructTypeInst` is a **struct** - [l. 1321 of instruction.hh](https://github.com/grame-cncm/faust/blob/00a03871a26d0371f1dd33a0791e6ab3070e3e3a/compiler/generator/instructions.hh#L1321) - but is re-declared as a **class**  - [l. 61 of compiler/global.hh](https://github.com/grame-cncm/faust/blob/master-dev/compiler/global.hh#L61).