### PR TITLE
Use `MediaDevices` instead of deprecated API for `getUserMedia`

### DIFF
--- a/architecture/webaudio/component-creator.html
+++ b/architecture/webaudio/component-creator.html
@@ -477,18 +477,16 @@
 			    // Audio input handling
     		function activateAudioInput(){
        			console.log("activateAudioInput");
-		     	if (!navigator.getUserMedia) {
-		            navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-        		}
-        
-		        if (navigator.getUserMedia) {
-        		    navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice, function(e) {
-                	    alert('Error getting audio input');
-                    	console.log(e);
-            		});
-		        } else {
-        		    alert('Audio input API not available');
-        		}
+            if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+                navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                    .then(getDevice)
+                    .catch((e) => {
+                        alert('Error getting audio input');
+                        console.log(e);
+                    });
+            } else {
+                alert('Audio input API not available');
+            }
     		}
 
             function getDevice(device) {

--- a/architecture/webaudio/faustlive-wasm.html
+++ b/architecture/webaudio/faustlive-wasm.html
@@ -603,16 +603,15 @@
             function activateAudioInput()
             {
                 console.log("activateAudioInput");
-                if (!navigator.getUserMedia) {
-                    navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-                }
 
-                if (navigator.getUserMedia) {
-                    navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice, function(e) {
-                                           alert('Error getting audio input');
-                                           console.log(e);
-                                           audio_input = null;
-                                           });
+                if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+                    navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                        .then(getDevice)
+                        .catch((e) => {
+                            alert('Error getting audio input');
+                            console.log(e);
+                            audio_input = null;
+                        });
                 } else {
                     alert('Audio input API not available');
                 }

--- a/architecture/webaudio/webComponent/template/faustTemplate.html
+++ b/architecture/webaudio/webComponent/template/faustTemplate.html
@@ -366,16 +366,15 @@
     function activateAudioInput(DSP)
     {
         console.log("activateAudioInput");
-        if (!navigator.getUserMedia) {
-            navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-        }
-        
-        if (navigator.getUserMedia) {
-            navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice(DSP), function(e) {
+
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                .then(getDevice(DSP))
+                .catch((e) => {
                     alert('Error getting audio input');
                     console.log(e);
                     audio_input = null;
-            });
+                });
         } else {
             alert('Audio input API not available');
         }

--- a/architecture/webaudio/webaudio-wasm-emcc-footer.html
+++ b/architecture/webaudio/webaudio-wasm-emcc-footer.html
@@ -50,20 +50,24 @@
 
     // Audio input handling
     const activateAudioInput = () => {
-        if (!navigator.getUserMedia) {
-            navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            const onSuccess = device => {
+                audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
+                audioInput.connect(dspNode); // Connect it to the destination.
+            };
+
+            const onError = e => {
+                alert('Error getting audio input');
+                console.error(e);
+                audioInput = null;
+            };
+
+            navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                .then(onSuccess)
+                .catch(onError);
+        } else {
+            alert('Audio input API not available');
         }
-        if (!navigator.getUserMedia) alert("Audio input API not available") 
-        const onSuccess = device => {
-            audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
-            audioInput.connect(dspNode); // Connect it to the destination.
-        }
-        const onError = e => {
-            alert('Error getting audio input');
-            console.error(e);
-            audioInput = null;
-        }
-        navigator.getUserMedia({ audio: { echoCancellation: false } }, onSuccess, onError);
     }
 
     // Save/Load functions using local storage

--- a/architecture/webaudio/webaudio-wasm-emcc-poly-footer.html
+++ b/architecture/webaudio/webaudio-wasm-emcc-poly-footer.html
@@ -50,20 +50,24 @@
 
     // Audio input handling
     const activateAudioInput = () => {
-        if (!navigator.getUserMedia) {
-            navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            const onSuccess = device => {
+                audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
+                audioInput.connect(dspNode); // Connect it to the destination.
+            };
+
+            const onError = e => {
+                alert('Error getting audio input');
+                console.error(e);
+                audioInput = null;
+            };
+
+            navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                .then(onSuccess)
+                .catch(onError);
+        } else {
+            alert('Audio input API not available');
         }
-        if (!navigator.getUserMedia) alert("Audio input API not available") 
-        const onSuccess = device => {
-            audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
-            audioInput.connect(dspNode); // Connect it to the destination.
-        }
-        const onError = e => {
-            alert('Error getting audio input');
-            console.error(e);
-            audioInput = null;
-        }
-        navigator.getUserMedia({ audio: { echoCancellation: false } }, onSuccess, onError);
     }
     
     // Save/Load functions using local storage

--- a/architecture/webaudio/webaudio-wasm-emcc-poly-worklet-footer.html
+++ b/architecture/webaudio/webaudio-wasm-emcc-poly-worklet-footer.html
@@ -109,15 +109,13 @@ function activateMIDIInput() {
 
 function activateAudioInput()
 {
-    if (!navigator.getUserMedia) {
-        navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-    }
-    
-    if (navigator.getUserMedia) {
-        navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice, function(e) {
-                               alert('Error getting audio input');
-                               console.log(e);
-                               });
+    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+            .then(getDevice)
+            .catch((e) => {
+                alert('Error getting audio input');
+                console.log(e);
+            });
     } else {
         alert('Audio input API not available');
     }

--- a/architecture/webaudio/webaudio-wasm-emcc-worklet-footer.html
+++ b/architecture/webaudio/webaudio-wasm-emcc-worklet-footer.html
@@ -89,15 +89,13 @@ function activateMIDIInput() {
 
 function activateAudioInput()
 {
-    if (!navigator.getUserMedia) {
-        navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-    }
-
-    if (navigator.getUserMedia) {
-        navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice, function(e) {
-                               alert('Error getting audio input');
-                               console.log(e);
-                               });
+    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+            .then(getDevice)
+            .catch((e) => {
+                alert('Error getting audio input');
+                console.log(e);
+            });
     } else {
         alert('Audio input API not available');
     }

--- a/architecture/webaudio/webaudio-wasm-footer.html
+++ b/architecture/webaudio/webaudio-wasm-footer.html
@@ -48,20 +48,24 @@
 
     // Audio input handling
     const activateAudioInput = () => {
-        if (!navigator.getUserMedia) {
-            navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            const onSuccess = device => {
+                audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
+                audioInput.connect(dspNode); // Connect it to the destination.
+            };
+
+            const onError = e => {
+                alert('Error getting audio input');
+                console.error(e);
+                audioInput = null;
+            };
+
+            navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                .then(onSuccess)
+                .catch(onError);
+        } else {
+            alert('Audio input API not available');
         }
-        if (!navigator.getUserMedia) alert("Audio input API not available") 
-        const onSuccess = device => {
-            audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
-            audioInput.connect(dspNode); // Connect it to the destination.
-        }
-        const onError = e => {
-            alert('Error getting audio input');
-            console.error(e);
-            audioInput = null;
-        }
-        navigator.getUserMedia({ audio: { echoCancellation: false } }, onSuccess, onError);
     }
 
     // Save/Load functions using local storage

--- a/architecture/webaudio/webaudio-wasm-poly-footer.html
+++ b/architecture/webaudio/webaudio-wasm-poly-footer.html
@@ -51,20 +51,24 @@
 
     // Audio input handling
     const activateAudioInput = () => {
-        if (!navigator.getUserMedia) {
-            navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            const onSuccess = device => {
+                audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
+                audioInput.connect(dspNode); // Connect it to the destination.
+            };
+
+            const onError = e => {
+                alert('Error getting audio input');
+                console.error(e);
+                audioInput = null;
+            };
+
+            navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+                .then(onSuccess)
+                .catch(onError);
+        } else {
+            alert('Audio input API not available');
         }
-        if (!navigator.getUserMedia) alert("Audio input API not available") 
-        const onSuccess = device => {
-            audioInput = audioCtx.createMediaStreamSource(device); // Create an AudioNode from the stream.
-            audioInput.connect(dspNode); // Connect it to the destination.
-        }
-        const onError = e => {
-            alert('Error getting audio input');
-            console.error(e);
-            audioInput = null;
-        }
-        navigator.getUserMedia({ audio: { echoCancellation: false } }, onSuccess, onError);
     }
     
     // Save/Load functions using local storage

--- a/architecture/webaudio/webaudio-wasm-poly-worklet-footer.html
+++ b/architecture/webaudio/webaudio-wasm-poly-worklet-footer.html
@@ -109,15 +109,13 @@ function activateMIDIInput() {
 
 function activateAudioInput()
 {
-    if (!navigator.getUserMedia) {
-        navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-    }
-    
-    if (navigator.getUserMedia) {
-        navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice, function(e) {
-                               alert('Error getting audio input');
-                               console.log(e);
-                               });
+    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+            .then(getDevice)
+            .catch((e) => {
+                alert('Error getting audio input');
+                console.log(e);
+            });
     } else {
         alert('Audio input API not available');
     }

--- a/architecture/webaudio/webaudio-wasm-worklet-footer.html
+++ b/architecture/webaudio/webaudio-wasm-worklet-footer.html
@@ -85,15 +85,13 @@ function activateMIDIInput() {
 
 function activateAudioInput()
 {
-    if (!navigator.getUserMedia) {
-        navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-    }
-
-    if (navigator.getUserMedia) {
-        navigator.getUserMedia({audio: { echoCancellation: false }}, getDevice, function(e) {
-                               alert('Error getting audio input');
-                               console.log(e);
-                               });
+    if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } })
+            .then(getDevice)
+            .catch((e) => {
+                alert('Error getting audio input');
+                console.log(e);
+            });
     } else {
         alert('Audio input API not available');
     }


### PR DESCRIPTION
Use `MediaDevices` because of `navigator.getUserMedia` is deprecated API ([NOTE](https://www.w3.org/TR/mediacapture-streams/#legacy-interface-extensions)).