### PR TITLE
Small fix for gcc 4.8.*

### DIFF
--- a/compiler/utils/exepath.cpp
+++ b/compiler/utils/exepath.cpp
@@ -62,7 +62,7 @@ string exepath::dirup(const string& path)
 string exepath::stripPath(const string& path)
 {
     regex  e("/[^/]*/\\.\\.");  // matches sequence like /path/..
-    string stripped = regex_replace(path, e, "");
+    string stripped = regex_replace(path, e, std::string(""));
     if (stripped == path) return path;
     return stripPath(stripped);
 }


### PR DESCRIPTION
Since CMAKE by default ignores your default c/c++ compiler and uses something inside /usr/bin instead, it often happens that faust is compiled with an older version of gcc.

P.S. Maybe add something like this to the makefile?
```
-DCMAKE_CXX_COMPILER=`which g++` -DCMAKE_C_COMPILER=`which gcc"
```
