### PR TITLE
added .dockerignore to avoid copying host build artifacts into docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/build/faustdir


### PR DESCRIPTION
It turned out that the problem I observed in #430 was because I had local build artifacts that got copied into the docker image and then messed up the cmake run.

There is a simple solution: Exclude `build/faustdir` from getting copied into the docker image via a `.dockerignore`.

CC @gierschv 