### PR TITLE
Fix architecture file for faust2alsaconsole

### DIFF
--- a/architecture/alsa-console.cpp
+++ b/architecture/alsa-console.cpp
@@ -42,6 +42,7 @@
 #include "faust/gui/FUI.h"
 #include "faust/misc.h"
 #include "faust/gui/GUI.h"
+#include "faust/gui/JSONUI.h"
 #include "faust/gui/console.h"
 #include "faust/audio/alsa-dsp.h"
 


### PR DESCRIPTION
alsa-console.cpp refers to JSONUI (see e.g. https://github.com/grame-cncm/faust/blob/f1985b49b74ec520a076e9d7f76793a5e3bea72f/architecture/alsa-console.cpp#L106) but JSONUI.h is not included at the top of the file. This PR adds it.