### PR TITLE
Interpreter backend: Fix asan and tsan in interpreter_optimizer.hh

### DIFF
--- a/compiler/generator/interpreter/interpreter_optimizer.hh
+++ b/compiler/generator/interpreter/interpreter_optimizer.hh
@@ -65,18 +65,8 @@ struct FBCInstructionCopyOptimizer : public FBCInstructionOptimizer<T> {
     }
 };
 
-#ifndef NDEBUG
-// To avoid asan and tsan hits. (reading past allocated memory)
-#  define DEF_INST2()
-#  define INST2 (*(cur+1))
-#  define DEF_INST3()
-#  define INST3 (*(cur+2))
-#else
-#  define DEF_INST2() const FBCBasicInstruction<T>* inst2 = *(cur + 1)
-#  define INST2 inst2
-#  define DEF_INST3() const FBCBasicInstruction<T>* inst3 = *(cur + 2)
-#  define INST3 inst3
-#endif
+#define INST2 (*(cur+1))
+#define INST3 (*(cur+2))
 
 // Cast optimizer
 template <class T>
@@ -86,7 +76,6 @@ struct FBCInstructionCastOptimizer : public FBCInstructionOptimizer<T> {
     virtual FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
 
         if (inst1->fOpcode == FBCInstruction::kLoadInt && INST2->fOpcode == FBCInstruction::kCastReal) {
             end = cur + 2;
@@ -111,7 +100,6 @@ struct FBCInstructionLoadStoreOptimizer : public FBCInstructionOptimizer<T> {
     FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
 
         if (inst1->fOpcode == FBCInstruction::kInt32Value && INST2->fOpcode == FBCInstruction::kLoadIndexedReal) {
             end = cur + 2;
@@ -144,7 +132,6 @@ struct FBCInstructionMoveOptimizer : public FBCInstructionOptimizer<T> {
     FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
 
         // Optimize Heap Load/Store as Move
         if (inst1->fOpcode == FBCInstruction::kLoadReal && INST2->fOpcode == FBCInstruction::kStoreReal) {
@@ -241,7 +228,6 @@ struct FBCInstructionPairMoveOptimizer : public FBCInstructionOptimizer<T> {
     FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
 
         if (inst1->fOpcode == FBCInstruction::kMoveReal && INST2->fOpcode == FBCInstruction::kMoveReal &&
             (inst1->fOffset1 == (inst1->fOffset2 + 1)) && (INST2->fOffset1 == (INST2->fOffset2 + 1)) &&
@@ -374,8 +360,6 @@ struct FBCInstructionMathOptimizer : public FBCInstructionOptimizer<T> {
     FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
-        DEF_INST3();
 
         faustassert(gFIRMath2Heap.size() > 0);
         faustassert(gFIRMath2Stack.size() > 0);
@@ -626,7 +610,6 @@ struct FBCInstructionConstantValueHeap2Map : public FBCInstructionOptimizer<T> {
     virtual FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
 
         if (inst1->fOpcode == FBCInstruction::kRealValue && INST2->fOpcode == FBCInstruction::kStoreReal) {
             end = cur + 2;
@@ -655,7 +638,6 @@ struct FBCInstructionCastSpecializer : public FBCInstructionOptimizer<T> {
     virtual FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
 
         if (inst1->fOpcode == FBCInstruction::kInt32Value && INST2->fOpcode == FBCInstruction::kCastReal) {
             end = cur + 2;
@@ -1045,8 +1027,6 @@ struct FBCInstructionMathSpecializer : public FBCInstructionOptimizer<T> {
     virtual FBCBasicInstruction<T>* rewrite(const InstructionIT cur, InstructionIT& end)
     {
         const FBCBasicInstruction<T>* inst1 = *cur;
-        DEF_INST2();
-        DEF_INST3();
 
         FBCBasicInstruction<T>* res;
 
@@ -1175,7 +1155,6 @@ struct FBCInstructionOptimizer {
 
         do {
             const FBCBasicInstruction<T>* inst1 = *cur;
-            DEF_INST2();
 
             // Specialization
             if (inst1->fOpcode == FBCInstruction::kInt32Value && FBCInstruction::isChoice(INST2->fOpcode)) {
@@ -1323,9 +1302,7 @@ struct FBCInstructionOptimizer {
     }
 };
 
-#undef DEF_INST2
 #undef INST2
-#undef DEF_INST3
 #undef INST3
 
 #endif


### PR DESCRIPTION
Firstmost a fix for asan, but even tsan compaints (see below).

But maybe both NDEBUG and !NDEBUG should use "INST2 (*(cur+1))"? It's not so pretty reading past allocated memory, although a combination of the c compiler optimizing it out and the memory after allocation is readable anyway, probably makes it safe.

```
WARNING: ThreadSanitizer: heap-use-after-free (pid=22570)
  Read of size 8 at 0x7b04000a2b40 by thread T21 (mutexes: write M392):
    #0 FBCInstructionOptimizer<float>::optimize_aux(FBCBlockInstruction<float>*, FBCInstructionOptimizer<float>&) /home/kjetil/faust/compiler/generator/interpreter/interpreter_optimizer.hh:1164:45 (radium_linux.bin+0x17f811f)
    #1 FBCInstructionOptimizer<float>::optimize(FBCBlockInstruction<float>*, FBCInstructionOptimizer<float>&) /home/kjetil/faust/compiler/generator/interpreter/interpreter_optimizer.hh:1203:45 (radium_linux.bin+0x17f5928)
    #2 FBCInstructionOptimizer<float>::optimizeBlock(FBCBlockInstruction<float>*, int, int) /home/kjetil/faust/compiler/generator/interpreter/interpreter_optimizer.hh:1286:21 (radium_linux.bin+0x17f3d95)
    #3 interpreter_dsp_factory_aux<float, 0>::optimize() /home/kjetil/faust/compiler/generator/interpreter/interpreter_dsp_aux.hh:156:36 (radium_linux.bin+0x191f59d)
    #4 interpreter_dsp_aux<float, 0>::interpreter_dsp_aux(interpreter_dsp_factory_aux<float, 0>*) /home/kjetil/faust/compiler/generator/interpreter/interpreter_dsp_aux.hh:667:19 (radium_linux.bin+0x191f120)
    #5 interpreter_dsp_factory_aux<float, 0>::createDSPInstance(dsp_factory*) /home/kjetil/faust/compiler/generator/interpreter/interpreter_dsp_aux.hh:1286:38 (radium_linux.bin+0x191d379)
    #6 interpreter_dsp_factory::createDSPInstance() /home/kjetil/faust/compiler/generator/interpreter/interpreter_dsp_aux.cpp:88:26 (radium_linux.bin+0x1bbe061)
    #7 (anonymous namespace)::FFF_Thread::create_reply_data((anonymous namespace)::FFF_Reply&) /home/kjetil/radium/audio/Faust_factory_factory.cpp:312:34 (radium_linux.bin+0x12a3dc1)
    #8 (anonymous namespace)::FFF_Thread::create_reply(QString, QString, int, (anonymous namespace)::FFF_Reply&) /home/kjetil/radium/audio/Faust_factory_factory.cpp:417:23 (radium_linux.bin+0x12a17f5)
    #9 (anonymous namespace)::FFF_Thread::run() /home/kjetil/radium/audio/Faust_factory_factory.cpp:485:13 (radium_linux.bin+0x12a131c)
    #10 <null> <null> (libQt5Core.so.5+0xac60b)
```