### PR TITLE
esp32_midi():midi_handler("esp32"):fProcessMidiHandle(NULL) throws a …

### DIFF
--- a/architecture/esp32/esp32.cpp
+++ b/architecture/esp32/esp32.cpp
@@ -148,7 +148,6 @@ AudioFaust::~AudioFaust()
 bool AudioFaust::start()
 {
 #if MIDICTRL
-    if (!fMIDIHandler->startMidi()) return false;
     fMIDIInterface->run();
 #endif
     return (xTaskCreatePinnedToCore(audioTaskHandler, "Faust DSP Task", 1024, (void*)this, 24, &fHandle, 0) == pdPASS);
@@ -157,7 +156,6 @@ bool AudioFaust::start()
 void AudioFaust::stop()
 {
 #if MIDICTRL
-    fMIDIHandler->stopMidi();
     fMIDIInterface->stop();
 #endif
     if (fHandle != NULL) {

--- a/architecture/faust/midi/esp32-midi.h
+++ b/architecture/faust/midi/esp32-midi.h
@@ -55,7 +55,7 @@ class esp32_midi : public midi_handler {
     
     private:
     
-        TaskHandle_t fProcessMidiHandle;
+        TaskHandle_t fProcessMidiHandle = NULL;
     
         void processMidi()
         {
@@ -149,7 +149,7 @@ class esp32_midi : public midi_handler {
     
     public:
     
-        esp32_midi():midi_handler("esp32"):fProcessMidiHandle(NULL)
+        esp32_midi():midi_handler("esp32")
         {
             // Setup UART for MIDI
             setupMidi();


### PR DESCRIPTION
…compile error. Added NULL initialization to where the taskhandle gets declared.

+

Removed duplicate fMIDIHandler -> startMidi() and stopMidi() calls.