### PR TITLE
webaudio-workletnode-standalone-wrapper: ecmascript 6 export of factory class 

### DIFF
--- a/architecture/webaudio/webaudio-workletnode-standalone-wrapper.js
+++ b/architecture/webaudio/webaudio-workletnode-standalone-wrapper.js
@@ -344,7 +344,7 @@ class mydspNode extends AudioWorkletNode {
 }
 
 // Factory class
-class mydsp {
+export default class mydsp {
 
     /**
      * Factory constructor.


### PR DESCRIPTION
class mydsp now exported in ecmasript 6 compliant way: 

// Factory class
export default class mydsp {

so that the factory can be imported into other js modules using the import statement.
(windows name space and npm exports unchanged at the end of the file). 