### PR TITLE
Fix compatibility.hh on MinGW with clang

### DIFF
--- a/compiler/tlib/compatibility.hh
+++ b/compiler/tlib/compatibility.hh
@@ -45,7 +45,7 @@ unsigned faust_alarm(unsigned seconds);
 
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
-#if GCC_VERSION < 40700
+#if GCC_VERSION < 40700 && !defined(__clang__)
 struct timezone {
     int tz_minuteswest; /* minutes W of Greenwich */
     int tz_dsttime;     /* type of dst correction */


### PR DESCRIPTION
clang masquerades itself as a GCC 4.2.1 (https://lists.llvm.org/pipermail/llvm-dev/2011-February/038151.html) even though it is able of much more (in my case it's clang-8) ; this fixes a redefinition of struct timezone in that case.