### PR TITLE
Fix potential memory leak when creating OpenSL ES engine

### DIFF
--- a/architecture/faust/audio/android-dsp.h
+++ b/architecture/faust/audio/android-dsp.h
@@ -341,6 +341,26 @@ class androidaudio : public audio {
                     return false;
             }
           
+			if (fInputBufferQueue) {
+				(*fInputBufferQueue)->Destroy(fInputBufferQueue);
+				fInputBufferQueue = NULL;
+			}
+
+			if (fOutputBufferQueue) {
+				(*fOutputBufferQueue)->Destroy(fOutputBufferQueue);
+				fOutputBufferQueue = NULL;
+			}
+
+			if (fOutputMix) {
+				(*fOutputMix)->Destroy(fOutputMix);
+				fOutputMix = NULL;
+			}
+
+			if (fOpenSLEngine) {
+				(*fOpenSLEngine)->Destroy(fOpenSLEngine);
+				fOpenSLEngine = NULL;
+			}
+			
             // Create the OpenSL ES engine.
             result = slCreateEngine(&fOpenSLEngine, 0, NULL, 0, NULL, NULL);
             if (result != SL_RESULT_SUCCESS) {


### PR DESCRIPTION
Memory leak occurs during init when I switch between different dsp objects multiple times on the same DspFaust instance.