### PR TITLE
[WIP] add idiomatic dsp trait for rust

### DIFF
--- a/architecture/minimal-jack.rs
+++ b/architecture/minimal-jack.rs
@@ -26,6 +26,8 @@ use jack::prelude as j;
 use std::io;
 extern crate libm;
 
+// TODO: adapt
+
 pub trait Meta {
 
     // -- metadata declarations

--- a/architecture/minimal-portaudio.rs
+++ b/architecture/minimal-portaudio.rs
@@ -26,6 +26,8 @@ use portaudio as pa;
 use std::io;
 extern crate libm;
 
+// TODO: adapt
+
 pub trait Meta {
 
     // -- metadata declarations

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -103,7 +103,7 @@ void RustCodeContainer::produceInternal()
     *fOut << "pub struct " << fKlassName << " {";
 
     tab(n + 1, *fOut);
-   
+
     // Fields
     fCodeProducer.Tab(n + 1);
     generateDeclarations(&fCodeProducer);
@@ -117,14 +117,14 @@ void RustCodeContainer::produceInternal()
 
     tab(n + 1, *fOut);
     tab(n + 1, *fOut);
-    produceInfoFunctions(n + 1, fKlassName, "&mut self", false, false, &fCodeProducer);
+    produceInfoFunctions(n + 1);
 
     // Init
     // TODO
     // generateInstanceInitFun("instanceInit" + fKlassName, false, false)->accept(&fCodeProducer);
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn instanceInit" << fKlassName << "(&mut self, sample_rate: i32) {";
+    *fOut << "pub fn instance_init" << fKlassName << "(&mut self, sample_rate: i32) {";
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
     generateInit(&fCodeProducer);
@@ -190,7 +190,7 @@ void RustCodeContainer::produceClass()
 
     *fOut << "pub struct " << fKlassName << " {";
     tab(n + 1, *fOut);
-   
+
     // Dummy field used for 'declare'
     *fOut << "fDummy: " << ifloat() << ",";
     tab(n + 1, *fOut);
@@ -204,7 +204,7 @@ void RustCodeContainer::produceClass()
     tab(n, *fOut);
 
     tab(n, *fOut);
-    *fOut << "impl " << fKlassName << " {";
+    *fOut << "impl FaustDsp for " << fKlassName << " {";
 
     // Memory methods
     tab(n + 2, *fOut);
@@ -229,7 +229,7 @@ void RustCodeContainer::produceClass()
         tab(n + 1, *fOut);
     }
 
-    *fOut << "pub fn new() -> " << fKlassName << " { ";
+    *fOut << "fn new() -> " << fKlassName << " { ";
     if (fAllocateInstructions->fCode.size() > 0) {
         tab(n + 2, *fOut);
         *fOut << "allocate" << fKlassName << "(dsp);";
@@ -251,9 +251,9 @@ void RustCodeContainer::produceClass()
     // Get sample rate method
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
-    generateGetSampleRate("getSampleRate" + fKlassName, "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetSampleRate("get_sample_rate", "&mut self", false, false)->accept(&fCodeProducer);
 
-    produceInfoFunctions(n + 1, "", "&mut self", false, false, &fCodeProducer);
+    produceInfoFunctions(n + 1);
 
     // Inits
 
@@ -265,19 +265,20 @@ void RustCodeContainer::produceClass()
     // generateInstanceInitFun("instanceInit" + fKlassName, false, false)->accept(&codeproducer2);
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn classInit(sample_rate: i32) {";
+    *fOut << "fn class_init(sample_rate: i32) {";
     {
         tab(n + 2, *fOut);
         // Local visitor here to avoid DSP object type wrong generation
         RustInstVisitor codeproducer(fOut, "");
         codeproducer.Tab(n + 2);
+        // TODO: This creates function calls with "wrong" function names. How to forward the proper names?
         generateStaticInit(&codeproducer);
     }
     back(1, *fOut);
     *fOut << "}";
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn instanceResetUserInterface(&mut self) {";
+    *fOut << "fn instance_reset_user_interface(&mut self) {";
     {
         tab(n + 2, *fOut);
         // Local visitor here to avoid DSP object type wrong generation
@@ -289,7 +290,7 @@ void RustCodeContainer::produceClass()
     *fOut << "}";
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn instanceClear(&mut self) {";
+    *fOut << "fn instance_clear(&mut self) {";
     {
         tab(n + 2, *fOut);
         // Local visitor here to avoid DSP object type wrong generation
@@ -301,7 +302,7 @@ void RustCodeContainer::produceClass()
     *fOut << "}";
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn instanceConstants(&mut self, sample_rate: i32) {";
+    *fOut << "fn instance_constants(&mut self, sample_rate: i32) {";
     {
         tab(n + 2, *fOut);
         // Local visitor here to avoid DSP object type wrong generation
@@ -313,28 +314,28 @@ void RustCodeContainer::produceClass()
     *fOut << "}";
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn instanceInit(&mut self, sample_rate: i32) {";
+    *fOut << "fn instance_init(&mut self, sample_rate: i32) {";
     tab(n + 2, *fOut);
-    *fOut << "self.instanceConstants(sample_rate);";
+    *fOut << "self.instance_constants(sample_rate);";
     tab(n + 2, *fOut);
-    *fOut << "self.instanceResetUserInterface();";
+    *fOut << "self.instance_reset_user_interface();";
     tab(n + 2, *fOut);
-    *fOut << "self.instanceClear();";
+    *fOut << "self.instance_clear();";
     tab(n + 1, *fOut);
     *fOut << "}";
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn init(&mut self, sample_rate: i32) {";
+    *fOut << "fn init(&mut self, sample_rate: i32) {";
     tab(n + 2, *fOut);
-    *fOut << fKlassName << "::classInit(sample_rate);";
+    *fOut << fKlassName << "::class_init(sample_rate);";
     tab(n + 2, *fOut);
-    *fOut << "self.instanceInit(sample_rate);";
+    *fOut << "self.instance_init(sample_rate);";
     tab(n + 1, *fOut);
     *fOut << "}";
 
     // User interface
     tab(n + 1, *fOut);
-    *fOut << "pub fn buildUserInterface(&mut self, ui_interface: &mut UI<" << ifloat() << ">) {";
+    *fOut << "fn build_user_interface(&mut self, ui_interface: &mut dyn UI<" << ifloat() << ">) {";
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
     generateUserInterface(&fCodeProducer);
@@ -352,7 +353,7 @@ void RustCodeContainer::produceClass()
 void RustCodeContainer::produceMetadata(int n)
 {
     tab(n, *fOut);
-    *fOut << "pub fn metadata(&mut self, m: &mut Meta) { ";
+    *fOut << "fn metadata(&mut self, m: &mut dyn Meta) { ";
 
     // We do not want to accumulate metadata from all hierachical levels, so the upper level only is kept
     for (auto& i : gGlobal->gMetaDataSet) {
@@ -380,6 +381,30 @@ void RustCodeContainer::produceMetadata(int n)
     *fOut << "}" << endl;
 }
 
+void RustCodeContainer::produceInfoFunctions(int tabs)
+{
+    // TODO: This sometimes omits the info functions for some reason.
+    // Do we need a manual implementation (sketched below)?
+    generateGetInputs("get_num_inputs", "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetOutputs("get_num_outputs", "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetInputRate("get_input_rate", "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetOutputRate("get_output_rate", "&mut self", false, false)->accept(&fCodeProducer);
+    /*
+    tab(tabs, *fOut);
+    *fOut << "fn get_num_inputs() {";
+    {
+        tab(tabs + 1, *fOut);
+        // Local visitor here to avoid DSP object type wrong generation
+        RustInstVisitor codeproducer(fOut, "");
+        codeproducer.Tab(n + 2);
+        // ...
+    }
+    back(1, *fOut);
+    *fOut << "}";
+    */
+}
+
+
 // Scalar
 RustScalarCodeContainer::RustScalarCodeContainer(const string& name, int numInputs, int numOutputs, std::ostream* out,
                                                  int sub_container_type)
@@ -397,7 +422,7 @@ void RustScalarCodeContainer::generateCompute(int n)
     // Generates declaration
     tab(n, *fOut);
     tab(n, *fOut);
-    *fOut << "pub fn compute("
+    *fOut << "fn compute("
           << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
@@ -432,7 +457,7 @@ void RustVectorCodeContainer::generateCompute(int n)
 
     // Compute declaration
     tab(n, *fOut);
-    *fOut << "pub fn compute("
+    *fOut << "fn compute("
           << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
@@ -462,7 +487,7 @@ void RustOpenMPCodeContainer::generateCompute(int n)
 
     // Compute declaration
     tab(n, *fOut);
-    *fOut << "pub fn compute("
+    *fOut << "fn compute("
           << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
@@ -500,8 +525,10 @@ void RustWorkStealingCodeContainer::generateCompute(int n)
     generateComputeFunctions(&fCodeProducer);
 
     // Generates "computeThread" code
+    // Note that users either have to adjust the trait in their architecture file.
+    // Alternatively we would have to attach this method to the impl, not the trait.
     tab(n, *fOut);
-    *fOut << "pub fn computeThread(" << fKlassName << "&mut self, num_thread: i32) {";
+    *fOut << "pub fn compute_thread(" << fKlassName << "&mut self, num_thread: i32) {";
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
 
@@ -513,7 +540,7 @@ void RustWorkStealingCodeContainer::generateCompute(int n)
 
     // Compute "compute" declaration
     tab(n, *fOut);
-    *fOut << "pub fn compute("
+    *fOut << "fn compute("
           << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
@@ -527,7 +554,7 @@ void RustWorkStealingCodeContainer::generateCompute(int n)
     tab(n, *fOut);
     *fOut << "extern \"C\" void computeThreadExternal(&mut self, num_thread: i32) {";
     tab(n + 1, *fOut);
-    *fOut << "computeThread((" << fKlassName << "*)dsp, num_thread);";
+    *fOut << "compute_thread((" << fKlassName << "*)dsp, num_thread);";
     tab(n, *fOut);
     *fOut << "}" << endl;
 }

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -206,6 +206,11 @@ void RustCodeContainer::produceClass()
     tab(n, *fOut);
     *fOut << "impl FaustDsp for " << fKlassName << " {";
 
+    // Associated type
+    tab(n + 2, *fOut);
+    *fOut << "type Float = " << ifloat() << ";";
+    tab(n + 2, *fOut);
+
     // Memory methods
     tab(n + 2, *fOut);
     if (fAllocateInstructions->fCode.size() > 0) {
@@ -335,7 +340,7 @@ void RustCodeContainer::produceClass()
 
     // User interface
     tab(n + 1, *fOut);
-    *fOut << "fn build_user_interface(&mut self, ui_interface: &mut dyn UI<" << ifloat() << ">) {";
+    *fOut << "fn build_user_interface(&mut self, ui_interface: &mut dyn UI<Self::Float>) {";
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
     generateUserInterface(&fCodeProducer);
@@ -423,7 +428,7 @@ void RustScalarCodeContainer::generateCompute(int n)
     tab(n, *fOut);
     tab(n, *fOut);
     *fOut << "fn compute("
-          << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
+          << subst("&mut self, $0: i32, inputs: &[&[Self::Float]], outputs: &mut[&mut[Self::Float]]) {", fFullCount);
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
 
@@ -458,7 +463,7 @@ void RustVectorCodeContainer::generateCompute(int n)
     // Compute declaration
     tab(n, *fOut);
     *fOut << "fn compute("
-          << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
+          << subst("&mut self, $0: i32, inputs: &[&[Self::Float]], outputs: &mut[&mut[Self::Float]]) {", fFullCount);
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
 
@@ -488,7 +493,7 @@ void RustOpenMPCodeContainer::generateCompute(int n)
     // Compute declaration
     tab(n, *fOut);
     *fOut << "fn compute("
-          << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
+          << subst("&mut self, $0: i32, inputs: &[&[Self::Float]], outputs: &mut[&mut[Self::Float]]) {", fFullCount);
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
 
@@ -541,7 +546,7 @@ void RustWorkStealingCodeContainer::generateCompute(int n)
     // Compute "compute" declaration
     tab(n, *fOut);
     *fOut << "fn compute("
-          << subst("&mut self, $0: i32, inputs: &[&[$1]], outputs: &mut[&mut[$1]]) {", fFullCount, ifloat());
+          << subst("&mut self, $0: i32, inputs: &[&[Self::Float]], outputs: &mut[&mut[Self::Float]]) {", fFullCount);
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
 

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -124,7 +124,7 @@ void RustCodeContainer::produceInternal()
     // generateInstanceInitFun("instanceInit" + fKlassName, false, false)->accept(&fCodeProducer);
 
     tab(n + 1, *fOut);
-    *fOut << "pub fn instance_init" << fKlassName << "(&mut self, sample_rate: i32) {";
+    *fOut << "pub fn instance_init_" << fKlassName << "(&mut self, sample_rate: i32) {";
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
     generateInit(&fCodeProducer);

--- a/compiler/generator/rust/rust_code_container.hh
+++ b/compiler/generator/rust/rust_code_container.hh
@@ -55,6 +55,7 @@ class RustCodeContainer : public virtual CodeContainer {
     virtual void              generateCompute(int tab) = 0;
     void                      produceInternal();
     virtual dsp_factory_base* produceFactory();
+    virtual void              produceInfoFunctions(int tabs);
 
     CodeContainer* createScalarContainer(const string& name, int sub_container_type);
 

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -109,7 +109,7 @@ class RustInstVisitor : public TextInstVisitor {
         fMathLibTable["sinf"]       = "f32::sin";
         fMathLibTable["sqrtf"]      = "f32::sqrt";
         fMathLibTable["tanf"]       = "f32::tan";
-        
+
         // Additional hyperbolic math functions
         fMathLibTable["acoshf"]     = "f32::acosh";
         fMathLibTable["asinhf"]     = "f32::asinh";
@@ -141,7 +141,7 @@ class RustInstVisitor : public TextInstVisitor {
         fMathLibTable["sin"]       = "f64::sin";
         fMathLibTable["sqrt"]      = "f64::sqrt";
         fMathLibTable["tan"]       = "f64::tan";
-        
+
         // Additional hyperbolic math functions
         fMathLibTable["acosh"]     = "f64::acosh";
         fMathLibTable["asinh"]     = "f64::asinh";
@@ -171,13 +171,13 @@ class RustInstVisitor : public TextInstVisitor {
         string name;
         switch (inst->fOrient) {
             case OpenboxInst::kVerticalBox:
-                name = "ui_interface.openVerticalBox(";
+                name = "ui_interface.open_vertical_box(";
                 break;
             case OpenboxInst::kHorizontalBox:
-                name = "ui_interface.openHorizontalBox(";
+                name = "ui_interface.open_horizontal_box(";
                 break;
             case OpenboxInst::kTabBox:
-                name = "ui_interface.openTabBox(";
+                name = "ui_interface.open_tab_box(";
                 break;
         }
         *fOut << name << quote(inst->fName) << ")";
@@ -186,16 +186,16 @@ class RustInstVisitor : public TextInstVisitor {
 
     virtual void visit(CloseboxInst* inst)
     {
-        *fOut << "ui_interface.closeBox();";
+        *fOut << "ui_interface.close_box();";
         tab(fTab, *fOut);
     }
 
     virtual void visit(AddButtonInst* inst)
     {
         if (inst->fType == AddButtonInst::kDefaultButton) {
-            *fOut << "ui_interface.addButton(" << quote(inst->fLabel) << ", &mut self." << inst->fZone << ")";
+            *fOut << "ui_interface.add_button(" << quote(inst->fLabel) << ", &mut self." << inst->fZone << ")";
         } else {
-            *fOut << "ui_interface.addCheckButton(" << quote(inst->fLabel) << ", &mut self." << inst->fZone << ")";
+            *fOut << "ui_interface.add_check_button(" << quote(inst->fLabel) << ", &mut self." << inst->fZone << ")";
         }
         EndLine();
     }
@@ -205,13 +205,13 @@ class RustInstVisitor : public TextInstVisitor {
         string name;
         switch (inst->fType) {
             case AddSliderInst::kHorizontal:
-                name = "ui_interface.addHorizontalSlider";
+                name = "ui_interface.add_horizontal_slider";
                 break;
             case AddSliderInst::kVertical:
-                name = "ui_interface.addVerticalSlider";
+                name = "ui_interface.add_vertical_slider";
                 break;
             case AddSliderInst::kNumEntry:
-                name = "ui_interface.addNumEntry";
+                name = "ui_interface.add_num_entry";
                 break;
         }
         *fOut << name << "(" << quote(inst->fLabel) << ", "
@@ -225,10 +225,10 @@ class RustInstVisitor : public TextInstVisitor {
         string name;
         switch (inst->fType) {
             case AddBargraphInst::kHorizontal:
-                name = "ui_interface.addHorizontalBargraph";
+                name = "ui_interface.add_horizontal_bargraph";
                 break;
             case AddBargraphInst::kVertical:
-                name = "ui_interface.addVerticalBargraph";
+                name = "ui_interface.add_vertical_bargraph";
                 break;
         }
         *fOut << name << "(" << quote(inst->fLabel) << ", &mut self." << inst->fZone << ", " << checkReal(inst->fMin)
@@ -271,7 +271,12 @@ class RustInstVisitor : public TextInstVisitor {
         // Only generates additional functions
         if (fMathLibTable.find(inst->fName) == fMathLibTable.end()) {
             // Prototype
-            *fOut << "pub fn " << inst->fName;
+            // Since functions are attached to a trait they must not be prefixed with "pub".
+            // In case we need a mechanism to attach functions to both traits and normal
+            // impls, we need a mechanism to forward the information whether to use "pub"
+            // or not. In the worst case, we have to prefix the name string like "pub fname",
+            // and handle the prefix here.
+            *fOut << "fn " << inst->fName;
             generateFunDefArgs(inst);
             generateFunDefBody(inst);
         }
@@ -402,7 +407,7 @@ class RustInstVisitor : public TextInstVisitor {
             generateFunCall(inst, inst->fName);
         }
     }
-    
+
     virtual void generateFunCall(FunCallInst* inst, const std::string& fun_name)
     {
         if (inst->fMethod) {

--- a/tests/impulse-tests/archs/rust/architecture.rs
+++ b/tests/impulse-tests/archs/rust/architecture.rs
@@ -5,7 +5,6 @@
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 #![allow(non_upper_case_globals)]
-#![allow(bare_trait_objects)]
 
 extern crate libm;
 extern crate num_traits;
@@ -16,31 +15,49 @@ use std::env;
 
 use num_traits::{cast::FromPrimitive, float::Float};
 
+pub trait FaustDsp {
+    fn new() -> Self where Self: Sized;
+    fn metadata(&mut self, m: &mut dyn Meta);
+    fn get_sample_rate(&mut self) -> i32;
+    fn get_num_inputs(&mut self) -> i32;
+    fn get_num_outputs(&mut self) -> i32;
+    fn get_input_rate(&mut self, channel: i32) -> i32;
+    fn get_output_rate(&mut self, channel: i32) -> i32;
+    fn class_init(sample_rate: i32);
+    fn instance_reset_user_interface(&mut self);
+    fn instance_clear(&mut self);
+    fn instance_constants(&mut self, sample_rate: i32);
+    fn instance_init(&mut self, sample_rate: i32);
+    fn init(&mut self, sample_rate: i32);
+    fn build_user_interface(&mut self, ui_interface: &mut dyn UI<f64>);
+    fn compute(&mut self, count: i32, inputs: &[&[f64]], outputs: &mut[&mut[f64]]);
+}
+
 pub trait Meta {
     // -- metadata declarations
-    fn declare(&mut self, key: &str, value: &str) -> ();
+    fn declare(&mut self, key: &str, value: &str);
 }
 
 pub trait UI<T> {
     // -- widget's layouts
-    fn openTabBox(&mut self, label: &str) -> ();
-    fn openHorizontalBox(&mut self, label: &str) -> ();
-    fn openVerticalBox(&mut self, label: &str) -> ();
-    fn closeBox(&mut self) -> ();
+    fn open_tab_box(&mut self, label: &str);
+    fn open_horizontal_box(&mut self, label: &str);
+    fn open_vertical_box(&mut self, label: &str);
+    fn close_box(&mut self);
 
     // -- active widgets
-    fn addButton(&mut self, label: &str, zone: &mut T) -> ();
-    fn addCheckButton(&mut self, label: &str, zone: &mut T) -> ();
-    fn addVerticalSlider(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T) -> ();
-    fn addHorizontalSlider(&mut self, label: &str, zone: &mut T , init: T, min: T, max: T, step: T) -> ();
-    fn addNumEntry(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T) -> ();
+    fn add_button(&mut self, label: &str, zone: &mut T);
+    fn add_check_button(&mut self, label: &str, zone: &mut T);
+    fn add_vertical_slider(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T);
+    fn add_horizontal_slider(&mut self, label: &str, zone: &mut T , init: T, min: T, max: T, step: T);
+    fn add_num_entry(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T);
 
     // -- passive widgets
-    fn addHorizontalBargraph(&mut self, label: &str, zone: &mut T, min: T, max: T) -> ();
-    fn addVerticalBargraph(&mut self, label: &str, zone: &mut T, min: T, max: T) -> ();
+    fn add_horizontal_bargraph(&mut self, label: &str, zone: &mut T, min: T, max: T);
+    fn add_vertical_bargraph(&mut self, label: &str, zone: &mut T, min: T, max: T);
 
     // -- metadata declarations
-    fn declare(&mut self, zone: &mut T, key: &str, value: &str) -> ();
+    fn declare(&mut self, zone: &mut T, key: &str, value: &str);
 }
 
 pub struct ButtonUI<T>
@@ -51,39 +68,28 @@ pub struct ButtonUI<T>
 impl<T: Float + FromPrimitive> UI<T> for ButtonUI<T>
 {
     // -- widget's layouts
-    fn openTabBox(&mut self, label: &str) -> ()
-    {}
-    fn openHorizontalBox(&mut self, label: &str) -> ()
-    {}
-    fn openVerticalBox(&mut self, label: &str) -> ()
-    {}
-    fn closeBox(&mut self) -> ()
-    {}
+    fn open_tab_box(&mut self, label: &str) {}
+    fn open_horizontal_box(&mut self, label: &str) {}
+    fn open_vertical_box(&mut self, label: &str) {}
+    fn close_box(&mut self) {}
 
     // -- active widgets
-    fn addButton(&mut self, label: &str, zone: &mut T) -> ()
+    fn add_button(&mut self, label: &str, zone: &mut T)
     {
         //println!("addButton: {}", label);
         *zone = self.fState;
     }
-    fn addCheckButton(&mut self, label: &str, zone: &mut T) -> ()
-    {}
-    fn addVerticalSlider(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T) -> ()
-    {}
-    fn addHorizontalSlider(&mut self, label: &str, zone: &mut T , init: T, min: T, max: T, step: T) -> ()
-    {}
-    fn addNumEntry(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T) -> ()
-    {}
+    fn add_check_button(&mut self, label: &str, zone: &mut T) {}
+    fn add_vertical_slider(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T) {}
+    fn add_horizontal_slider(&mut self, label: &str, zone: &mut T , init: T, min: T, max: T, step: T) {}
+    fn add_num_entry(&mut self, label: &str, zone: &mut T, init: T, min: T, max: T, step: T) {}
 
     // -- passive widgets
-    fn addHorizontalBargraph(&mut self, label: &str, zone: &mut T, min: T, max: T) -> ()
-    {}
-    fn addVerticalBargraph(&mut self, label: &str, zone: &mut T, min: T, max: T) -> ()
-    {}
+    fn add_horizontal_bargraph(&mut self, label: &str, zone: &mut T, min: T, max: T) {}
+    fn add_vertical_bargraph(&mut self, label: &str, zone: &mut T, min: T, max: T) {}
 
     // -- metadata declarations
-    fn declare(&mut self, zone: &mut T, key: &str, value: &str) -> ()
-    {}
+    fn declare(&mut self, zone: &mut T, key: &str, value: &str) {}
 }
 
 // Generated intrinsics:
@@ -99,8 +105,8 @@ type FloatType = f64;
 fn print_header(output_file: &mut File, num_total_samples: usize) {
     let mut dsp = Box::new(mydsp::new());
     dsp.init(SAMPLE_RATE);
-    writeln!(output_file, "number_of_inputs  : {}", dsp.getNumInputs()).unwrap();
-    writeln!(output_file, "number_of_outputs : {}", dsp.getNumOutputs()).unwrap();
+    writeln!(output_file, "number_of_inputs  : {}", dsp.get_num_inputs()).unwrap();
+    writeln!(output_file, "number_of_outputs : {}", dsp.get_num_outputs()).unwrap();
     writeln!(output_file, "number_of_frames  : {}", num_total_samples).unwrap();
 }
 
@@ -108,14 +114,13 @@ fn run_dsp(output_file: &mut File, num_samples: usize, line_num_offset: usize) {
 
     // Generation constants
     let buffer_size = 64usize;
-    let num_buffers_to_generate = 100;
 
     // Init dsp
     let mut dsp = Box::new(mydsp::new());
     dsp.init(SAMPLE_RATE);
 
-    let num_inputs = dsp.getNumInputs() as usize;
-    let num_outputs = dsp.getNumOutputs() as usize;
+    let num_inputs = dsp.get_num_inputs() as usize;
+    let num_outputs = dsp.get_num_outputs() as usize;
 
     // Prepare buffers
     let mut in_buffer = vec![vec![0 as FloatType; buffer_size]; num_inputs];
@@ -138,11 +143,11 @@ fn run_dsp(output_file: &mut File, num_samples: usize, line_num_offset: usize) {
 
         // Set button state
         if cycle == 0 {
-            let mut buttonOn = ButtonUI::<f64>{ fState: 1.0 };
-            dsp.buildUserInterface(&mut buttonOn);
+            let mut button_on = ButtonUI::<f64>{ fState: 1.0 };
+            dsp.build_user_interface(&mut button_on);
         } else {
-            let mut buttonOff = ButtonUI::<f64>{ fState: 0.0 };
-            dsp.buildUserInterface(&mut buttonOff);
+            let mut button_off = ButtonUI::<f64>{ fState: 0.0 };
+            dsp.build_user_interface(&mut button_off);
         }
 
         dsp.compute(

--- a/tests/impulse-tests/archs/rust/architecture.rs
+++ b/tests/impulse-tests/archs/rust/architecture.rs
@@ -16,6 +16,8 @@ use std::env;
 use num_traits::{cast::FromPrimitive, float::Float};
 
 pub trait FaustDsp {
+    type Float;
+
     fn new() -> Self where Self: Sized;
     fn metadata(&mut self, m: &mut dyn Meta);
     fn get_sample_rate(&mut self) -> i32;
@@ -29,8 +31,8 @@ pub trait FaustDsp {
     fn instance_constants(&mut self, sample_rate: i32);
     fn instance_init(&mut self, sample_rate: i32);
     fn init(&mut self, sample_rate: i32);
-    fn build_user_interface(&mut self, ui_interface: &mut dyn UI<f64>);
-    fn compute(&mut self, count: i32, inputs: &[&[f64]], outputs: &mut[&mut[f64]]);
+    fn build_user_interface(&mut self, ui_interface: &mut dyn UI<Self::Float>);
+    fn compute(&mut self, count: i32, inputs: &[&[Self::Float]], outputs: &mut[&mut[Self::Float]]);
 }
 
 pub trait Meta {


### PR DESCRIPTION
As a first step for #409 this PR tries to add a trait for underlying the Rust code generation. So far, no changes regarding UI interfaces are included. I guess it's better to leave that as a second step. The fundamental trait would look like:

```rust
pub trait FaustDsp {
    type Float;

    fn new() -> Self where Self: Sized;
    fn metadata(&mut self, m: &mut dyn Meta);
    fn get_sample_rate(&mut self) -> i32;
    fn get_num_inputs(&mut self) -> i32;
    fn get_num_outputs(&mut self) -> i32;
    fn get_input_rate(&mut self, channel: i32) -> i32;
    fn get_output_rate(&mut self, channel: i32) -> i32;
    fn class_init(sample_rate: i32) where Self: Sized;
    fn instance_reset_user_interface(&mut self);
    fn instance_clear(&mut self);
    fn instance_constants(&mut self, sample_rate: i32);
    fn instance_init(&mut self, sample_rate: i32);
    fn init(&mut self, sample_rate: i32);
    fn build_user_interface(&mut self, ui_interface: &mut dyn UI<Self::Float>);
    fn compute(&mut self, count: i32, inputs: &[&[Self::Float]], outputs: &mut[&mut[Self::Float]]);
}
```

**Notes**

- The trait is object safe. I've adapted the impulse tests so that they actually verify object safety. For instance, if you remove one of the `where Self: Sized` annotations (a object safety violation), the code would no longer compile.
- In order to make it easier to support both `f32` and `f64` dsp types, I have introduced that underlying float type as an associated type the to trait. Otherwise we would either have to introduce two separate traits for `FaustDsp32` and `FaustDsp64` or the trait definition from an architecture file would only be compatible with either `f32` or `f64` code generation. With the associated type it is possible for a project to have mixed DSPs in f32 and f64 as well. In use cases where only a single dsp type is needed (more common I guess), users can easily simplify things with a type alias like `type Dsp = FaustDsp<Float=f32>`. I went for the name `FaustDsp` to encourage such type aliases and make it easier for project to use the name `Dsp` as desired.
- In order to make the public interfaces more idiomatic, I tried to adapt the code generation to produce snake-case function names.
- I'm generating all methods under the `impl FaustDsp for MyDsp { ... }` scope now, i.e., there is not directly `impl MyDsp { ... }` at all, which simplifies things. If it turns out that we need both, the code generation would probably require a refactoring, because we would have to sort functions depending on where they should get attached.
- I'm only using the trait for the "class" but not the "internal class" generation. I don't understand the role of the internal class yet, so I'm not quite sure if using the trait would be preferred there as well.
- I don't fully understand yet why the code generates the unnecessary `fDummy` field. I feel like it might be related to the associated type. Maybe now that the type is encoded in the trait already we can get rid of it?

**Status** 

Currently many impulse tests already work, but there are some problems. Actually, all failures seem to have the same cause at the moment (e.g. `comb_delay1`). In these cases, two things happen:

- My attempt at `produceInfoFunctions` actually doesn't produce any code for some reason, leading to the error `not all trait items implemented, missing: get_num_inputs, get_num_output`, get_input_rate, get_output_rate`. Why does the code generation sometimes omit them? To satisfy the trait requirements it would be necessary to produce them unconditionally.
- The `generateStaticInit` produces a line over which I don't have control, which produces an invalid function call name e.g. `sig0.instanceInitmydspSIG0(sample_rate);`. This seems to happen exactly if and only if the `produceInfoFunctions` omits the functions.

CC @bkfox Would be good to have your opinion on the trait design.
