### PR TITLE
The Docker image needs pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /faust
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm libncurses5-dev libncurses5 libmicrohttpd-dev git cmake && \
+  apt-get install -y build-essential llvm libncurses5-dev libncurses5 libmicrohttpd-dev git cmake pkg-config && \
   rm -rf /var/lib/apt/lists/*
 
 RUN \


### PR DESCRIPTION
Probably since the latest Debian stable `pkg-config` was not installed as a dependency, but the CMake script relies on it.

Tested on:
- Ubuntu 19.10 with Linux 5.3.0-29-generic
- Docker version 19.03.2, build 6a30dfca03