### PR TITLE
fix make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ help :
 	@echo " 'parser'        : generates the parser from the lex and yacc files"
 	@echo
 	@echo "Distribution target"
-	@echo " 'world'         : the 'all' target and sound2faust
+	@echo " 'world'         : the 'all' target and sound2faust"
 	@echo
 	@echo "Platform specific targets:"
 	@echo " 'universal'     : [MacOSX] switch to universal binaries mode"


### PR DESCRIPTION
there was a missing `"` which caused 

```
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [help] Error 2
```

when running `make help`