### PR TITLE
build fixes on archlinux

### DIFF
--- a/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -74,22 +74,22 @@ extern "C" EXPORT const char* getCLibFaustVersion()
 #endif
 
 // Debug tools
-EXPORT extern "C" void printInt32(int val)
+extern "C" EXPORT void printInt32(int val)
 {
     std::cout << "printInt32 : " << val << std::endl;
 }
 
-EXPORT extern "C" void printFloat(float val)
+extern "C" EXPORT void printFloat(float val)
 {
     std::cout << "printFloat : " << val << std::endl;
 }
 
-EXPORT extern "C" void printDouble(double val)
+extern "C" EXPORT void printDouble(double val)
 {
     std::cout << "printDouble : " << val << std::endl;
 }
 
-EXPORT extern "C" void printPtr(void* val)
+extern "C" EXPORT void printPtr(void* val)
 {
     std::cout << "printPtr : " << val << std::endl;
 }

--- a/compiler/parser/sourcefetcher.cpp
+++ b/compiler/parser/sourcefetcher.cpp
@@ -658,8 +658,6 @@ void http_perror(const char* string)
  */
 const char* http_strerror()
 {
-	extern int errno;
-
 	if (errorSource == ERRNO)
 		return strerror(errno);
 	else if (errorSource == H_ERRNO)


### PR DESCRIPTION
I had to perform these changes to build the latest commit - the first (order of extern "C" and export) should not break anything - and I guess the second one neither since <errno.h> is included, thus making that errno declaration redundant.