### PR TITLE
Fixed path handling in faust2*rust scripts

### DIFF
--- a/tools/faust2appls/faust2jackrust
+++ b/tools/faust2appls/faust2jackrust
@@ -49,13 +49,15 @@ for p in $FILES; do
 
     f=$(basename "$p")
     SRCDIR=$(dirname "$p")
-  
+
     # creates the dir
     dspName="${f%.dsp}-jackrust"
     rm -rf "$SRCDIR/$dspName"
 
     # create rust project
+    pushd "$SRCDIR"
     cargo new $dspName --bin
+    popd
 
     # compile Faust DSP and put in the cargo folder
     faust -a $ARCHFILE -lang rust "$SRCDIR/$f" -o "$SRCDIR/$dspName/src/main.rs"

--- a/tools/faust2appls/faust2portaudiorust
+++ b/tools/faust2appls/faust2portaudiorust
@@ -57,7 +57,9 @@ for p in $FILES; do
     rm -rf "$SRCDIR/$dspName"
 
     # create rust project
+    pushd "$SRCDIR"
     cargo new $dspName --bin
+    popd
 
     # compile Faust DSP and put in the cargo folder
     faust -a $ARCHFILE -lang rust "$SRCDIR/$f" -o "$SRCDIR/$dspName/src/main.rs"


### PR DESCRIPTION
A tiny bugfix for the `faust2*rust` scripts:

Currently the `cargo new` happens in the working directoryi, i.e., if the working directory is different from `$SRCDIR` the project is directed in the wrong place. The script will basically fail in

```
faust -a $ARCHFILE -lang rust "$SRCDIR/$f" -o "$SRCDIR/$dspName/src/main.rs"
```

with

```
ERROR : file '<ACTUAL-PROJECT-PATH>/src/main.rs' cannot be opened
```

because the parent directories don't exist.