### PR TITLE
[WIP] Improved rust autovectorization

### DIFF
--- a/compiler/generator/instructions_compiler.cpp
+++ b/compiler/generator/instructions_compiler.cpp
@@ -525,17 +525,6 @@ void InstructionsCompiler::compileMultiSignal(Tree L)
                     }
                 }
             }
-        } else {
-            for (int index = 0; index < fContainer->inputs(); index++) {
-                string name = subst("input$0", T(index));
-                Typed* type_dummy = new BasicTyped(Typed::VarType::kNoType);
-                pushComputeBlockMethod(InstBuilder::genDecStackVar(
-                    name, type_dummy,
-                    InstBuilder::genLoadStackVar("inputs")));
-                if (gGlobal->gInPlace) {
-                    CS(sigInput(index));
-                }
-            }
         }
 
         // HACK for Rust backend
@@ -557,13 +546,13 @@ void InstructionsCompiler::compileMultiSignal(Tree L)
                         InstBuilder::genLoadArrayFunArgsVar("outputs", InstBuilder::genInt32NumInst(index))));
                 }
             }
-        } else {
-            for (int index = 0; index < fContainer->outputs(); index++) {
-                string name = subst("output$0", T(index));
-                pushComputeBlockMethod(InstBuilder::genDecStackVar(
-                    name, InstBuilder::genArrayTyped(type, 0),
-                    InstBuilder::genLoadArrayFunArgsVar("outputs", InstBuilder::genInt32NumInst(index))));
-            }
+        }
+
+        if (gGlobal->gOutputLang == "rust") {
+            int num_inputs = fContainer->inputs();
+            int num_outputs = fContainer->outputs();
+            pushComputeBlockMethod(InstBuilder::genDeclareBufferIteratorsRust("inputs", num_inputs, false));
+            pushComputeBlockMethod(InstBuilder::genDeclareBufferIteratorsRust("outputs", num_outputs, true));
         }
     }
 

--- a/compiler/generator/instructions_compiler.cpp
+++ b/compiler/generator/instructions_compiler.cpp
@@ -146,7 +146,7 @@ void InstructionsCompiler::conditionStatistics(Tree l)
     std::cout << "\nConditions statistics" << std::endl;
     for (const auto& p : fConditionStatistics) {
         std::cout << ppsig(p.first) << ":" << p.second << std::endl;
-        
+
     }
 }
 #endif
@@ -206,10 +206,10 @@ void InstructionsCompiler::conditionAnnotation(Tree t, Tree nc)
         // first visit
         fConditionProperty[t] = nc;
     }
-    
+
     // Annotate the subtrees with the new condition nc
     // which is either the nc passed as argument or nc <- (cc v nc)
-    
+
     Tree x, y;
     if (isSigControl(t, x, y)) {
         // specific annotation case for sigControl
@@ -260,7 +260,7 @@ Tree InstructionsCompiler::prepare(Tree LS)
     endTiming("Constant propagation");
 
     Tree L5 = privatise(L4);  // Un-share tables with multiple writers
-    
+
     conditionAnnotation(L5);
 
     // dump normal form
@@ -276,13 +276,13 @@ Tree InstructionsCompiler::prepare(Tree LS)
     endTiming("L5 typeAnnotation");
 
     sharingAnalysis(L5);         // Annotate L5 with sharing count
-    
+
     if (fOccMarkup != 0) {
         delete fOccMarkup;
     }
     fOccMarkup = new old_OccMarkup(fConditionProperty);
     fOccMarkup->mark(L5);        // Annotate L5 with occurrences analysis
-    
+
     // annotationStatistics();
     endTiming("prepare");
 
@@ -300,13 +300,13 @@ Tree InstructionsCompiler::prepare2(Tree L0)
     recursivnessAnnotation(L0);  // Annotate L0 with recursivness information
     typeAnnotation(L0, true);    // Annotate L0 with type information
     sharingAnalysis(L0);         // Annotate L0 with sharing count
-    
+
     if (fOccMarkup != 0) {
         delete fOccMarkup;
     }
     fOccMarkup = new old_OccMarkup();
     fOccMarkup->mark(L0);        // Annotate L0 with occurrences analysis
-  
+
     endTiming("prepare2");
     return L0;
 }
@@ -496,6 +496,9 @@ void InstructionsCompiler::compileMultiSignal(Tree L)
 
     Typed* type = InstBuilder::genFloatMacroTyped();
 
+    std::cout << "gGlobal->gOneSampleControl: " << gGlobal->gOneSampleControl << "\n";
+    std::cout << "gGlobal->gOneSample: " << gGlobal->gOneSample << "\n";
+
     if (!gGlobal->gOpenCLSwitch && !gGlobal->gCUDASwitch) {  // HACK
 
         // HACK for Rust backend
@@ -522,6 +525,17 @@ void InstructionsCompiler::compileMultiSignal(Tree L)
                     }
                 }
             }
+        } else {
+            for (int index = 0; index < fContainer->inputs(); index++) {
+                string name = subst("input$0", T(index));
+                Typed* type_dummy = new BasicTyped(Typed::VarType::kNoType);
+                pushComputeBlockMethod(InstBuilder::genDecStackVar(
+                    name, type_dummy,
+                    InstBuilder::genLoadStackVar("inputs")));
+                if (gGlobal->gInPlace) {
+                    CS(sigInput(index));
+                }
+            }
         }
 
         // HACK for Rust backend
@@ -543,6 +557,13 @@ void InstructionsCompiler::compileMultiSignal(Tree L)
                         InstBuilder::genLoadArrayFunArgsVar("outputs", InstBuilder::genInt32NumInst(index))));
                 }
             }
+        } else {
+            for (int index = 0; index < fContainer->outputs(); index++) {
+                string name = subst("output$0", T(index));
+                pushComputeBlockMethod(InstBuilder::genDecStackVar(
+                    name, InstBuilder::genArrayTyped(type, 0),
+                    InstBuilder::genLoadArrayFunArgsVar("outputs", InstBuilder::genInt32NumInst(index))));
+            }
         }
     }
 
@@ -555,8 +576,8 @@ void InstructionsCompiler::compileMultiSignal(Tree L)
         // HACK for Rust backend
         string name;
         if (gGlobal->gOutputLang == "rust") {
-            name = subst("outputs[$0]", T(index));
-            pushComputeDSPMethod(InstBuilder::genStoreArrayStackVar(name, getCurrentLoopIndex(), res));
+            name = subst("*output$0", T(index));
+            pushComputeDSPMethod(InstBuilder::genStoreStackVar(name, res));
         } else if (gGlobal->gOneSampleControl) {
             name = subst("output$0", T(index));
             pushComputeDSPMethod(InstBuilder::genStoreStackVar(name, res));
@@ -812,7 +833,7 @@ ValueInst* InstructionsCompiler::generateFConst(Tree sig, Tree type, const strin
 
     // Special case for 02/25/19 renaming
     string name = (name_aux == "fSamplingFreq") ? "fSampleRate" : name_aux;
-    
+
     // Check access (handling "fSampleRate" as a special case)
     if (name != "fSampleRate" && !gGlobal->gAllowForeignConstant) {
         stringstream error;
@@ -820,7 +841,7 @@ ValueInst* InstructionsCompiler::generateFConst(Tree sig, Tree type, const strin
         << " is not allowed in this compilation mode!" << endl;
         throw faustexception(error.str());
     }
-  
+
     // Keep SR generation state
     if (name == "fSampleRate") {
         fContainer->setGeneratedSR();
@@ -830,7 +851,7 @@ ValueInst* InstructionsCompiler::generateFConst(Tree sig, Tree type, const strin
     Typed::VarType ctype;
     string         vname;
     old_Occurences*    o = fOccMarkup->retrieve(sig);
-    
+
     if (o->getMaxDelay() > 0) {
         getTypedNames(getCertifiedSigType(sig), "Vec", ctype, vname);
         generateDelayVec(
@@ -863,7 +884,7 @@ ValueInst* InstructionsCompiler::generateFVar(Tree sig, Tree type, const string&
         << " is not allowed in this compilation mode!" << endl;
         throw faustexception(error.str());
     }
-    
+
     fContainer->addIncludeFile(file);
 
     // Special case for 'count' parameter of the 'compute' method
@@ -892,7 +913,7 @@ ValueInst* InstructionsCompiler::generateInput(Tree sig, int idx)
     // HACK for Rust backend
     if (gGlobal->gOutputLang == "rust") {
         res = InstBuilder::genCastFloatInst(
-            InstBuilder::genLoadArrayStackVar(subst("inputs[$0]", T(idx)), getCurrentLoopIndex()));
+            InstBuilder::genLoadStackVar(subst("*input$0", T(idx))));
     } else if (gGlobal->gOneSampleControl) {
         res = InstBuilder::genCastFloatInst(InstBuilder::genLoadStructVar(subst("input$0", T(idx))));
     } else if (gGlobal->gOneSample) {
@@ -933,7 +954,7 @@ ValueInst* InstructionsCompiler::generateBinOp(Tree sig, int opcode, Tree a1, Tr
         cerr << "WARNING : potential division by zero (" << i << "/" << j << ") in " << ppsig(sig) << endl;
     }
     */
-     
+
     // Logical and shift operations work on kInt32, so cast both operands here
     if (isLogicalOpcode(opcode) || isShiftOpcode(opcode)) {
         res = InstBuilder::genBinopInst(opcode, promote2int(t1, v1), promote2int(t2, v2));
@@ -1119,24 +1140,24 @@ ValueInst* InstructionsCompiler::generateVariableStore(Tree sig, ValueInst* exp)
 
         case kSamp:
             getTypedNames(t, "Temp", ctype, vname);
-            
+
             // Only generated for the DSP loop
             if (gGlobal->gHasTeeLocal) {
-                
+
                 if (dynamic_cast<NullValueInst*>(getConditionCode(sig))) {
                     pushComputeDSPMethod(InstBuilder::genDecStackVar(vname, InstBuilder::genBasicTyped(ctype)));
                 } else {
                     getTypedNames(t, "TempPerm", ctype, vname_perm);
                     pushDeclare(InstBuilder::genDecStructVar(vname_perm, InstBuilder::genBasicTyped(ctype)));
                     pushClearMethod(InstBuilder::genStoreStructVar(vname_perm, InstBuilder::genTypedZero(ctype)));
-                    
+
                     pushComputeBlockMethod(InstBuilder::genDecStackVar(vname, InstBuilder::genBasicTyped(ctype), InstBuilder::genLoadStructVar(vname_perm)));
                     pushPostComputeBlockMethod(InstBuilder::genStoreStructVar(vname_perm, InstBuilder::genLoadStackVar(vname)));
                 }
-                
+
                 return InstBuilder::genTeeVar(vname, exp);
             } else {
-                
+
                 if (dynamic_cast<NullValueInst*>(getConditionCode(sig))) {
                     pushComputeDSPMethod(InstBuilder::genDecStackVar(vname, InstBuilder::genBasicTyped(ctype), exp));
                     return InstBuilder::genLoadStackVar(vname);
@@ -1144,7 +1165,7 @@ ValueInst* InstructionsCompiler::generateVariableStore(Tree sig, ValueInst* exp)
                     getTypedNames(t, "TempPerm", ctype, vname_perm);
                     pushDeclare(InstBuilder::genDecStructVar(vname_perm, InstBuilder::genBasicTyped(ctype)));
                     pushClearMethod(InstBuilder::genStoreStructVar(vname_perm, InstBuilder::genTypedZero(ctype)));
-                    
+
                     if (gGlobal->gOneSample || gGlobal->gOneSampleControl) {
                         pushComputeDSPMethod(InstBuilder::genControlInst(getConditionCode(sig), InstBuilder::genStoreStructVar(vname_perm, exp)));
                         return InstBuilder::genLoadStructVar(vname_perm);
@@ -1322,18 +1343,18 @@ ValueInst* InstructionsCompiler::generateSoundfileLength(Tree sig, ValueInst* sf
     string SFcache_length = gGlobal->getFreshID(SFcache + "_le");
 
     if (gGlobal->gOneSample) {
-        
+
         // Struct access using an index that will be converted as a field name
         ValueInst* v1 = InstBuilder::genLoadStructPtrVar(SFcache, Address::kStruct, InstBuilder::genInt32NumInst(1));
-        
+
         pushDeclare(InstBuilder::genDecStructVar(SFcache_length, type));
         pushComputeBlockMethod(InstBuilder::genStoreStructVar(SFcache_length, v1));
         return InstBuilder::genLoadArrayStructVar(SFcache_length, x);
     } else {
-        
+
         // Struct access using an index that will be converted as a field name
         ValueInst* v1 = InstBuilder::genLoadStructPtrVar(SFcache, Address::kStack, InstBuilder::genInt32NumInst(1));
-        
+
         pushComputeBlockMethod(InstBuilder::genDecStackVar(SFcache_length, type, v1));
         return InstBuilder::genLoadArrayStackVar(SFcache_length, x);
     }
@@ -1350,7 +1371,7 @@ ValueInst* InstructionsCompiler::generateSoundfileRate(Tree sig, ValueInst* sf, 
     string SFcache_rate = gGlobal->getFreshID(SFcache + "_ra");
 
     if (gGlobal->gOneSample) {
-        
+
         // Struct access using an index that will be converted as a field name
         ValueInst* v1 = InstBuilder::genLoadStructPtrVar(SFcache, Address::kStruct, InstBuilder::genInt32NumInst(2));
 
@@ -1358,7 +1379,7 @@ ValueInst* InstructionsCompiler::generateSoundfileRate(Tree sig, ValueInst* sf, 
         pushComputeBlockMethod(InstBuilder::genStoreStructVar(SFcache_rate, v1));
         return InstBuilder::genLoadArrayStructVar(SFcache_rate, x);
     } else {
-        
+
         // Struct access using an index that will be converted as a field name
         ValueInst* v1 = InstBuilder::genLoadStructPtrVar(SFcache, Address::kStack, InstBuilder::genInt32NumInst(2));
 
@@ -1383,7 +1404,7 @@ ValueInst* InstructionsCompiler::generateSoundfileBuffer(Tree sig, ValueInst* sf
     string SFcache_offset      = gGlobal->getFreshID(SFcache + "_of");
 
     if (gGlobal->gOneSample) {
-        
+
         // Struct access using an index that will be converted as a field name
         ValueInst* v1 = InstBuilder::genLoadStructPtrVar(SFcache, Address::kStruct, InstBuilder::genInt32NumInst(3));
 
@@ -1405,7 +1426,7 @@ ValueInst* InstructionsCompiler::generateSoundfileBuffer(Tree sig, ValueInst* sf
             SFcache_buffer_chan, Address::kStruct,
             InstBuilder::genAdd(InstBuilder::genLoadArrayStructVar(SFcache_offset, y), z));
     } else {
-        
+
         // Struct access using an index that will be converted as a field name
         ValueInst* v1 = InstBuilder::genLoadStructPtrVar(SFcache, Address::kStack, InstBuilder::genInt32NumInst(3));
 
@@ -1607,7 +1628,7 @@ ValueInst* InstructionsCompiler::generateWRTbl(Tree sig, Tree tbl, Tree idx, Tre
     ValueInst*   tblname    = CS(tbl);
     LoadVarInst* load_value = dynamic_cast<LoadVarInst*>(tblname);
     faustassert(load_value);
-  
+
     Tree id, size, content;
     if (isSigTable(tbl, id, size, content)) {
         // Check write access
@@ -1627,13 +1648,13 @@ ValueInst* InstructionsCompiler::generateWRTbl(Tree sig, Tree tbl, Tree idx, Tre
             }
         }
     }
-   
+
     // Check types and possibly cast written value
     int table_type = getCertifiedSigType(tbl)->nature();
     int data_type  = getCertifiedSigType(data)->nature();
     ValueInst* cdata = (table_type != data_type) ? InstBuilder::genCastInst(CS(data), genBasicFIRTyped(table_type)) : CS(data);
     string vname = load_value->fAddress->getName();
-    
+
     Type t2 = getCertifiedSigType(idx);
     Type t3 = getCertifiedSigType(data);
     // TODO : for a bug in type caching, t->variability() is not correct.
@@ -1650,7 +1671,7 @@ ValueInst* InstructionsCompiler::generateWRTbl(Tree sig, Tree tbl, Tree idx, Tre
             pushComputeDSPMethod(InstBuilder::genControlInst(getConditionCode(sig), InstBuilder::genStoreArrayStructVar(vname, CS(idx), cdata)));
             break;
     }
-    
+
     // Return table access
     return InstBuilder::genLoadStructVar(vname);
 }
@@ -1665,7 +1686,7 @@ ValueInst* InstructionsCompiler::generateRDTbl(Tree sig, Tree tbl, Tree idx)
     Tree                id, size, content;
     ValueInst*          tblname;
     Address::AccessType access;
-    
+
     if (isSigTable(tbl, id, size, content)) {
         // Check read access
         if (gGlobal->gCheckTable != "") {
@@ -1691,7 +1712,7 @@ ValueInst* InstructionsCompiler::generateRDTbl(Tree sig, Tree tbl, Tree idx)
         access  = Address::kStruct;
         tblname = CS(tbl);
     }
- 
+
     LoadVarInst* load_value1 = dynamic_cast<LoadVarInst*>(tblname);
     faustassert(load_value1);
 
@@ -1949,7 +1970,7 @@ ValueInst* InstructionsCompiler::generateXtended(Tree sig)
 
  case 1-sample max delay :
  Y(t-0)	Y(t-1)
- 
+
  V[0]	V[1]
 
  case max delay < gMaxCopyDelay :
@@ -1984,10 +2005,10 @@ ValueInst* InstructionsCompiler::generateFixDelay(Tree sig, Tree exp, Tree delay
     }
 
     if (mxd == 0) {
-        
+
         // not a real vector name but a scalar name
         return InstBuilder::genLoadStackVar(vname);
-        
+
     } else if (mxd < gGlobal->gMaxCopyDelay) {
         int d;
         if (isSigInt(delay, &d)) {
@@ -1996,18 +2017,18 @@ ValueInst* InstructionsCompiler::generateFixDelay(Tree sig, Tree exp, Tree delay
             return generateCacheCode(sig, InstBuilder::genLoadArrayStructVar(vname, CS(delay)));
         }
     } else {
-        
+
         int N = pow2limit(mxd + 1);
         if (N <= gGlobal->gMaskDelayLineThreshold) {
             FIRIndex value2 = (FIRIndex(InstBuilder::genLoadStructVar("IOTA")) - CS(delay)) & FIRIndex(N - 1);
             return generateCacheCode(sig, InstBuilder::genLoadArrayStructVar(vname, value2));
         } else {
             string ridx_name = gGlobal->getFreshID(vname + "_ridx_tmp");
-            
+
             // int ridx = widx - delay;
             FIRIndex widx1 = FIRIndex(InstBuilder::genLoadStructVar(vname + "_widx"));
             pushComputeDSPMethod(InstBuilder::genDecStackVar(ridx_name, InstBuilder::genBasicTyped(Typed::kInt32), widx1 - CS(delay)));
-            
+
             // dline[((ridx < 0) ? ridx + delay : ridx)];
             FIRIndex ridx1 = FIRIndex(InstBuilder::genLoadStackVar(ridx_name));
             FIRIndex ridx2 = FIRIndex(InstBuilder::genSelect2Inst(ridx1 < 0, ridx1 + FIRIndex(mxd + 1), ridx1));
@@ -2094,7 +2115,7 @@ ValueInst* InstructionsCompiler::generateDelayLine(ValueInst* exp, Typed::VarTyp
                                                    Address::AccessType& var_access, ValueInst* ccs)
 {
     if (mxd == 0) {
-        
+
         // Generate scalar use
         if (dynamic_cast<NullValueInst*>(ccs)) {
             pushComputeDSPMethod(InstBuilder::genDecStackVar(vname, InstBuilder::genBasicTyped(ctype), exp));
@@ -2102,9 +2123,9 @@ ValueInst* InstructionsCompiler::generateDelayLine(ValueInst* exp, Typed::VarTyp
             pushPreComputeDSPMethod(InstBuilder::genDecStackVar(vname, InstBuilder::genBasicTyped(ctype), InstBuilder::genTypedZero(ctype)));
             pushComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreStackVar(vname, exp)));
         }
-   
+
     } else if (mxd < gGlobal->gMaxCopyDelay) {
-        
+
         // Generates table init
         pushClearMethod(generateInitArray(vname, ctype, mxd + 1));
 
@@ -2122,12 +2143,12 @@ ValueInst* InstructionsCompiler::generateDelayLine(ValueInst* exp, Typed::VarTyp
         }
 
     } else {
-        
+
         int N = pow2limit(mxd + 1);
         if (N <= gGlobal->gMaskDelayLineThreshold) {
-            
+
             ensureIotaCode();
-       
+
             // Generates table init
             pushClearMethod(generateInitArray(vname, ctype, N));
 
@@ -2136,43 +2157,43 @@ ValueInst* InstructionsCompiler::generateDelayLine(ValueInst* exp, Typed::VarTyp
                 if (fIOTATable.find(N) == fIOTATable.end()) {
                     string   iota_name = subst("i$0", gGlobal->getFreshID("IOTA_temp"));
                     FIRIndex value2 = FIRIndex(InstBuilder::genLoadStructVar("IOTA")) & FIRIndex(N - 1);
-                
+
                     pushPreComputeDSPMethod(InstBuilder::genDecStackVar(iota_name, InstBuilder::genInt32Typed(), InstBuilder::genInt32NumInst(0)));
                     pushComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreStackVar(iota_name, value2)));
-                    
+
                     fIOTATable[N] = iota_name;
                 }
-                
+
                 pushComputeDSPMethod(InstBuilder::genControlInst(ccs,
                     InstBuilder::genStoreArrayStructVar(vname, InstBuilder::genLoadStackVar(fIOTATable[N]), exp)));
-                
+
             } else {
                 FIRIndex value2 = FIRIndex(InstBuilder::genLoadStructVar("IOTA")) & FIRIndex(N - 1);
                 pushComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreArrayStructVar(vname, value2, exp)));
             }
         } else {
-        
+
             // 'select' based delay
             string widx_tmp_name = vname + "_widx_tmp";
             string widx_name = vname + "_widx";
-            
+
             // Generates table write index
             pushDeclare(InstBuilder::genDecStructVar(widx_name, InstBuilder::genInt32Typed()));
             pushInitMethod(InstBuilder::genStoreStructVar(widx_name, InstBuilder::genInt32NumInst(0)));
-            
+
             // Generates table init
             pushClearMethod(generateInitArray(vname, ctype, mxd + 1));
-            
+
             // int w = widx;
             pushComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genDecStackVar(widx_tmp_name, InstBuilder::genBasicTyped(Typed::kInt32), InstBuilder::genLoadStructVar(widx_name))));
-            
+
             // dline[w] = v;
             pushComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreArrayStructVar(vname, InstBuilder::genLoadStackVar(widx_tmp_name), exp)));
-            
+
             // w = w + 1;
             FIRIndex widx_tmp1 = FIRIndex(InstBuilder::genLoadStackVar(widx_tmp_name));
             pushPostComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreStackVar(widx_tmp_name, widx_tmp1 + 1)));
-            
+
             // w = ((w == delay) ? 0 : w);
             FIRIndex widx_tmp2 = FIRIndex(InstBuilder::genLoadStackVar(widx_tmp_name));
             pushPostComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreStackVar(widx_tmp_name,
@@ -2183,7 +2204,7 @@ ValueInst* InstructionsCompiler::generateDelayLine(ValueInst* exp, Typed::VarTyp
             pushPostComputeDSPMethod(InstBuilder::genControlInst(ccs, InstBuilder::genStoreStructVar(widx_name, InstBuilder::genLoadStackVar(widx_tmp_name))));
         }
     }
-    
+
     return exp;
 }
 
@@ -2506,22 +2527,22 @@ void InstructionsCompiler::generateWidgetMacro(const string& pathname, Tree full
         fContainer->addUIMacroActives(subst("p(NUMENTRY, $0, \"$1\", $2, $3, $4, $5, $6) \\", rawlabel, pathlabel,
                                             tree2str(varname), T(tree2float(c)), T(tree2float(x)), T(tree2float(y)),
                                             T(tree2float(z))));
-        
+
     } else if (isSigVBargraph(sig, path, x, y, z)) {
         fContainer->addUIMacro(subst("FAUST_ADDVERTICALBARGRAPH(\"$0\", $1, $2, $3);", pathlabel, tree2str(varname),
                                      T(tree2float(x)), T(tree2float(y))));
         fContainer->addUIMacroPassives(subst("p(VERTICALBARGRAPH, $0, \"$1\", $2, 0.0, $3, $4, 0.0) \\", rawlabel, pathlabel,
                                             tree2str(varname), T(tree2float(x)), T(tree2float(y))));
-        
+
     } else if (isSigHBargraph(sig, path, x, y, z)) {
         fContainer->addUIMacro(subst("FAUST_ADDHORIZONTALBARGRAPH(\"$0\", $1, $2, $3);", pathlabel, tree2str(varname),
                                      T(tree2float(x)), T(tree2float(y))));
         fContainer->addUIMacroPassives(subst("p(HORIZONTALBARGRAPH, $0, \"$1\", $2, 0.0, $3, $4, 0.0) \\", rawlabel, pathlabel,
                                             tree2str(varname), T(tree2float(x)), T(tree2float(y))));
-        
+
     } else if (isSigSoundfile(sig, path)) {
         fContainer->addUIMacro(subst("FAUST_ADDSOUNDFILE(\"$0\", $1);", pathlabel, tree2str(varname)));
-        
+
     } else {
         throw faustexception("ERROR in generating widget code\n");
     }

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -146,7 +146,9 @@ void RustCodeContainer::produceInternal()
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
     generateComputeBlock(&fCodeProducer);
-    SimpleForLoopInst* loop = fCurLoop->generateSimpleScalarLoop(counter);
+    // FIXME: How should we know the input/output iterators here?
+    std::vector<std::string> iterators;
+    IteratorForLoopInst* loop = fCurLoop->generateSimpleScalarLoop(iterators);
     loop->accept(&fCodeProducer);
     back(1, *fOut);
     *fOut << "}" << endl;
@@ -411,7 +413,18 @@ void RustScalarCodeContainer::generateCompute(int n)
     generateComputeBlock(&fCodeProducer);
 
     // Generates one single scalar loop
-    SimpleForLoopInst* loop = fCurLoop->generateSimpleScalarLoop(fFullCount);
+    std::vector<std::string> iterators;
+    for (int i = 0; i < fNumInputs; ++i) {
+        std::stringstream ss;
+        ss << "inputs" << i;
+        iterators.push_back(ss.str());
+    }
+    for (int i = 0; i < fNumOutputs; ++i) {
+        std::stringstream ss;
+        ss << "outputs" << i;
+        iterators.push_back(ss.str());
+    }
+    IteratorForLoopInst* loop = fCurLoop->generateSimpleScalarLoop(iterators);
     loop->accept(&fCodeProducer);
 
     back(1, *fOut);

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -29,6 +29,13 @@
 
 using namespace std;
 
+inline string makeNameSingular(const string& name) {
+    string result = name;
+    result = std::regex_replace(result, std::regex("inputs"), "input");
+    result = std::regex_replace(result, std::regex("outputs"), "output");
+    return result;
+}
+
 // Visitor used to initialize fields into the DSP constructor
 struct RustInitFieldsVisitor : public DispatchVisitor {
     std::ostream* fOut;
@@ -270,7 +277,7 @@ class RustInstVisitor : public TextInstVisitor {
     virtual void visit(DeclareBufferIteratorsRust* inst)
     {
         /* Generates an expression like:
-        let (outputs0, outputs1) = if let [outputs0, outputs1, ..] = &mut outputs {
+        let (outputs0, outputs1) = if let [outputs0, outputs1, ..] = outputs {
             let outputs0 = outputs0[..count as usize].iter_mut();
             let outputs1 = outputs1[..count as usize].iter_mut();
             (outputs0, outputs1)
@@ -279,6 +286,8 @@ class RustInstVisitor : public TextInstVisitor {
         };
         */
         std::string name = inst->fBufferName;
+
+        // Build pattern matching + if let line
         *fOut << "let (";
         for (int i = 0; i < inst->fNumChannels; ++i) {
             if (i > 0) {
@@ -292,6 +301,7 @@ class RustInstVisitor : public TextInstVisitor {
         }
         *fOut << "..] = " << name << " {";
 
+        // Build fixed size iterator variables
         fTab++;
         for (int i = 0; i < inst->fNumChannels; ++i) {
             tab(fTab, *fOut);
@@ -302,6 +312,8 @@ class RustInstVisitor : public TextInstVisitor {
                 *fOut << ".iter();";
             }
         }
+
+        // Build return tuple
         tab(fTab, *fOut);
         *fOut << "(";
         for (int i = 0; i < inst->fNumChannels; ++i) {
@@ -312,6 +324,7 @@ class RustInstVisitor : public TextInstVisitor {
         }
         *fOut << ")";
 
+        // Build else branch
         fTab--;
         tab(fTab, *fOut);
         *fOut << "} else {";
@@ -610,16 +623,9 @@ class RustInstVisitor : public TextInstVisitor {
         for (std::size_t i = 0; i < inst->fIterators.size() - 1; ++i) {
             *fOut << "(";
         }
-        // Maybe find a nicer way to go from plural names to singular names here?
-        string name = inst->fIterators[0]->getName();
-        name = std::regex_replace(name, std::regex("inputs"), "input");
-        name = std::regex_replace(name, std::regex("outputs"), "output");
-        *fOut << name;
+        *fOut << makeNameSingular(inst->fIterators[0]->getName());
         for (std::size_t i = 1; i < inst->fIterators.size(); ++i) {
-            string name = inst->fIterators[i]->getName();
-            name = std::regex_replace(name, std::regex("inputs"), "input");
-            name = std::regex_replace(name, std::regex("outputs"), "output");
-            *fOut << ", " << name << ")";
+            *fOut << ", " << makeNameSingular(inst->fIterators[i]->getName()) << ")";
         }
         *fOut << " in zipped_iterators {";
         fTab++;

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -247,7 +247,12 @@ class RustInstVisitor : public TextInstVisitor {
             *fOut << "let mut ";
         }
 
-        *fOut << fTypeManager->generateType(inst->fType, inst->fAddress->getName());
+        // If kNoType only generate the name, otherwise a typed expression
+        if (inst->fType->getType() == Typed::VarType::kNoType) {
+            *fOut << inst->fAddress->getName();
+        } else {
+            *fOut << fTypeManager->generateType(inst->fType, inst->fAddress->getName());
+        }
 
         if (inst->fValue) {
             *fOut << " = ";

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -22,6 +22,8 @@
 #ifndef _RUST_INSTRUCTIONS_H
 #define _RUST_INSTRUCTIONS_H
 
+#include <regex>
+
 #include "text_instructions.hh"
 #include "Text.hh"
 
@@ -247,7 +249,7 @@ class RustInstVisitor : public TextInstVisitor {
             *fOut << "let mut ";
         }
 
-        // If kNoType only generate the name, otherwise a typed expression
+        // If type is kNoType, only generate the name, otherwise a typed expression
         if (inst->fType->getType() == Typed::VarType::kNoType) {
             *fOut << inst->fAddress->getName();
         } else {
@@ -288,13 +290,7 @@ class RustInstVisitor : public TextInstVisitor {
         for (int i = 0; i < inst->fNumChannels; ++i) {
             *fOut << name << i << ", ";
         }
-        *fOut << "..] = ";
-        if (inst->fMutable) {
-            *fOut << "&mut ";
-        } else {
-            *fOut << "&";
-        }
-        *fOut << name << " {";
+        *fOut << "..] = " << name << " {";
 
         fTab++;
         for (int i = 0; i < inst->fNumChannels; ++i) {
@@ -583,6 +579,49 @@ class RustInstVisitor : public TextInstVisitor {
             inst->fUpperBound->accept(this);
         }
         *fOut << " {";
+        fTab++;
+        tab(fTab, *fOut);
+        inst->fCode->accept(this);
+        fTab--;
+        back(1, *fOut);
+        *fOut << "}";
+        tab(fTab, *fOut);
+    }
+
+    virtual void visit(IteratorForLoopInst* inst)
+    {
+        // Don't generate empty loops...
+        if (inst->fCode->size() == 0) return;
+
+        *fOut << "let zipped_iterators = ";
+        for (std::size_t i = 0; i < inst->fIterators.size(); ++i) {
+            if (i == 0) {
+                inst->fIterators[i]->accept(this);
+            } else {
+                *fOut << ".zip(";
+                inst->fIterators[i]->accept(this);
+                *fOut << ")";
+            }
+        }
+        *fOut << ";";
+        tab(fTab, *fOut);
+
+        *fOut << "for ";
+        for (std::size_t i = 0; i < inst->fIterators.size() - 1; ++i) {
+            *fOut << "(";
+        }
+        // Maybe find a nicer way to go from plural names to singular names here?
+        string name = inst->fIterators[0]->getName();
+        name = std::regex_replace(name, std::regex("inputs"), "input");
+        name = std::regex_replace(name, std::regex("outputs"), "output");
+        *fOut << name;
+        for (std::size_t i = 1; i < inst->fIterators.size(); ++i) {
+            string name = inst->fIterators[i]->getName();
+            name = std::regex_replace(name, std::regex("inputs"), "input");
+            name = std::regex_replace(name, std::regex("outputs"), "output");
+            *fOut << ", " << name << ")";
+        }
+        *fOut << " in zipped_iterators {";
         fTab++;
         tab(fTab, *fOut);
         inst->fCode->accept(this);

--- a/compiler/parallelize/code_loop.hh
+++ b/compiler/parallelize/code_loop.hh
@@ -161,7 +161,7 @@ class CodeLoop : public virtual Garbageable {
 
     ForLoopInst* generateScalarLoop(const string& counter, bool loop_var_in_bytes = false);
 
-    SimpleForLoopInst* generateSimpleScalarLoop(const string& counter);
+    IteratorForLoopInst* generateSimpleScalarLoop(const std::vector<string> iterators);
 
     BlockInst* generateOneSample();
 


### PR DESCRIPTION
@sletz I think I need some help with this to get it finalized ;). I have found a basic way to make the code gen produce an iterator based for loop, but there is still some missing functionality, and your feedback would be highly welcome.

For basic DSPs the code gen already works, and produces a `compute` method like this now (`copy2` example):

```rust
fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]) {
    let (inputs0, inputs1) = if let [inputs0, inputs1, ..] = inputs {
        let inputs0 = inputs0[..count as usize].iter();
        let inputs1 = inputs1[..count as usize].iter();
        (inputs0, inputs1)
    } else {
        panic!("wrong number of inputs");
    };
    let (outputs0, outputs1) = if let [outputs0, outputs1, ..] = outputs {
        let outputs0 = outputs0[..count as usize].iter_mut();
        let outputs1 = outputs1[..count as usize].iter_mut();
        (outputs0, outputs1)
    } else {
        panic!("wrong number of outputs");
    };
    let zipped_iterators = inputs0.zip(inputs1).zip(outputs0).zip(outputs1);
    for (((input0, input1), output0), output1) in zipped_iterators {
        *output0 = (*input0 as f32);
        *output1 = (*input1 as f32);
    }
}
```

Performance looks pretty good with these changes (MB/sec output):

|           |   Rust |   Rust (iterators) |   C++ (no fastmath) |   C++ (fastmath) |
|:----------|-------:|-------------------:|--------------------:|-----------------:|
| copy1     | 5052.4 |            34314.1 |             19449.7 |          19261.8 |
| copy2     | 5040.1 |            40644.8 |             65471.4 |          65031.8 |
| math      |  951.5 |             6537.1 |              6688.1 |           7156.8 |

The first tricky part was to generate the pattern matching based destructuring of the input/output buffers. Technically the destructuring based approach is only strictly needed for the mutable buffer part (because the borrow checker then knows that no two different indexes into `outputs` are mutable borrowed at the same time). But the approach also makes sense on input side, because it gives a nice consistent error handling in case of insufficient number of channels. At first I tried to "fake" the whole expression with existing instructions, but that became incredibly difficult, and doesn't appear to be the right way. Since Rust simply has instructions that differ from the C++ oriented instruction set, I thought it makes the most sense to introduce a special instruction for that purpose, called `DeclareBufferIteratorsRust`, which can handle both the input and the output expression.

Similarly it probably does not make sense to model the concept of a "zipped iterator" with some abuse of existing iterators, so I decided to create a special `IteratorForLoopInst` for that purpose as well.

Open questions are:
- I don't understand how I should implement the for loop in `RustCodeContainer::produceInternal`. Somehow it uses the same `fCurLoop->generateSimpleScalarLoop()` as is used for the normal `compute`, but since it operates on different inputs/outputs (I assume), I'm not quite sure how I can make that work.
- Since I'm just producing an empty loop there now, some impulse tests don't work. Currently the `comb_delay1` impulse tests seems to run into an infinite loop in the Faust compiler, but maybe that is just a consequence of that.
- I wasn't confident enough to fully replace the other Rust specific `SimpleForLoopInst` for now, which is still used in `generateInitArray`, `generateShiftArray`, and `generateCopyArray`. Maybe this could also be turned into iterator based loops at a later point (if beneficial at all), so perhaps it makes sense to keep `SimpleForLoopInst` for the time being. Are there any simple DSP examples that produce these three loops?
