### PR TITLE
Fix DLL name on iOS in the unity template

### DIFF
--- a/architecture/unity/FaustPolyUtilities_template.cs
+++ b/architecture/unity/FaustPolyUtilities_template.cs
@@ -245,8 +245,10 @@ namespace FaustUtilities_MODEL {
 
 		private IntPtr _context;
 
-        #if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_WSA_10_0 || UNITY_IOS
+        #if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_WSA_10_0
         const string _dllName = "PLUGNAME";
+        #elif UNITY_IOS
+        const string _dllName = "__Internal";
         #elif UNITY_EDITOR || UNITY_ANDROID || UNITY_STANDALONE_LINUX
         const string _dllName = "PLUGINNAME";
         #else


### PR DESCRIPTION
Hi, thanks for the great repository.

I tried `faust2unity` converter and it throws DllNotFound error on iOS. the DLL name should be `__Intanal` on iOS-unity platform. 

Tested on 
- Unity Version: 2018.3.4f1
- Xcode: 10.1