### PR TITLE
[Rust] Removed unnecessary mutable self references

### DIFF
--- a/architecture/minimal-jack.rs
+++ b/architecture/minimal-jack.rs
@@ -34,12 +34,12 @@ pub trait FaustDsp {
     type Sample;
 
     fn new() -> Self where Self: Sized;
-    fn metadata(&mut self, m: &mut dyn Meta);
-    fn get_sample_rate(&mut self) -> i32;
-    fn get_num_inputs(&mut self) -> i32;
-    fn get_num_outputs(&mut self) -> i32;
-    fn get_input_rate(&mut self, channel: i32) -> i32;
-    fn get_output_rate(&mut self, channel: i32) -> i32;
+    fn metadata(&self, m: &mut dyn Meta);
+    fn get_sample_rate(&self) -> i32;
+    fn get_num_inputs(&self) -> i32;
+    fn get_num_outputs(&self) -> i32;
+    fn get_input_rate(&self, channel: i32) -> i32;
+    fn get_output_rate(&self, channel: i32) -> i32;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_user_interface(&mut self);
     fn instance_clear(&mut self);

--- a/architecture/minimal-portaudio.rs
+++ b/architecture/minimal-portaudio.rs
@@ -34,12 +34,12 @@ pub trait FaustDsp {
     type Sample;
 
     fn new() -> Self where Self: Sized;
-    fn metadata(&mut self, m: &mut dyn Meta);
-    fn get_sample_rate(&mut self) -> i32;
-    fn get_num_inputs(&mut self) -> i32;
-    fn get_num_outputs(&mut self) -> i32;
-    fn get_input_rate(&mut self, channel: i32) -> i32;
-    fn get_output_rate(&mut self, channel: i32) -> i32;
+    fn metadata(&self, m: &mut dyn Meta);
+    fn get_sample_rate(&self) -> i32;
+    fn get_num_inputs(&self) -> i32;
+    fn get_num_outputs(&self) -> i32;
+    fn get_input_rate(&self, channel: i32) -> i32;
+    fn get_output_rate(&self, channel: i32) -> i32;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_user_interface(&mut self);
     fn instance_clear(&mut self);

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -117,7 +117,7 @@ void RustCodeContainer::produceInternal()
 
     tab(n + 1, *fOut);
     tab(n + 1, *fOut);
-    produceInfoFunctions(n + 1, fKlassName, "&mut self", false, false, &fCodeProducer);
+    produceInfoFunctions(n + 1, fKlassName, "&self", false, false, &fCodeProducer);
 
     // Init
     // TODO
@@ -201,7 +201,7 @@ void RustCodeContainer::produceClass()
     // Associated type
     tab(n + 1, *fOut);
     *fOut << "type Sample = " << ifloat() << ";";
-   
+
     // Memory methods
     tab(n + 2, *fOut);
     if (fAllocateInstructions->fCode.size() > 0) {
@@ -247,9 +247,9 @@ void RustCodeContainer::produceClass()
     // Get sample rate method
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
-    generateGetSampleRate("get_sample_rate", "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetSampleRate("get_sample_rate", "&self", false, false)->accept(&fCodeProducer);
 
-    produceInfoFunctions(n + 1, "", "&mut self", false, false, &fCodeProducer);
+    produceInfoFunctions(n + 1, "", "&self", false, false, &fCodeProducer);
 
     // Inits
 
@@ -349,7 +349,7 @@ void RustCodeContainer::produceClass()
 void RustCodeContainer::produceMetadata(int n)
 {
     tab(n, *fOut);
-    *fOut << "fn metadata(&mut self, m: &mut dyn Meta) { ";
+    *fOut << "fn metadata(&self, m: &mut dyn Meta) { ";
 
     // We do not want to accumulate metadata from all hierachical levels, so the upper level only is kept
     for (auto& i : gGlobal->gMetaDataSet) {
@@ -381,12 +381,12 @@ void RustCodeContainer::produceInfoFunctions(int tabs, const string& classname, 
                                              TextInstVisitor* producer)
 {
     producer->Tab(tabs);
-    generateGetInputs(subst("get_num_inputs$0", classname), "&mut self", false, false)->accept(&fCodeProducer);
-    generateGetOutputs(subst("get_num_outputs$0", classname), "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetInputs(subst("get_num_inputs$0", classname), obj, false, false)->accept(&fCodeProducer);
+    generateGetOutputs(subst("get_num_outputs$0", classname), obj, false, false)->accept(&fCodeProducer);
     producer->Tab(tabs);
-    generateGetInputRate(subst("get_input_rate$0", classname), "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetInputRate(subst("get_input_rate$0", classname), obj, false, false)->accept(&fCodeProducer);
     producer->Tab(tabs);
-    generateGetOutputRate(subst("get_output_rate$0", classname), "&mut self", false, false)->accept(&fCodeProducer);
+    generateGetOutputRate(subst("get_output_rate$0", classname), obj, false, false)->accept(&fCodeProducer);
 }
 
 // Scalar

--- a/tests/impulse-tests/archs/rust/architecture.rs
+++ b/tests/impulse-tests/archs/rust/architecture.rs
@@ -19,12 +19,12 @@ pub trait FaustDsp {
     type Sample;
 
     fn new() -> Self where Self: Sized;
-    fn metadata(&mut self, m: &mut dyn Meta);
-    fn get_sample_rate(&mut self) -> i32;
-    fn get_num_inputs(&mut self) -> i32;
-    fn get_num_outputs(&mut self) -> i32;
-    fn get_input_rate(&mut self, channel: i32) -> i32;
-    fn get_output_rate(&mut self, channel: i32) -> i32;
+    fn metadata(&self, m: &mut dyn Meta);
+    fn get_sample_rate(&self) -> i32;
+    fn get_num_inputs(&self) -> i32;
+    fn get_num_outputs(&self) -> i32;
+    fn get_input_rate(&self, channel: i32) -> i32;
+    fn get_output_rate(&self, channel: i32) -> i32;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_user_interface(&mut self);
     fn instance_clear(&mut self);


### PR DESCRIPTION
A minor follow-up to #448: As suggested by @bkfox, we can avoid some of the `&mut self` references.

Note: Eventually when `build_user_interface` returns only parameter indices, it can also become immutable. Without touching the interface of the UI functions I had to keep it for now due to the mutable borrows there.