### PR TITLE
Allow midi CC channel filtering

### DIFF
--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -135,14 +135,18 @@ class uiMidi {
         
         midi* fMidiOut;
         bool fInputCtrl;
-        
+        int fChan;
     public:
         
-        uiMidi(midi* midi_out, bool input):fMidiOut(midi_out), fInputCtrl(input)
+        uiMidi(midi* midi_out, bool input, int chan = -1):fMidiOut(midi_out), fInputCtrl(input), fChan(chan)
         {}
         virtual ~uiMidi()
         {}
-    
+
+        int getChanFilter()
+        {
+            return fChan;
+        }
 };
 
 /*****************************************************************************
@@ -153,8 +157,8 @@ class uiMidiItem : public uiMidi, public uiItem {
     
     public:
         
-        uiMidiItem(midi* midi_out, GUI* ui, FAUSTFLOAT* zone, bool input = true)
-            :uiMidi(midi_out, input), uiItem(ui, zone)
+        uiMidiItem(midi* midi_out, GUI* ui, FAUSTFLOAT* zone, bool input = true, int chan = -1)
+            :uiMidi(midi_out, input, chan), uiItem(ui, zone)
         {}
         virtual ~uiMidiItem()
         {}
@@ -171,8 +175,8 @@ class uiMidiTimedItem : public uiMidi, public uiTimedItem {
     
     public:
         
-        uiMidiTimedItem(midi* midi_out, GUI* ui, FAUSTFLOAT* zone, bool input = true)
-            :uiMidi(midi_out, input), uiTimedItem(ui, zone)
+        uiMidiTimedItem(midi* midi_out, GUI* ui, FAUSTFLOAT* zone, bool input = true, int chan = -1)
+            :uiMidi(midi_out, input, chan), uiTimedItem(ui, zone)
         {}
         virtual ~uiMidiTimedItem()
         {}
@@ -333,20 +337,13 @@ class uiMidiCtrlChange : public uiMidiTimedItem
     private:
     
     int fCtrl;
-    int fChanFilter;
     LinearValueConverter fConverter;
  
     public:
 
-        uiMidiCtrlChange(midi* midi_out, int ctrl, int chan, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true)
-        :uiMidiTimedItem(midi_out, ui, zone, input), fCtrl(ctrl), fChanFilter(chan), fConverter(0., 127., double(min), double(max))
+        uiMidiCtrlChange(midi* midi_out, int ctrl, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true, int chan = -1)
+            :uiMidiTimedItem(midi_out, ui, zone, input, chan), fCtrl(ctrl), fConverter(0., 127., double(min), double(max))
         {}
-
-        uiMidiCtrlChange(midi* midi_out, int ctrl, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true)
-
-        :uiMidiCtrlChange(midi_out, ctrl, -1, ui, zone, min, max, input)
-        {}
-
         virtual ~uiMidiCtrlChange()
         {}
         
@@ -354,7 +351,7 @@ class uiMidiCtrlChange : public uiMidiTimedItem
         {
             FAUSTFLOAT v = *fZone;
             fCache = v;
-            fMidiOut->ctrlChange( (((fChanFilter<0) || (fChanFilter>15)) ? 0 : fChanFilter), fCtrl, fConverter.faust2ui(v));
+            fMidiOut->ctrlChange( (((fChan<0) || (fChan>15)) ? 0 : fChan), fCtrl, fConverter.faust2ui(v));
         }
         
         void modifyZone(FAUSTFLOAT v)
@@ -369,11 +366,6 @@ class uiMidiCtrlChange : public uiMidiTimedItem
             if (fInputCtrl) {
                 uiMidiTimedItem::modifyZone(date, FAUSTFLOAT(fConverter.ui2faust(v)));
             }
-        }
-
-        int getChanFilter()
-        {
-            return fChanFilter;
         }
 };
 
@@ -395,8 +387,8 @@ class uiMidiPitchWheel : public uiMidiTimedItem
  
     public:
     
-        uiMidiPitchWheel(midi* midi_out, GUI* ui, FAUSTFLOAT* zone, bool input = true)
-            :uiMidiTimedItem(midi_out, ui, zone, input)
+        uiMidiPitchWheel(midi* midi_out, GUI* ui, FAUSTFLOAT* zone, bool input = true, int chan = -1)
+            :uiMidiTimedItem(midi_out, ui, zone, input, chan)
         {}
         virtual ~uiMidiPitchWheel()
         {}
@@ -434,8 +426,8 @@ class uiMidiKeyOn : public uiMidiTimedItem
   
     public:
     
-        uiMidiKeyOn(midi* midi_out, int key, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true)
-            :uiMidiTimedItem(midi_out, ui, zone, input), fKeyOn(key), fConverter(0., 127., double(min), double(max))
+        uiMidiKeyOn(midi* midi_out, int key, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true, int chan = -1)
+            :uiMidiTimedItem(midi_out, ui, zone, input, chan), fKeyOn(key), fConverter(0., 127., double(min), double(max))
         {}
         virtual ~uiMidiKeyOn()
         {}
@@ -473,8 +465,8 @@ class uiMidiKeyOff : public uiMidiTimedItem
   
     public:
     
-        uiMidiKeyOff(midi* midi_out, int key, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true)
-            :uiMidiTimedItem(midi_out, ui, zone, input), fKeyOff(key), fConverter(0., 127., double(min), double(max))
+        uiMidiKeyOff(midi* midi_out, int key, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true, int chan = -1)
+            :uiMidiTimedItem(midi_out, ui, zone, input, chan), fKeyOff(key), fConverter(0., 127., double(min), double(max))
         {}
         virtual ~uiMidiKeyOff()
         {}
@@ -512,8 +504,8 @@ class uiMidiKeyPress : public uiMidiTimedItem
   
     public:
     
-        uiMidiKeyPress(midi* midi_out, int key, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true)
-            :uiMidiTimedItem(midi_out, ui, zone, input), fKey(key), fConverter(0., 127., double(min), double(max))
+        uiMidiKeyPress(midi* midi_out, int key, GUI* ui, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max, bool input = true, int chan = -1)
+            :uiMidiTimedItem(midi_out, ui, zone, input, chan), fKey(key), fConverter(0., 127., double(min), double(max))
         {}
         virtual ~uiMidiKeyPress()
         {}
@@ -588,9 +580,11 @@ class MidiUI : public GUI, public midi
                     unsigned chan;
                     if (fMetaAux[i].first == "midi") {
                         if (gsscanf(fMetaAux[i].second.c_str(), "ctrl %u %u", &num, &chan) == 2) {
-                            fCtrlChangeTable[num].push_back(new uiMidiCtrlChange(fMidiHandler, num, chan, this, zone, min, max, input));
+                            fCtrlChangeTable[num].push_back(new uiMidiCtrlChange(fMidiHandler, num, this, zone, min, max, input, chan));
                         } else if (gsscanf(fMetaAux[i].second.c_str(), "ctrl %u", &num) == 1) {
                             fCtrlChangeTable[num].push_back(new uiMidiCtrlChange(fMidiHandler, num, this, zone, min, max, input));
+                        } else if (gsscanf(fMetaAux[i].second.c_str(), "keyon %u %u", &num, &chan) == 2) {
+                            fKeyOnTable[num].push_back(new uiMidiKeyOn(fMidiHandler, num, this, zone, min, max, input, chan));
                         } else if (gsscanf(fMetaAux[i].second.c_str(), "keyon %u", &num) == 1) {
                             fKeyOnTable[num].push_back(new uiMidiKeyOn(fMidiHandler, num, this, zone, min, max, input));
                         } else if (gsscanf(fMetaAux[i].second.c_str(), "keyoff %u", &num) == 1) {
@@ -695,11 +689,15 @@ class MidiUI : public GUI, public midi
             if (fKeyOnTable.find(note) != fKeyOnTable.end()) {
                 if (fTimeStamp) {
                     for (unsigned int i = 0; i < fKeyOnTable[note].size(); i++) {
-                        fKeyOnTable[note][i]->modifyZone(date, FAUSTFLOAT(velocity));
+                        if (fKeyOnTable[note][i]->getChanFilter() == -1 || channel == fKeyOnTable[note][i]->getChanFilter()) {
+                            fKeyOnTable[note][i]->modifyZone(date, FAUSTFLOAT(velocity));
+                        }
                     }
                 } else {
                     for (unsigned int i = 0; i < fKeyOnTable[note].size(); i++) {
-                        fKeyOnTable[note][i]->modifyZone(FAUSTFLOAT(velocity));
+                        if (fKeyOnTable[note][i]->getChanFilter() == -1 || channel == fKeyOnTable[note][i]->getChanFilter()) {
+                            fKeyOnTable[note][i]->modifyZone(FAUSTFLOAT(velocity));
+                        }
                     }
                 }
             }
@@ -707,11 +705,15 @@ class MidiUI : public GUI, public midi
             if (fKeyTable.find(note) != fKeyTable.end()) {
                 if (fTimeStamp) {
                     for (unsigned int i = 0; i < fKeyTable[note].size(); i++) {
-                        fKeyTable[note][i]->modifyZone(date, FAUSTFLOAT(velocity));
+                        if (fKeyTable[note][i]->getChanFilter() == -1 || channel == fKeyTable[note][i]->getChanFilter()) {
+                            fKeyTable[note][i]->modifyZone(date, FAUSTFLOAT(velocity));
+                        }
                     }
                 } else {
                     for (unsigned int i = 0; i < fKeyTable[note].size(); i++) {
-                        fKeyTable[note][i]->modifyZone(FAUSTFLOAT(velocity));
+                        if (fKeyTable[note][i]->getChanFilter() == -1 || channel == fKeyTable[note][i]->getChanFilter()) {
+                            fKeyTable[note][i]->modifyZone(FAUSTFLOAT(velocity));
+                        }
                     }
                 }
             }
@@ -751,8 +753,6 @@ class MidiUI : public GUI, public midi
             if (fCtrlChangeTable.find(ctrl) != fCtrlChangeTable.end()) {
                 if (fTimeStamp) {
                     for (unsigned int i = 0; i < fCtrlChangeTable[ctrl].size(); i++) {
-                        // ChanFilter == -1 -> Listen on all channels
-                        // ChanFilter == x -> Lister on channel x
                         if (fCtrlChangeTable[ctrl][i]->getChanFilter() == -1 || channel == fCtrlChangeTable[ctrl][i]->getChanFilter()){
                             fCtrlChangeTable[ctrl][i]->modifyZone(date, FAUSTFLOAT(value));
                         }

--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -811,7 +811,7 @@ class MidiUI : public GUI, public midi
         {
             if (fChanPressTable.find(press) != fChanPressTable.end()) {
                 for (unsigned int i = 0; i < fChanPressTable[press].size(); i++) {
-                    if (fKeyPressTable[pitch][i]->getChan() == -1 || channel == fKeyPressTable[pitch][i]->getChan()) {
+                    if (fChanPressTable[press][i]->getChan() == -1 || channel == fChanPressTable[press][i]->getChan()) {
                         if (fTimeStamp) {
                             fChanPressTable[press][i]->modifyZone(date, FAUSTFLOAT(1));
                         } else {

--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -587,6 +587,8 @@ class MidiUI : public GUI, public midi
                             fKeyOnTable[num].push_back(new uiMidiKeyOn(fMidiHandler, num, this, zone, min, max, input, chan));
                         } else if (gsscanf(fMetaAux[i].second.c_str(), "keyon %u", &num) == 1) {
                             fKeyOnTable[num].push_back(new uiMidiKeyOn(fMidiHandler, num, this, zone, min, max, input));
+                        } else if (gsscanf(fMetaAux[i].second.c_str(), "keyoff %u %u", &num, &chan) == 2) {
+                            fKeyOffTable[num].push_back(new uiMidiKeyOff(fMidiHandler, num, this, zone, min, max, input, chan));
                         } else if (gsscanf(fMetaAux[i].second.c_str(), "keyoff %u", &num) == 1) {
                             fKeyOffTable[num].push_back(new uiMidiKeyOff(fMidiHandler, num, this, zone, min, max, input));
                         } else if (gsscanf(fMetaAux[i].second.c_str(), "key %u", &num) == 1) {
@@ -725,11 +727,15 @@ class MidiUI : public GUI, public midi
             if (fKeyOffTable.find(note) != fKeyOffTable.end()) {
                 if (fTimeStamp) {
                     for (unsigned int i = 0; i < fKeyOffTable[note].size(); i++) {
-                        fKeyOffTable[note][i]->modifyZone(date, FAUSTFLOAT(velocity));
+                        if (fKeyOffTable[note][i]->getChanFilter() == -1 || channel == fKeyOffTable[note][i]->getChanFilter()) {
+                            fKeyOffTable[note][i]->modifyZone(date, FAUSTFLOAT(velocity));
+                        }
                     }
                 } else {
                     for (unsigned int i = 0; i < fKeyOffTable[note].size(); i++) {
-                        fKeyOffTable[note][i]->modifyZone(FAUSTFLOAT(velocity));
+                        if (fKeyOffTable[note][i]->getChanFilter() == -1 || channel == fKeyOffTable[note][i]->getChanFilter()) {
+                            fKeyOffTable[note][i]->modifyZone(FAUSTFLOAT(velocity));
+                        }
                     }
                 }
             }
@@ -737,11 +743,15 @@ class MidiUI : public GUI, public midi
             if (fKeyTable.find(note) != fKeyTable.end()) {
                 if (fTimeStamp) {
                     for (unsigned int i = 0; i < fKeyTable[note].size(); i++) {
-                        fKeyTable[note][i]->modifyZone(date, 0);
+                        if (fKeyTable[note][i]->getChanFilter() == -1 || channel == fKeyTable[note][i]->getChanFilter()) {
+                            fKeyTable[note][i]->modifyZone(date, 0);
+                        }
                     }
                 } else {
                     for (unsigned int i = 0; i < fKeyTable[note].size(); i++) {
-                        fKeyTable[note][i]->modifyZone(0);
+                        if (fKeyTable[note][i]->getChanFilter() == -1 || channel == fKeyTable[note][i]->getChanFilter()) {
+                            fKeyTable[note][i]->modifyZone(0);
+                        }
                     }
                 }
             }

--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -354,7 +354,7 @@ class uiMidiCtrlChange : public uiMidiTimedItem
         {
             FAUSTFLOAT v = *fZone;
             fCache = v;
-            fMidiOut->ctrlChange(((fChanFilter<0) ? 0 : fChanFilter), fCtrl, fConverter.faust2ui(v));
+            fMidiOut->ctrlChange( (((fChanFilter<0) || (fChanFilter>15)) ? 0 : fChanFilter), fCtrl, fConverter.faust2ui(v));
         }
         
         void modifyZone(FAUSTFLOAT v)

--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -355,7 +355,7 @@ class uiMidiCtrlChange : public uiMidiTimedItem
         }
         
         void modifyZone(FAUSTFLOAT v)
-        { 
+        {
             if (fInputCtrl) {
                 uiItem::modifyZone(FAUSTFLOAT(fConverter.ui2faust(v)));
             }
@@ -397,7 +397,7 @@ class uiMidiPitchWheel : public uiMidiTimedItem
         {
             FAUSTFLOAT v = *fZone;
             fCache = v;
-            fMidiOut->pitchWheel(0, bend2wheel(v));
+            fMidiOut->pitchWheel( (((fChan<0) || (fChan>15)) ? 0 : fChan), bend2wheel(v));
         }
         
         void modifyZone(FAUSTFLOAT v)
@@ -436,7 +436,7 @@ class uiMidiKeyOn : public uiMidiTimedItem
         {
             FAUSTFLOAT v = *fZone;
             fCache = v;
-            fMidiOut->keyOn(0, fKeyOn, fConverter.faust2ui(v));
+            fMidiOut->keyOn( (((fChan<0) || (fChan>15)) ? 0 : fChan), fKeyOn, fConverter.faust2ui(v));
         }
         
         void modifyZone(FAUSTFLOAT v)
@@ -475,7 +475,7 @@ class uiMidiKeyOff : public uiMidiTimedItem
         {
             FAUSTFLOAT v = *fZone;
             fCache = v;
-            fMidiOut->keyOff(0, fKeyOff, fConverter.faust2ui(v));
+            fMidiOut->keyOff( (((fChan<0) || (fChan>15)) ? 0 : fChan), fKeyOff, fConverter.faust2ui(v));
         }
         
         void modifyZone(FAUSTFLOAT v)
@@ -514,7 +514,7 @@ class uiMidiKeyPress : public uiMidiTimedItem
         {
             FAUSTFLOAT v = *fZone;
             fCache = v;
-            fMidiOut->keyPress(0, fKey, fConverter.faust2ui(v));
+            fMidiOut->keyPress( (((fChan<0) || (fChan>15)) ? 0 : fChan), fKey, fConverter.faust2ui(v));
         }
         
         void modifyZone(FAUSTFLOAT v)

--- a/documentation/faust-manual/src/midi.md
+++ b/documentation/faust-manual/src/midi.md
@@ -72,6 +72,42 @@ process = os.sawtooth(freq);
 ```
 <!-- /faust-run -->
 
+### `[midi:ctrl num chan]` Metadata
+
+The `[midi:ctrl num chan]` metadata assigns MIDI CC (control change)
+to a specific UI element. The UI element receive and send MIDI CC
+values from/to the specified MIDI channel. When used in a slider
+or a bargraph, this metadata will map the UI element value to
+the {0, 127} range. When used with a button or a checkbox, 
+1 will be mapped to 127, 0 will be mapped to 0. 
+
+**Usage**
+
+```
+toto = hslider("toto[midi:ctrl num chan]",...);
+```
+
+Where:
+
+* `num`: the MIDI CC number
+* `chan`: the MIDI CC channel
+
+**Example**
+
+In the following example, the frequency of a sawtooth wave oscillator is 
+controlled by MIDI CC 11. The UI element receive and send CC 11
+values on channel 2. When CC11=0, then the frequency is 200Hz, when 
+CC11=127, then the frequency is 1000Hz.
+
+<!-- faust-run -->
+```
+import("stdfaust.lib");
+freq = hslider("frequency[midi:ctrl 11 2]",200,50,1000,0.01) : si.smoo;
+process = os.sawtooth(freq);
+```
+<!-- /faust-run -->
+
+
 ### `[midi:keyon midikey]` Metadata
 
 The `[midi:keyon midikey]` metadata assigns the velocity value of a key-on MIDI 

--- a/documentation/faust-manual/src/midi.md
+++ b/documentation/faust-manual/src/midi.md
@@ -140,6 +140,43 @@ process = os.sawtooth(freq);
 ```
 <!-- /faust-run -->
 
+### `[midi:keyon midikey chan]` Metadata
+
+The `[midi:keyon midikey chan]` metadata assigns the velocity value of a key-on MIDI 
+message received on a specific `midikey` to a Faust parameter.
+The UI element receive and send MIDI values from/to the specified MIDI channel in
+range {0, 15}.
+When used in a slider or a bargraph, this metadata will map the UI element value to the 
+{0, 127} range. When used with a button or a checkbox, 1 will be mapped to 127, 
+0 will be mapped to 0.
+
+**Usage**
+
+```
+toto = hslider("toto[midi:keyon midikey chan]",...);
+```
+
+Where:
+
+* `midikey`: the MIDI key number
+* `chan`: the MIDI key channel (range {0,15})
+
+**Example**
+
+In the following example, the frequency of a sawtooth wave oscillator is 
+controlled by the velocity value received on key 62 when a key-on message is
+sent. Therefore, the frequency will only be updated when receiving a MIDI key 62
+message from channel 3.
+
+<!-- faust-run -->
+```
+import("stdfaust.lib");
+freq = hslider("frequency[midi:keyon 62 3]",200,50,1000,0.01) : si.smoo;
+process = os.sawtooth(freq);
+```
+<!-- /faust-run -->
+
+
 ### `[midi:keyoff midikey]` Metadata
 
 The `[midi:keyoff midikey]` metadata assigns the velocity value of a key-off MIDI 
@@ -173,6 +210,44 @@ process = os.sawtooth(freq);
 ```
 <!-- /faust-run -->
 
+
+### `[midi:keyoff midikey chan]` Metadata
+
+The `[midi:keyoff midikey chan]` metadata assigns the velocity value of a key-off MIDI 
+message received on a specific `midikey` to a Faust parameter.
+The UI element receive and send MIDI values from/to the specified MIDI channel in
+range {0, 15}.
+When used in a slider or a bargraph, this metadata will map the UI element value to the 
+{0, 127} range. When used with a button or a checkbox, 1 will be mapped to 127, 
+0 will be mapped to 0.
+
+**Usage**
+
+```
+toto = hslider("toto[midi:keyoff midikey chan]",...);
+```
+
+Where:
+
+* `midikey`: the MIDI key number
+* `chan`: the MIDI key channel (range {0,15})
+
+**Example**
+
+In the following example, the frequency of a sawtooth wave oscillator is 
+controlled by the velocity value received on key 62 when a key-off message is
+sent on channel 3. (The frequency will only be updated when MIDI key 62 is 
+released.)
+
+<!-- faust-run -->
+```
+import("stdfaust.lib");
+freq = hslider("frequency[midi:keyon 62 3]",200,50,1000,0.01) : si.smoo;
+process = os.sawtooth(freq);
+```
+<!-- /faust-run -->
+
+
 ### `[midi:key midikey]` Metadata
 
 The `[midi:key midikey]` metadata assigns the velocity value of key-on and 
@@ -190,6 +265,43 @@ toto = hslider("toto[midi:key midikey]",...);
 Where:
 
 * `midikey`: the MIDI key number
+
+**Example**
+
+In the following example, the frequency of a sawtooth wave oscillator is 
+controlled by the velocity value received on key 62 when key-on and key-off 
+messages are sent. Therefore, the frequency will only be updated when MIDI key 
+62 is pressed and released.
+
+<!-- faust-run -->
+```
+import("stdfaust.lib");
+freq = hslider("frequency[midi:key 62]",200,50,1000,0.01) : si.smoo;
+process = os.sawtooth(freq);
+```
+<!-- /faust-run -->
+
+
+### `[midi:key midikey chan]` Metadata
+
+The `[midi:key midikey chan]` metadata assigns the velocity value of key-on and 
+key-off MIDI messages received on a specific `midikey` to a Faust parameter. 
+The UI element receive and send MIDI values from/to the specified MIDI channel in
+range {0, 15}.
+When used in a slider or a bargraph, this metadata will map the UI element 
+value to the {0, 127} range. When used with a button or a checkbox, 1 will be 
+mapped to 127, 0 will be mapped to 0.
+
+**Usage**
+
+```
+toto = hslider("toto[midi:key midikey chan]",...);
+```
+
+Where:
+
+* `midikey`: the MIDI key number
+* `chan`: the MIDI key channel (range {0,15})
 
 **Example**
 
@@ -269,6 +381,38 @@ freq = hslider("frequency[midi:pitchwheel]",200,50,1000,0.01) : si.smoo;
 process = os.sawtooth(freq);
 ```
 <!-- /faust-run -->
+
+
+### `[midi:pitchwheel chan]` Metadata
+
+The `[midi:pitchwheel chan]` metadata assigns the pitch-wheel value to a 
+Faust parameter.
+The UI element receive and send MIDI values from/to the specified MIDI channel in
+range {0, 15}. When used in a slider or a bargraph, this metadata will map 
+the UI element value to the {0, 16383} range. When used with a button or a 
+checkbox, 1 will be mapped to 16383, 0 will be mapped to 0.
+
+**Usage**
+
+```
+toto = hslider("toto[midi:pitchwheel chan]",...);
+```
+
+* `chan`: the MIDI pitchwheel channel (range {0,15})
+
+**Example**
+
+In the following example, the frequency of a sawtooth wave oscillator is 
+controlled by the pitch-wheel values sent on MIDI channel 3.
+
+<!-- faust-run -->
+```
+import("stdfaust.lib");
+freq = hslider("frequency[midi:pitchwheel 3]",200,50,1000,0.01) : si.smoo;
+process = os.sawtooth(freq);
+```
+<!-- /faust-run -->
+
 
 ### `[midi:start]` Metadata
 

--- a/documentation/faust-manual/src/midi.md
+++ b/documentation/faust-manual/src/midi.md
@@ -164,9 +164,8 @@ Where:
 **Example**
 
 In the following example, the frequency of a sawtooth wave oscillator is 
-controlled by the velocity value received on key 62 when a key-on message is
-sent. Therefore, the frequency will only be updated when receiving a MIDI key 62
-message from channel 3.
+controlled by the velocity values attached to `key-on 62` messages
+received on channel 3.
 
 <!-- faust-run -->
 ```
@@ -235,8 +234,8 @@ Where:
 **Example**
 
 In the following example, the frequency of a sawtooth wave oscillator is 
-controlled by the velocity value received on key 62 when a key-off message is
-sent on channel 3. (The frequency will only be updated when MIDI key 62 is 
+controlled by the velocity values attached to `key-off 62` messages
+received on channel 3. (The frequency will only be updated when MIDI key 62 is 
 released.)
 
 <!-- faust-run -->
@@ -306,9 +305,8 @@ Where:
 **Example**
 
 In the following example, the frequency of a sawtooth wave oscillator is 
-controlled by the velocity value received on key 62 when key-on and key-off 
-messages are sent. Therefore, the frequency will only be updated when MIDI key 
-62 is pressed and released.
+controlled by the velocity values attached to `key-on 62` and `key-off 62` messages 
+received on channel 3. (The frequency is updated when key 62 is pressed and released.)
 
 <!-- faust-run -->
 ```

--- a/documentation/faust-manual/src/midi.md
+++ b/documentation/faust-manual/src/midi.md
@@ -95,8 +95,8 @@ Where:
 **Example**
 
 In the following example, the frequency of a sawtooth wave oscillator is 
-controlled by MIDI CC 11. The UI element receive and send CC 11
-values on channel 2. When CC11=0, then the frequency is 200Hz, when 
+controlled by values attached to `Control change 11` messages received
+on channel 2. When CC11=0, then the frequency is 200Hz, when 
 CC11=127, then the frequency is 1000Hz.
 
 <!-- faust-run -->

--- a/documentation/faust-manual/src/midi.md
+++ b/documentation/faust-manual/src/midi.md
@@ -76,10 +76,10 @@ process = os.sawtooth(freq);
 
 The `[midi:ctrl num chan]` metadata assigns MIDI CC (control change)
 to a specific UI element. The UI element receive and send MIDI CC
-values from/to the specified MIDI channel. When used in a slider
-or a bargraph, this metadata will map the UI element value to
-the {0, 127} range. When used with a button or a checkbox, 
-1 will be mapped to 127, 0 will be mapped to 0. 
+values from/to the specified MIDI channel in range {0, 15}.
+When used in a slider or a bargraph, this metadata will map the
+UI element value to the {0, 127} range. When used with a button
+or a checkbox, 1 will be mapped to 127, 0 will be mapped to 0. 
 
 **Usage**
 
@@ -90,7 +90,7 @@ toto = hslider("toto[midi:ctrl num chan]",...);
 Where:
 
 * `num`: the MIDI CC number
-* `chan`: the MIDI CC channel
+* `chan`: the MIDI CC channel (range {0,15})
 
 **Example**
 

--- a/examples/misc/midiTester.dsp
+++ b/examples/misc/midiTester.dsp
@@ -6,7 +6,7 @@ declare reference   "www.sonejo.net";
 
 // FAUST MIDI TESTER
 
-process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, noteontester, noteofftester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester) :> _)) : attach;
+process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteofftester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester) :> _)) : attach;
 
 ///////////////////////////
 
@@ -15,6 +15,12 @@ controltester = vgroup("CTRL IN/OUT", valuetest(50,51), booltest(100,101))
 with{
 valuetest(i,o) = hslider("Ctrl Value IN (Ctrl %i) [midi:ctrl %i]", 60, 0, 127, 1) : hbargraph("Ctrl Value OUT (Ctrl %o) [midi:ctrl %o]", 0, 127);
 booltest(i,o) = checkbox("Ctrl Bool IN (Ctrl %i) [midi:ctrl %i]") : hbargraph("Ctrl Bool OUT (Ctrl %o) [midi:ctrl %o]", 0, 1);
+};
+
+//Ctrl chan tester (ctrl chan): tester(midi in, midi out)
+controlchantester = vgroup("CTRL CHAN IN/OUT", valuetest(50,0,74,2))
+with{
+valuetest(i,ic,o,oc) = hslider("Ctrl Value IN (Ctrl %i Channel Value IN(Chan %ic) [midi:ctrl %i %ic]", 60, 0, 127, 1) : hbargraph("Ctrl Value OUT (Ctrl %o) Channel OUT(Chan %oc) [midi:ctrl %o %oc]", 0, 127);
 };
 
 //Note tester (keyon) : tester(midi in, midi out)

--- a/examples/misc/midiTester.dsp
+++ b/examples/misc/midiTester.dsp
@@ -6,7 +6,7 @@ declare reference   "www.sonejo.net";
 
 // FAUST MIDI TESTER
 
-process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, noteoffchantester, keypresschantester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester, pitchwheelchantester) :> _)) : attach;
+process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, noteoffchantester, keypresschantester, midiclocktester), hgroup("[2]", kattester, pctester, pcchantester, chattester, pitchwheeltester, pitchwheelchantester) :> _)) : attach;
 
 ///////////////////////////
 
@@ -73,10 +73,17 @@ booltest(i,o) = checkbox("Note KAT Bool IN (Note %i) [midi:keypress %i]") : hbar
 };
 
 //ProgramChange tester (pgm) : tester(midi in, midi out)
-pctester = vgroup("PROGRAM CHANGE (PC) IN/OUT",valuetest(50,51), booltest(100,101))
+pctester = vgroup("PROGRAM CHANGE (PC) IN/OUT",valuetest(1,2), booltest(1,2))
 with{
 valuetest(i,o) = hslider("ProgramChange Value IN (PC %i) [midi:pgm %i]", 60, 0, 127, 1) : hbargraph("ProgramChange Value OUT (PC %o) [midi:pgm %o]", 0, 127);
 booltest(i,o) = checkbox("ProgramChange Bool IN (PC %i) [midi:pgm %i]") : hbargraph("ProgramChange Bool OUT (PC %o) [midi:pgm %o]", 0, 1);
+};
+
+//ProgramChange Chan tester (pgm) : tester(midi in, midi out)
+pcchantester = vgroup("PROGRAM CHANGE CHAN (PC) IN/OUT",valuetest(1, 2, 2, 3), booltest(1, 2, 2, 3))
+with{
+valuetest(i,ic,o,oc) = hslider("ProgramChange Value IN (PC %i) (CHAN %ic) [midi:pgm %i %ic]", 60, 0, 127, 1) : hbargraph("ProgramChange Value OUT (PC %o) (CHAN %oc) [midi:pgm %o %oc]", 0, 127);
+booltest(i,ic,o,oc) = checkbox("ProgramChange Bool IN (PC %i) (CHAN %ic) [midi:pgm %i %ic]") : hbargraph("ProgramChange Bool OUT (PC %o) (CHAN %oc) [midi:pgm %o %oc]", 0, 1);
 };
 
 //Channel Aftertourch tester (chanpress) : tester(midi in, midi out)

--- a/examples/misc/midiTester.dsp
+++ b/examples/misc/midiTester.dsp
@@ -6,7 +6,7 @@ declare reference   "www.sonejo.net";
 
 // FAUST MIDI TESTER
 
-process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, noteoffchantester, keypresschantester, midiclocktester), hgroup("[2]", kattester, pctester, pcchantester, chattester, pitchwheeltester, pitchwheelchantester) :> _)) : attach;
+process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, noteoffchantester, keypresschantester, midiclocktester), hgroup("[2]", kattester, katchantester, pctester, pcchantester, chattester, chatchantester, pitchwheeltester, pitchwheelchantester) :> _)) : attach;
 
 ///////////////////////////
 
@@ -72,6 +72,13 @@ valuetest(i,o) = hslider("Note KAT Value IN (Note %i) [midi:keypress %i]", 60, 0
 booltest(i,o) = checkbox("Note KAT Bool IN (Note %i) [midi:keypress %i]") : hbargraph("Note KAT Bool OUT (Note %o) [midi:keypress %o]", 0, 1);
 };
 
+//Key Aftertouch tester (keypress) : tester(midi in, midi out)
+katchantester = vgroup("KEY AFTERTOUCH CHAN (KAT) IN/OUT",valuetest(50,2,51,3), booltest(100,2,101,3))
+with{
+valuetest(i,ic,o,oc) = hslider("Note KAT Value IN (Note %i) (Chan %ic) [midi:keypress %i %ic]", 60, 0, 127, 1) : hbargraph("Note KAT Value OUT (Note %o) (Chan %oc) [midi:keypress %o %oc]", 0, 127);
+booltest(i,ic,o,oc) = checkbox("Note KAT Bool IN (Note %i) (Chan %ic) [midi:keypress %i %ic]") : hbargraph("Note KAT Bool OUT (Note %o) (Chan %oc)[midi:keypress %o %oc]", 0, 1);
+};
+
 //ProgramChange tester (pgm) : tester(midi in, midi out)
 pctester = vgroup("PROGRAM CHANGE (PC) IN/OUT",valuetest(1,2), booltest(1,2))
 with{
@@ -91,6 +98,13 @@ chattester = vgroup("CHANNEL AFTERTOUCH (CHAT) IN/OUT",valuetest(50,51), booltes
 with{
 valuetest(i,o) = hslider("Note CHAT Value IN (Note %i) [midi:chanpress %i]", 60, 0, 127, 1) : hbargraph("Note CHAT Value OUT (Note %o) [midi:chanpress %o]", 0, 127);
 booltest(i,o) = checkbox("Note CHAT Bool IN (Note %i) [midi:chanpress %i]") : hbargraph("Note CHAT Bool OUT (Note %o) [midi:chanpress %o]", 0, 1);
+};
+
+//Channel Aftertourch tester (chanpress) : tester(midi in, midi out)
+chatchantester = vgroup("CHANNEL AFTERTOUCH CHAN (CHAT) IN/OUT",valuetest(50,2,51,3), booltest(100,2,101,3))
+with{
+valuetest(i,ic,o,oc) = hslider("Note CHAT Chan Value IN (Note %i) (Chan %ic) [midi:chanpress %i %ic]", 60, 0, 127, 1) : hbargraph("Note CHAT Value OUT (Note %o) (Chan %oc) [midi:chanpress %o %oc]", 0, 127);
+booltest(i,ic,o,oc) = checkbox("Note CHAT Bool IN (Note %i) (Chan %ic) [midi:chanpress %i %ic]") : hbargraph("Note CHAT Bool OUT (Note %o) (Chan %oc) [midi:chanpress %o %oc]", 0, 1);
 };
 
 //Pitchwheel tester (pitchwheel) : tester(midi in, midi out)

--- a/examples/misc/midiTester.dsp
+++ b/examples/misc/midiTester.dsp
@@ -6,7 +6,7 @@ declare reference   "www.sonejo.net";
 
 // FAUST MIDI TESTER
 
-process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteofftester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester) :> _)) : attach;
+process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester) :> _)) : attach;
 
 ///////////////////////////
 
@@ -18,7 +18,7 @@ booltest(i,o) = checkbox("Ctrl Bool IN (Ctrl %i) [midi:ctrl %i]") : hbargraph("C
 };
 
 //Ctrl chan tester (ctrl chan): tester(midi in, midi out)
-controlchantester = vgroup("CTRL CHAN IN/OUT", valuetest(50,0,74,2))
+controlchantester = vgroup("CTRL CHAN IN/OUT", valuetest(50,2,74,16))
 with{
 valuetest(i,ic,o,oc) = hslider("Ctrl Value IN (Ctrl %i Channel Value IN(Chan %ic) [midi:ctrl %i %ic]", 60, 0, 127, 1) : hbargraph("Ctrl Value OUT (Ctrl %o) Channel OUT(Chan %oc) [midi:ctrl %o %oc]", 0, 127);
 };
@@ -28,6 +28,12 @@ noteontester = vgroup("NOTE ON IN/OUT", valuetest(50,51), booltest(100,101))
 with{
 valuetest(i,o) = hslider("NoteOn Value IN (Note %i) [midi:keyon %i]", 60, 0, 127, 1) : hbargraph("NoteOn Value OUT (Note %o) [midi:keyon %o]", 0, 127);
 booltest(i,o) = checkbox("NoteOn Bool IN (Note %i) [midi:keyon %i]") : hbargraph("NoteOn Bool OUT (Note %o) [midi:keyon %o]", 0, 1);
+};
+
+//Note chan tester (keyon) : tester(midi in, midi out)
+noteonchantester = vgroup("NOTE ON CHAN IN/OUT", valuetest(50, 2, 51, 16))
+with{
+valuetest(i, ic, o, oc) = hslider("NoteOn Value IN (Note %i Channel %ic) [midi:keyon %i %ic]", 60, 0, 127, 1) : hbargraph("NoteOn Value OUT (Note %o Chan %oc) [midi:keyon %o %oc]", 0, 127);
 };
 
 //Note tester (keyoff) : tester(midi in, midi out)

--- a/examples/misc/midiTester.dsp
+++ b/examples/misc/midiTester.dsp
@@ -6,7 +6,7 @@ declare reference   "www.sonejo.net";
 
 // FAUST MIDI TESTER
 
-process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester) :> _)) : attach;
+process = _*0, (vgroup("FAUST MIDI TESTER", hgroup("[1]", controltester, controlchantester, noteontester, noteonchantester, noteofftester, noteoffchantester, keypresschantester, midiclocktester), hgroup("[2]", kattester, pctester, chattester, pitchwheeltester, pitchwheelchantester) :> _)) : attach;
 
 ///////////////////////////
 
@@ -17,10 +17,10 @@ valuetest(i,o) = hslider("Ctrl Value IN (Ctrl %i) [midi:ctrl %i]", 60, 0, 127, 1
 booltest(i,o) = checkbox("Ctrl Bool IN (Ctrl %i) [midi:ctrl %i]") : hbargraph("Ctrl Bool OUT (Ctrl %o) [midi:ctrl %o]", 0, 1);
 };
 
-//Ctrl chan tester (ctrl chan): tester(midi in, midi out)
-controlchantester = vgroup("CTRL CHAN IN/OUT", valuetest(50,2,74,16))
+//Ctrl Chan tester (ctrl chan): tester(midi in, midi out)
+controlchantester = vgroup("CTRL CHAN IN/OUT", valuetest(50,2,74,3))
 with{
-valuetest(i,ic,o,oc) = hslider("Ctrl Value IN (Ctrl %i Channel Value IN(Chan %ic) [midi:ctrl %i %ic]", 60, 0, 127, 1) : hbargraph("Ctrl Value OUT (Ctrl %o) Channel OUT(Chan %oc) [midi:ctrl %o %oc]", 0, 127);
+valuetest(i,ic,o,oc) = hslider("Ctrl Value IN (Ctrl %i Channel %ic) [midi:ctrl %i %ic]", 60, 0, 127, 1) : hbargraph("Ctrl Value OUT (Ctrl %o) Channel OUT(Chan %oc) [midi:ctrl %o %oc]", 0, 127);
 };
 
 //Note tester (keyon) : tester(midi in, midi out)
@@ -30,10 +30,11 @@ valuetest(i,o) = hslider("NoteOn Value IN (Note %i) [midi:keyon %i]", 60, 0, 127
 booltest(i,o) = checkbox("NoteOn Bool IN (Note %i) [midi:keyon %i]") : hbargraph("NoteOn Bool OUT (Note %o) [midi:keyon %o]", 0, 1);
 };
 
-//Note chan tester (keyon) : tester(midi in, midi out)
-noteonchantester = vgroup("NOTE ON CHAN IN/OUT", valuetest(50, 2, 51, 16))
+//Note Chan tester (keyon) : tester(midi in, midi out)
+noteonchantester = vgroup("NOTE ON CHAN IN/OUT", valuetest(50, 2, 51, 3), booltest(50, 2, 101, 3))
 with{
 valuetest(i, ic, o, oc) = hslider("NoteOn Value IN (Note %i Channel %ic) [midi:keyon %i %ic]", 60, 0, 127, 1) : hbargraph("NoteOn Value OUT (Note %o Chan %oc) [midi:keyon %o %oc]", 0, 127);
+booltest(i, ic, o, oc) = checkbox("NoteOn Chan Bool IN (Note %i Channel %ic) [midi:keyon %i %ic]") : hbargraph("NoteOn Chan Bool OUT (Note %o Channel %oc) [midi:keyon %o %oc]", 0, 1);
 };
 
 //Note tester (keyoff) : tester(midi in, midi out)
@@ -41,6 +42,20 @@ noteofftester = vgroup("NOTE OFF IN/OUT", valuetest(50,51), booltest(100,101))
 with{
 valuetest(i,o) = hslider("NoteOff Value IN (Note %i) [midi:keyoff %i]", 60, 0, 127, 1) : hbargraph("NoteOff Value OUT (Note %o) [midi:keyoff %o]", 0, 127);
 booltest(i,o) = checkbox("NoteOff Bool IN (Note %i) [midi:keyoff %i]") : hbargraph("NoteOff Bool OUT (Note %o) [midi:keyoff %o]", 0, 1);
+};
+
+//Note Chan tester (keyoff) : tester(midi in, midi out)
+noteoffchantester = vgroup("NOTE OFF CHAN IN/OUT", valuetest(50, 2, 51, 3), booltest(50, 2, 101, 3))
+with{
+valuetest(i, ic, o, oc) = hslider("NoteOff Value IN (Note %i Channel %ic) [midi:keyoff %i %ic]", 60, 0, 127, 1) : hbargraph("NoteOff Value OUT (Note %o Channel %oc) [midi:keyoff %o %oc]", 0, 127);
+booltest(i, ic, o, oc) = checkbox("NoteOff Bool IN (Note %i Channel %ic) [midi:keyoff %i %ic]") : hbargraph("NoteOff Bool OUT (Note %o Channel %oc) [midi:keyoff %o %oc]", 0, 1);
+};
+
+//KeyPress Chan tester (keypress) : tester(midi in, midi out)
+keypresschantester = vgroup("KEY PRESS CHAN IN/OUT", valuetest(50, 2, 51, 3), booltest(50, 2, 101, 3))
+with{
+valuetest(i, ic, o, oc) = hslider("Pressure Value IN (Note %i Channel %ic) [midi:keypress %i %ic]", 60, 0, 127, 1) : hbargraph("Note Value OUT (Note %o Channel %oc) [midi:keypress %o %oc]", 0, 127);
+booltest(i, ic, o, oc) = checkbox("Pressure Bool IN (Note %i Channel %ic) [midi:keypress %i %ic]") : hbargraph("Pressure Bool OUT (Note %o Channel %oc) [midi:keypress %o %oc]", 0, 1);
 };
 
 //Midisync tester
@@ -78,4 +93,9 @@ valuetest = hslider("Pitchwheel Value IN  [midi:pitchwheel]", 0, -8192, 8191, 1)
 booltest = checkbox("Pitchwheel Bool IN [midi:pitchwheel]") : hbargraph("Pitchwheel Bool OUT [midi:pitchwheel]", 0, 1);
 };
 
-
+//Pitchwheel Chan tester (pitchwheel) : tester(midi in, midi out)
+pitchwheelchantester = vgroup("PITCHWHEEL CHAN IN/OUT",valuetest(2, 15), booltest(2, 15))
+with{
+valuetest(ic, oc) = hslider("Pitchwheel Value IN (Chan %ic) [midi:pitchwheel %ic]", 0, -8192, 8191, 1) : hbargraph("Pitchwheel Value OUT (Chan %oc)[midi:pitchwheel %oc]", -8192, 8191);
+booltest(ic, oc) = checkbox("Pitchwheel Bool IN (Chan %ic) [midi:pitchwheel %ic]") : hbargraph("Pitchwheel Bool OUT (Chan %oc) [midi:pitchwheel %oc]", 0, 1);
+};


### PR DESCRIPTION
Hi, 
This PR add [midi:ctrl num chan] metadata for UI elements and allow
MIDI CC channel filtering: UI Elements can now receive and send CC value from/to
a specified MIDI channel.

I tested, documented my modifications.
This is my first attempt contributing to a project,
I Hope I am doing this right...

Best regards...

Rem: most MIDI hardware use channel values from 1 to 16.
So [midi:ctrl num 0] will mean sending/receiving midi CC to the synth/controller... channel 1.
This look "unnatural" however when monitoring midi data coming from my synths 
with `aseqdump -p` I observed that:

synth Ch 1 -> aseqdump Ch 0
synth Ch 2 -> aseqdump Ch 1
...
synth Ch 16 -> aseqdump Ch 15

So I decided to keep the channel range to [0,15]. 