### PR TITLE
[faust2plot/faust2csvplot] allow specification of include directories

### DIFF
--- a/tools/faust2appls/faust2csvplot
+++ b/tools/faust2appls/faust2csvplot
@@ -15,6 +15,7 @@ CXXFLAGS=$MYGCCFLAGS
 
 ARCHFILE=$FAUSTARCH/csvplot.cpp
 FAUSTFLOAT=float
+FAUST_INCLUDES="0"
 SOUNDFILELIBS=""
 
 #-------------------------------------------------------------------
@@ -39,7 +40,11 @@ for p in $@; do
         exit
     fi
  
-    if [ $p = "-arch32" ]; then
+    if [ $FAUST_INCLUDES = "1" ]; then
+        OPTIONS="$OPTIONS -I $p"
+        CXXFLAGS="$CXXFLAGS -I $p"
+        FAUST_INCLUDES="0"
+    elif [ $p = "-arch32" ]; then
         PROCARCH="-m32 -L/usr/lib32"
     elif [ $p = "-arch64" ]; then
         PROCARCH="-m64"
@@ -49,6 +54,8 @@ for p in $@; do
     elif [ $p = "-soundfile" ]; then
         CXXFLAGS="$CXXFLAGS -DSOUNDFILE"
         SOUNDFILELIBS=`pkg-config --cflags --static --libs sndfile`
+    elif [ $p = "-I" ]; then
+        FAUST_INCLUDES="1"
     elif [ ${p:0:1} = "-" ]; then
         OPTIONS="$OPTIONS $p"
     elif [[ -f "$p" ]]; then

--- a/tools/faust2appls/faust2plot
+++ b/tools/faust2appls/faust2plot
@@ -16,6 +16,7 @@ CXXFLAGS=$MYGCCFLAGS
 ARCHFILE=$FAUSTARCH/matlabplot.cpp
 
 FAUSTFLOAT=float
+FAUST_INCLUDES="0"
 
 #-------------------------------------------------------------------
 # Analyze command arguments :
@@ -36,14 +37,20 @@ for p in $@; do
         option "Faust options"
         exit
     fi
-	
-	if [ $p = "-arch32" ]; then
+
+    if [ $FAUST_INCLUDES = "1" ]; then
+        OPTIONS="$OPTIONS -I $p"
+        CXXFLAGS="$CXXFLAGS -I $p"
+        FAUST_INCLUDES="0"
+	elif [ $p = "-arch32" ]; then
     	PROCARCH="-m32 -L/usr/lib32"
     elif [ $p = "-arch64" ]; then
     	PROCARCH="-m64"
     elif [ $p = "-double" ]; then
     	OPTIONS="$OPTIONS $p"
     	FAUSTFLOAT="double"
+    elif [ $p = "-I" ]; then
+        FAUST_INCLUDES="1"
     elif [ ${p:0:1} = "-" ]; then
     	OPTIONS="$OPTIONS $p"
     elif [[ -f "$p" ]]; then
@@ -61,6 +68,8 @@ for f in $FILES; do
 	
 	# compile faust to c++
     faust -i -a $ARCHFILE $OPTIONS "$f" -o "$f.cpp" || exit
+
+    echo $CXX $CXXFLAGS $PROCARCH $OMP -DFAUSTFLOAT=$FAUSTFLOAT "$f.cpp" -o "${f%.dsp}"
 
 	# compile c++ to binary
 	(


### PR DESCRIPTION
this PR adds (crude) functionality of specifying additional search paths for `.lib` files to `faust2plot` and `faust2csvplot`.