### PR TITLE
A number of Bela fixes

### DIFF
--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -68,6 +68,11 @@ using namespace std;
 #include "faust/gui/BelaOSCUI.h"
 #endif
 
+#ifdef HTTPDGUI
+#include "faust/gui/httpdUI.h"
+httpdUI* gHttpdinterface;
+#endif /* HTTPDGUI */
+
 // for polyphonic synths
 #include "faust/dsp/poly-dsp.h"
 
@@ -426,6 +431,11 @@ bool setup(BelaContext* context, void* userData)
     
     gDSP->init(context->audioSampleRate);
     gDSP->buildUserInterface(&gControlUI); // Maps Bela Analog/Digital IO and Faust widgets
+#ifdef HTTPDGUI
+    gHttpdinterface = new httpdUI("Bela-UI", gDSP->getNumInputs(), gDSP->getNumOutputs(), 0, NULL);
+    gDSP->buildUserInterface(gHttpdinterface);
+    gHttpdinterface->run();
+#endif /* HTTPDGUI */
 
 #ifdef MIDICTRL
 #ifdef NVOICES
@@ -461,6 +471,9 @@ void render(BelaContext* context, void* userData)
 
 void cleanup(BelaContext* context, void* userData)
 {
+#ifdef HTTPDGUI
+    delete gHttpdinterface;
+#endif /* HTTPDGUI */
     delete [] gInputs;
     delete [] gOutputs;
     delete gDSP;

--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -229,7 +229,7 @@ public:
             case kDIGITAL_13:
             case kDIGITAL_14:
             case kDIGITAL_15:
-                *fZone = digitalRead(context, 0, ((int)fBelaPin - kDIGITAL_0)) > 0 ? fMin : fMin+fRange;
+                *fZone = digitalRead(context, 0, ((int)fBelaPin - kDIGITAL_0)) == 0 ? fMin : fMin+fRange;
                 break;
                 
             case kANALOG_OUT_0:

--- a/architecture/faust/gui/BelaOSCUI.h
+++ b/architecture/faust/gui/BelaOSCUI.h
@@ -112,7 +112,7 @@ class BelaOSCUI : public GUI {
                 // "hello" message
                 } else if (msg.match("/hello").isOkNoMoreArgs()) {
                     // show datat to console.
-                    rt_printf("adresses:%s, in:%i, out:%i\n", fIP, fInputPort, fOutputPort);
+                    rt_printf("adresses:%s, in:%i, out:%i\n", fIP.c_str(), fInputPort, fOutputPort);
                     // set data by OSC
                     std::string s = fAPIUI.getParamAddress(0);
                     s.erase(0, 1);
@@ -126,7 +126,7 @@ class BelaOSCUI : public GUI {
         bool run() override
         {
             fReceiver.setup(fInputPort);
-            fSender.setup(fOutputPort, fIP);
+            fSender.setup(fOutputPort, fIP.c_str());
             rt_printf("initconnect\n");
             if (fOSCItems.size() == 0) {
                 rt_printf("%i widgets, OSC Adresses:\n", fAPIUI.getParamsCount());

--- a/tools/faust2appls/faust2bela
+++ b/tools/faust2appls/faust2bela
@@ -28,6 +28,7 @@ do
         echo "faust2bela [-osc][-midi][-nvoices <num>][-effect <auto or file.dsp>] [-tobela] <file.dsp>"
         echo "Use '-midi' to activate MIDI control"
         echo "Use '-osc' to activate OSC control"
+        echo "Use '-gui' to activate a self-hosted GUI interface. This requires that you installed libmicrohttpd and libHTTPDFaust."
         echo "Use '-nvoices <num>' to produce a polyphonic self-contained DSP with <num> voices, it must need -midi option also"
         echo "Polyphonic mode means MIDI instrument with at least 1 voice, so include monophonic instrument. Use no arguments for a simple effect."
         echo "Use '-effect <effect.dsp>' to produce a polyphonic DSP connected to a global output effect, ready to be used with MIDI"
@@ -50,6 +51,8 @@ do
     	MIDIDEFS="MIDI"
 	elif [ $p = "-osc" ]; then
 		OSCDEFS="OSC"
+	elif [ $p = "-gui" ]; then
+		GUIDEFS="GUI"
 	elif [ $p = "-tobela" ]; then
 		SEND2BELA="OK"
     else 
@@ -118,6 +121,11 @@ fi
 
 if [[ "$OSCDEFS" == *OSC* ]]; then
 	echo '#define OSCCTRL' >> "$PROJECTDIR/tmp.txt"
+fi
+
+if [[ "$GUIDEFS" == *GUI* ]]; then
+	echo '#define HTTPDGUI' >> "$PROJECTDIR/tmp.txt"
+	BELA_LDLIBS="$BELA_LDLIBS -lHTTPDFaust  -lmicrohttpd"
 fi
 
 cat "$PROJECTDIR/render.cpp" >> "$PROJECTDIR/tmp.txt"
@@ -211,7 +219,7 @@ uploadBuildRun(){
 		#  with older files from the host. This will solve 99% of the issues with Makefile thinking a target is up to date when it is not.
 		echo "Using rsync..."
 		
-		rsync -ac --out-format="   %n" --no-t --delete-after --exclude=$BBB_PROJECT_NAME --exclude=build $PROJECTDIR"/" "$BBB_NETWORK_TARGET_FOLDER/" #trailing slashes used here make sure rsync does not create another folder inside the target folder
+		rsync -ac --out-format="   %n" --no-t --delete-after --exclude=$BBB_PROJECT_NAME --exclude=build --exclude=settings.json $PROJECTDIR"/" "$BBB_NETWORK_TARGET_FOLDER/" #trailing slashes used here make sure rsync does not create another folder inside the target folder
 	fi
 
 	if [ $? -ne 0 ]
@@ -221,10 +229,8 @@ uploadBuildRun(){
 	fi
 	
 	# Make new Bela executable and run
-	MAKE_COMMAND="make --no-print-directory QUIET=true -C $BBB_BELA_HOME PROJECT='$BBB_PROJECT_NAME' CL='$COMMAND_ARGS' "
-	MAKE_COMMAND="make --no-print-directory QUIET=true -C $BBB_BELA_HOME PROJECT='$BBB_PROJECT_NAME' CL='$COMMAND_ARGS' "
+	MAKE_COMMAND="make --no-print-directory QUIET=true -C $BBB_BELA_HOME PROJECT='$BBB_PROJECT_NAME' CL='$COMMAND_ARGS' LDLIBS='$BELA_LDLIBS'"
 	
-	Echo "ssh commande:"
 	ssh -t $BBB_ADDRESS "$MAKE_COMMAND run"
 }
 


### PR DESCRIPTION
The polarity of digital inputs was wrong: a `0` meant `fMin + range`, a `1` meant `fMin`. Fixed.
The `BelaOSCUI` was not compiling. Fixed.
Added support for an `httpdUI`-based GUI to the architecture file and `faust2bela`.