### PR TITLE
Report the metadata in XML output

### DIFF
--- a/compiler/generator/description.hh
+++ b/compiler/generator/description.hh
@@ -47,6 +47,7 @@ class Description : public virtual Garbageable {
     string fCopyright;
     string fLicense;
     string fVersion;
+    map<string, set<string> > fMetadata;
 
     string       fClassName;
     int          fInputs;
@@ -116,6 +117,11 @@ class Description : public virtual Garbageable {
         fOutputs = n;
         return this;
     }
+    Description* declare(const string& key, const string& value)
+    {
+        fMetadata[key].insert(value);
+        return this;
+    }
 
     void ui(Tree t);
     void print(int n, ostream& fout);
@@ -127,6 +133,8 @@ class Description : public virtual Garbageable {
     void tab(int n, ostream& fout);
     void addActiveLine(const string& l) { fActiveLines.push_back(l); }
     void addPassiveLine(const string& l) { fPassiveLines.push_back(l); }
+    void addActiveMetadata(Tree label);
+    void addPassiveMetadata(Tree label);
     void addLayoutLine(int n, const string& l)
     {
         fLayoutTabs.push_back(n);

--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -1654,16 +1654,28 @@ static void generateOutputFiles()
             faustassert(D);
             ofstream xout(subst("$0.xml", gGlobal->makeDrawPath()).c_str());
 
-            if (gGlobal->gMetaDataSet.count(tree("name")) > 0)
-                D->name(tree2str(*(gGlobal->gMetaDataSet[tree("name")].begin())));
-            if (gGlobal->gMetaDataSet.count(tree("author")) > 0)
-                D->author(tree2str(*(gGlobal->gMetaDataSet[tree("author")].begin())));
-            if (gGlobal->gMetaDataSet.count(tree("copyright")) > 0)
-                D->copyright(tree2str(*(gGlobal->gMetaDataSet[tree("copyright")].begin())));
-            if (gGlobal->gMetaDataSet.count(tree("license")) > 0)
-                D->license(tree2str(*(gGlobal->gMetaDataSet[tree("license")].begin())));
-            if (gGlobal->gMetaDataSet.count(tree("version")) > 0)
-                D->version(tree2str(*(gGlobal->gMetaDataSet[tree("version")].begin())));
+            const MetaDataSet&          mds = gGlobal->gMetaDataSet;
+            MetaDataSet::const_iterator it1;
+            set<Tree>::const_iterator   it2;
+
+            for (it1 = mds.begin(); it1 != mds.end(); ++it1) {
+                const std::string key = tree2str(it1->first);
+                for (it2 = it1->second.begin(); it2 != it1->second.end(); ++it2) {
+                    const std::string value = tree2str(*it2);
+                    if (key == "name")
+                        D->name(value);
+                    else if (key == "author")
+                        D->author(value);
+                    else if (key == "copyright")
+                        D->copyright(value);
+                    else if (key == "license")
+                        D->license(value);
+                    else if (key == "version")
+                        D->version(value);
+                    else
+                        D->declare(key, value);
+                }
+            }
 
             D->className(gGlobal->gClassName);
             D->inputs(container->inputs());


### PR DESCRIPTION
This is a lack of the XML report in comparison to the JSON one.
I add the metadata from the global set, actives and passives.
It's in the form `<meta key="foo">bar</meta>`.

Remark: I have also noted that JSON lacks some information that XML has: `varname`