### PR TITLE
updated inkscape command line option to work with Inkscape 1.0

### DIFF
--- a/tools/faust2appls/faust2pdf
+++ b/tools/faust2appls/faust2pdf
@@ -8,7 +8,7 @@ for d in $@; do
         name=${d%.dsp}
         cd $name-svg
         for f in *.svg; do
-            inkscape -E ${f%.svg}.eps $f
+            inkscape -o ${f%.svg}.eps $f
             epstopdf ${f%.svg}.eps
             rm $f
         done


### PR DESCRIPTION
Inkscape version > (4035a4f, 2020-05-01) does not include `-o` option anymore, but uses `-E` instead.