### PR TITLE
tools/sound2faust/Makefile: Adding LDFLAGS

### DIFF
--- a/tools/sound2faust/Makefile
+++ b/tools/sound2faust/Makefile
@@ -16,16 +16,16 @@ all : sound2faust sound2file
 
 sound2faust : sound2faust.cpp
 
-	$(CXX) -O3 sound2faust.cpp -I../../architecture `pkg-config --cflags --static --libs sndfile` -o sound2faust $(LIBS)
+	$(CXX) -O3 $(LDFLAGS) sound2faust.cpp -I../../architecture $(shell pkg-config --cflags --static --libs sndfile) -o sound2faust $(LIBS)
 
 sound2file : sound2file.cpp
 
-	$(CXX) -O3 sound2file.cpp -I../../architecture `pkg-config --cflags --static --libs sndfile` -o sound2file $(LIBS)
+	$(CXX) -O3 $(LDFLAGS) sound2file.cpp -I../../architecture $(shell pkg-config --cflags --static --libs sndfile) -o sound2file $(LIBS)
 
 static:
 
-	$(CXX) -O3 sound2faust.cpp -I../../architecture `pkg-config --cflags  sndfile`  /usr/local/lib/libsndfile.a -o sound2faust
-	$(CXX) -O3 sound2file.cpp -I../../architecture `pkg-config --cflags  sndfile`  /usr/local/lib/libsndfile.a -o sound2file
+	$(CXX) -O3 sound2faust.cpp -I../../architecture $(shell pkg-config --cflags  sndfile)  /usr/local/lib/libsndfile.a -o sound2faust
+	$(CXX) -O3 sound2file.cpp -I../../architecture $(shell pkg-config --cflags  sndfile)  /usr/local/lib/libsndfile.a -o sound2file
 
 install :
 

--- a/tools/sound2faust/Makefile
+++ b/tools/sound2faust/Makefile
@@ -24,8 +24,8 @@ sound2file : sound2file.cpp
 
 static:
 
-	$(CXX) -O3 sound2faust.cpp -I../../architecture $(shell pkg-config --cflags  sndfile)  /usr/local/lib/libsndfile.a -o sound2faust
-	$(CXX) -O3 sound2file.cpp -I../../architecture $(shell pkg-config --cflags  sndfile)  /usr/local/lib/libsndfile.a -o sound2file
+	$(CXX) -O3 $(LDFLAGS) sound2faust.cpp -I../../architecture $(shell pkg-config --cflags  sndfile)  /usr/local/lib/libsndfile.a -o sound2faust
+	$(CXX) -O3 $(LDFLAGS) sound2file.cpp -I../../architecture $(shell pkg-config --cflags  sndfile)  /usr/local/lib/libsndfile.a -o sound2file
 
 install :
 


### PR DESCRIPTION
As discussed in #302, sound2{faust,file} lack [full RELRO](https://mudongliang.github.io/2016/07/11/relro-a-not-so-well-known-memory-corruption-mitigation-technique.html), which is caused by `tools/sound2faust/Makefile` being unaware of `LDFLAGS`.
This pull request adds `LDFLAGS` to the `CXX` call and additionally calls pkg-config more cleanly in a shell environment.