### PR TITLE
faust2sndfile: add options to LINPUTS call, fix jack_midi_clear_buffer issue

### DIFF
--- a/architecture/faust/gui/ControlUI.h
+++ b/architecture/faust/gui/ControlUI.h
@@ -89,7 +89,7 @@ class ControlUI : public UI {
         void encodeMidiControl(void* midi_control_buffer, unsigned int frames)
         { 
             assert(fControlOut.size() <= frames);
-            jack_midi_reset_buffer(midi_control_buffer);
+            jack_midi_clear_buffer(midi_control_buffer);
           
             for (unsigned int i = 0; i < fControlOut.size(); i++) {
                 jack_midi_data_t* buffer = jack_midi_event_reserve(midi_control_buffer, i, 4);
@@ -100,7 +100,7 @@ class ControlUI : public UI {
     
         static void encodeMidiControl(void* midi_control_buffer, float* control_buffer, int count)
         {
-            jack_midi_reset_buffer(midi_control_buffer);
+            jack_midi_clear_buffer(midi_control_buffer);
             
             for (unsigned int i = 0; i < count; i++) {
                 jack_midi_data_t* buffer = jack_midi_event_reserve(midi_control_buffer, i, 4);

--- a/tools/faust2appls/faust2sndfile
+++ b/tools/faust2appls/faust2sndfile
@@ -52,7 +52,7 @@ done
 for f in $FILES; do
 
 	SRCDIR=$(dirname "$p")
-	LINPUTS=$(faust -uim "$f" | grep FAUST_INPUTS)
+    LINPUTS=$(faust $OPTIONS -uim "$f" | grep FAUST_INPUTS)
 	NINPUTS=${LINPUTS//[^0-9]/}
 	if [ $NINPUTS -gt 0 ]; then
 		echo "Will process an input file to produce an output file"


### PR DESCRIPTION
allows to run `faust2sndfile` with additional custom libraries:

```
faust2sndfile -I ../lib myDSP.dsp
```