### PR TITLE
Refactor gui run

### DIFF
--- a/architecture/faust/gui/GUI.h
+++ b/architecture/faust/gui/GUI.h
@@ -109,6 +109,13 @@ class GUI : public UI
         void addCallback(FAUSTFLOAT* zone, uiCallback foo, void* data);
         virtual void show() {};	
         virtual bool run() { return false; };
+
+        static void runAllGuis() {
+            std::list<GUI*>::iterator g;
+            for (g = fGuiList.begin(); g != fGuiList.end(); g++) {
+                (*g)->run();
+            }
+        }
     
         virtual void stop() { fStopped = true; }
         bool stopped() { return fStopped; }

--- a/architecture/jack-gtk.cpp
+++ b/architecture/jack-gtk.cpp
@@ -229,21 +229,13 @@ int main(int argc, char *argv[])
 	httpdinterface.run();
 #endif
 
-#ifdef OSCCTRL
-	oscinterface.run();
-#endif
-    
-#ifdef MIDICTRL
-    if (!midiinterface->run()) {
-        std::cerr << "MidiUI run error\n";
-    }
-#endif
-
 #ifdef OCVCTRL
 	ocvinterface.run();
 #endif
 
-	interface.run();
+	/* call run all GUI instances */
+	GUI::runAllGuis();
+
 	
 	audio.stop();
 	finterface.saveState(rcfilename);


### PR DESCRIPTION
This PR adds the `GUI::runAllGuis()` function, and refactors the `jack-gtk.cpp` architecture to use it.