### PR TITLE
added es8388 driver support

### DIFF
--- a/architecture/esp32/drivers/es8388/CMakeLists.txt
+++ b/architecture/esp32/drivers/es8388/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(SRCS ./es8388.cpp
+                       INCLUDE_DIRS "include"                       # Edit following two lines to set component requirements (see docs)
+                       REQUIRES 
+                       PRIV_REQUIRES )
+

--- a/architecture/esp32/drivers/es8388/adf_structs.h
+++ b/architecture/esp32/drivers/es8388/adf_structs.h
@@ -1,0 +1,320 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
+ *
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/**
+ * this file contains structs and enums used by the es8388 driver usually included with the ESP-ADF
+ * es_* types are taken from esxxx_common.h
+ * audio_hal_* types are taken from audio_hal.h
+ * These enums are used for configuration of the audio codec and limit options to prevent errors
+ * 
+**/
+
+#ifndef _ADF_STRUCTS_H_
+#define _ADF_STRUCTS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "esp_types.h"
+
+//From es_common.h of the ESP-ADF
+
+typedef enum {
+    BIT_LENGTH_MIN = -1,
+    BIT_LENGTH_16BITS = 0x03,
+    BIT_LENGTH_18BITS = 0x02,
+    BIT_LENGTH_20BITS = 0x01,
+    BIT_LENGTH_24BITS = 0x00,
+    BIT_LENGTH_32BITS = 0x04,
+    BIT_LENGTH_MAX,
+} es_bits_length_t;
+
+typedef enum {
+    MCLK_DIV_MIN = -1,
+    MCLK_DIV_1 = 1,
+    MCLK_DIV_2 = 2,
+    MCLK_DIV_3 = 3,
+    MCLK_DIV_4 = 4,
+    MCLK_DIV_6 = 5,
+    MCLK_DIV_8 = 6,
+    MCLK_DIV_9 = 7,
+    MCLK_DIV_11 = 8,
+    MCLK_DIV_12 = 9,
+    MCLK_DIV_16 = 10,
+    MCLK_DIV_18 = 11,
+    MCLK_DIV_22 = 12,
+    MCLK_DIV_24 = 13,
+    MCLK_DIV_33 = 14,
+    MCLK_DIV_36 = 15,
+    MCLK_DIV_44 = 16,
+    MCLK_DIV_48 = 17,
+    MCLK_DIV_66 = 18,
+    MCLK_DIV_72 = 19,
+    MCLK_DIV_5 = 20,
+    MCLK_DIV_10 = 21,
+    MCLK_DIV_15 = 22,
+    MCLK_DIV_17 = 23,
+    MCLK_DIV_20 = 24,
+    MCLK_DIV_25 = 25,
+    MCLK_DIV_30 = 26,
+    MCLK_DIV_32 = 27,
+    MCLK_DIV_34 = 28,
+    MCLK_DIV_7  = 29,
+    MCLK_DIV_13 = 30,
+    MCLK_DIV_14 = 31,
+    MCLK_DIV_MAX,
+} es_sclk_div_t;
+
+typedef enum {
+    LCLK_DIV_MIN = -1,
+    LCLK_DIV_128 = 0,
+    LCLK_DIV_192 = 1,
+    LCLK_DIV_256 = 2,
+    LCLK_DIV_384 = 3,
+    LCLK_DIV_512 = 4,
+    LCLK_DIV_576 = 5,
+    LCLK_DIV_768 = 6,
+    LCLK_DIV_1024 = 7,
+    LCLK_DIV_1152 = 8,
+    LCLK_DIV_1408 = 9,
+    LCLK_DIV_1536 = 10,
+    LCLK_DIV_2112 = 11,
+    LCLK_DIV_2304 = 12,
+
+    LCLK_DIV_125 = 16,
+    LCLK_DIV_136 = 17,
+    LCLK_DIV_250 = 18,
+    LCLK_DIV_272 = 19,
+    LCLK_DIV_375 = 20,
+    LCLK_DIV_500 = 21,
+    LCLK_DIV_544 = 22,
+    LCLK_DIV_750 = 23,
+    LCLK_DIV_1000 = 24,
+    LCLK_DIV_1088 = 25,
+    LCLK_DIV_1496 = 26,
+    LCLK_DIV_1500 = 27,
+    LCLK_DIV_MAX,
+} es_lclk_div_t;
+
+typedef enum {
+    D2SE_PGA_GAIN_MIN = -1,
+    D2SE_PGA_GAIN_DIS = 0,
+    D2SE_PGA_GAIN_EN = 1,
+    D2SE_PGA_GAIN_MAX = 2,
+} es_d2se_pga_t;
+
+typedef enum {
+    ADC_INPUT_MIN = -1,
+    ADC_INPUT_LINPUT1_RINPUT1 = 0x00,
+    ADC_INPUT_MIC1  = 0x05,
+    ADC_INPUT_MIC2  = 0x06,
+    ADC_INPUT_LINPUT2_RINPUT2 = 0x50,
+    ADC_INPUT_DIFFERENCE = 0xf0,
+    ADC_INPUT_MAX,
+} es_adc_input_t;
+
+typedef enum {
+    DAC_OUTPUT_MIN = -1,
+    DAC_OUTPUT_LOUT1 = 0x04,
+    DAC_OUTPUT_LOUT2 = 0x08,
+    DAC_OUTPUT_SPK   = 0x09,
+    DAC_OUTPUT_ROUT1 = 0x10,
+    DAC_OUTPUT_ROUT2 = 0x20,
+    DAC_OUTPUT_ALL = 0x3c,
+    DAC_OUTPUT_MAX,
+} es_dac_output_t;
+
+typedef enum {
+    MIC_GAIN_MIN = -1,
+    MIC_GAIN_0DB = 0,
+    MIC_GAIN_3DB = 3,
+    MIC_GAIN_6DB = 6,
+    MIC_GAIN_9DB = 9,
+    MIC_GAIN_12DB = 12,
+    MIC_GAIN_15DB = 15,
+    MIC_GAIN_18DB = 18,
+    MIC_GAIN_21DB = 21,
+    MIC_GAIN_24DB = 24,
+    MIC_GAIN_MAX,
+} es_mic_gain_t;
+
+typedef enum {
+    ES_MODULE_MIN = -1,
+    ES_MODULE_ADC = 0x01,
+    ES_MODULE_DAC = 0x02,
+    ES_MODULE_ADC_DAC = 0x03,
+    ES_MODULE_LINE = 0x04,
+    ES_MODULE_MAX
+} es_module_t;
+
+typedef enum {
+    ES_MODE_MIN = -1,
+    ES_MODE_SLAVE = 0x00,
+    ES_MODE_MASTER = 0x01,
+    ES_MODE_MAX,
+} es_mode_t;
+
+typedef enum {
+    ES_I2S_MIN = -1,
+    ES_I2S_NORMAL = 0,
+    ES_I2S_LEFT = 1,
+    ES_I2S_RIGHT = 2,
+    ES_I2S_DSP = 3,
+    ES_I2S_MAX
+} es_i2s_fmt_t;
+
+/**
+ * @brief Configure ES8388 clock
+ */
+typedef struct {
+    es_sclk_div_t sclk_div;    /*!< bits clock divide */
+    es_lclk_div_t lclk_div;    /*!< WS clock divide */
+} es_i2s_clock_t;
+
+
+//from audio_hal.h of the ESP-ADF
+
+
+typedef struct audio_hal *audio_hal_handle_t;
+
+/**
+ * @brief Select media hal codec mode
+ */
+typedef enum {
+    AUDIO_HAL_CODEC_MODE_ENCODE = 1,  /*!< select adc */
+    AUDIO_HAL_CODEC_MODE_DECODE,      /*!< select dac */
+    AUDIO_HAL_CODEC_MODE_BOTH,        /*!< select both adc and dac */
+    AUDIO_HAL_CODEC_MODE_LINE_IN,     /*!< set adc channel */
+} audio_hal_codec_mode_t;
+
+/**
+ * @brief Select adc channel for input mic signal
+ */
+typedef enum {
+    AUDIO_HAL_ADC_INPUT_LINE1 = 0x00,  /*!< mic input to adc channel 1 */
+    AUDIO_HAL_ADC_INPUT_LINE2,         /*!< mic input to adc channel 2 */
+    AUDIO_HAL_ADC_INPUT_ALL,           /*!< mic input to both channels of adc */
+    AUDIO_HAL_ADC_INPUT_DIFFERENCE,    /*!< mic input to adc difference channel */
+} audio_hal_adc_input_t;
+
+/**
+ * @brief Select channel for dac output
+ */
+typedef enum {
+    AUDIO_HAL_DAC_OUTPUT_LINE1 = 0x00,  /*!< dac output signal to channel 1 */
+    AUDIO_HAL_DAC_OUTPUT_LINE2,         /*!< dac output signal to channel 2 */
+    AUDIO_HAL_DAC_OUTPUT_ALL,           /*!< dac output signal to both channels */
+} audio_hal_dac_output_t;
+
+/**
+ * @brief Select operating mode i.e. start or stop for audio codec chip
+ */
+typedef enum {
+    AUDIO_HAL_CTRL_STOP  = 0x00,  /*!< set stop mode */
+    AUDIO_HAL_CTRL_START = 0x01,  /*!< set start mode */
+} audio_hal_ctrl_t;
+
+/**
+ * @brief Select I2S interface operating mode i.e. master or slave for audio codec chip
+ */
+typedef enum {
+    AUDIO_HAL_MODE_SLAVE = 0x00,   /*!< set slave mode */
+    AUDIO_HAL_MODE_MASTER = 0x01,  /*!< set master mode */
+} audio_hal_iface_mode_t;
+
+/**
+ * @brief Select I2S interface samples per second
+ */
+typedef enum {
+    AUDIO_HAL_08K_SAMPLES,   /*!< set to  8k samples per second */
+    AUDIO_HAL_11K_SAMPLES,   /*!< set to 11.025k samples per second */
+    AUDIO_HAL_16K_SAMPLES,   /*!< set to 16k samples in per second */
+    AUDIO_HAL_22K_SAMPLES,   /*!< set to 22.050k samples per second */
+    AUDIO_HAL_24K_SAMPLES,   /*!< set to 24k samples in per second */
+    AUDIO_HAL_32K_SAMPLES,   /*!< set to 32k samples in per second */
+    AUDIO_HAL_44K_SAMPLES,   /*!< set to 44.1k samples per second */
+    AUDIO_HAL_48K_SAMPLES,   /*!< set to 48k samples per second */
+} audio_hal_iface_samples_t;
+
+/**
+ * @brief Select I2S interface number of bits per sample
+ */
+typedef enum {
+    AUDIO_HAL_BIT_LENGTH_16BITS = 1,   /*!< set 16 bits per sample */
+    AUDIO_HAL_BIT_LENGTH_24BITS,       /*!< set 24 bits per sample */
+    AUDIO_HAL_BIT_LENGTH_32BITS,       /*!< set 32 bits per sample */
+} audio_hal_iface_bits_t;
+
+/**
+ * @brief Select I2S interface format for audio codec chip
+ */
+typedef enum {
+    AUDIO_HAL_I2S_NORMAL = 0,  /*!< set normal I2S format */
+    AUDIO_HAL_I2S_LEFT,        /*!< set all left format */
+    AUDIO_HAL_I2S_RIGHT,       /*!< set all right format */
+    AUDIO_HAL_I2S_DSP,         /*!< set dsp/pcm format */
+} audio_hal_iface_format_t;
+
+/**
+ * @brief I2s interface configuration for audio codec chip
+ */
+typedef struct {
+    audio_hal_iface_mode_t mode;        /*!< audio codec chip mode */
+    audio_hal_iface_format_t fmt;       /*!< I2S interface format */
+    audio_hal_iface_samples_t samples;  /*!< I2S interface samples per second */
+    audio_hal_iface_bits_t bits;        /*!< i2s interface number of bits per sample */
+} audio_hal_codec_i2s_iface_t;
+
+/**
+ * @brief Configure media hal for initialization of audio codec chip
+ */
+typedef struct {
+    audio_hal_adc_input_t adc_input;       /*!< set adc channel */
+    audio_hal_dac_output_t dac_output;     /*!< set dac channel */
+    audio_hal_codec_mode_t codec_mode;     /*!< select codec mode: adc, dac or both */
+    audio_hal_codec_i2s_iface_t i2s_iface; /*!< set I2S interface configuration */
+} audio_hal_codec_config_t;
+
+/**
+ * @brief Configuration of functions and variables used to operate audio codec chip
+ */
+typedef struct audio_hal {
+    esp_err_t (*audio_codec_initialize)(audio_hal_codec_config_t *codec_cfg);                                /*!< initialize codec */
+    esp_err_t (*audio_codec_deinitialize)(void);                                                             /*!< deinitialize codec */
+    esp_err_t (*audio_codec_ctrl)(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state);                 /*!< control codec mode and state */
+    esp_err_t (*audio_codec_config_iface)(audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface);  /*!< configure i2s interface */
+    esp_err_t (*audio_codec_set_mute) (bool mute);                                                           /*!< set codec mute */
+    esp_err_t (*audio_codec_set_volume)(int volume);                                                         /*!< set codec volume */
+    esp_err_t (*audio_codec_get_volume)(int *volume);                                                        /*!< get codec volume */
+    xSemaphoreHandle audio_hal_lock;                                                                         /*!< semaphore of codec */
+    void *handle;                                                                                            /*!< handle of audio codec */
+} audio_hal_func_t;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/architecture/esp32/drivers/es8388/es8388.cpp
+++ b/architecture/esp32/drivers/es8388/es8388.cpp
@@ -1,0 +1,588 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+//TODO
+/*
+    - change the write/read Reg to be idf commplient
+    - remove headphone detect or rewrite the code
+    - maybe remove functionality?
+
+*/
+#include <string.h>
+#include "esp_log.h" //remove
+//#include "i2c_bus.h" //remove
+#include "es8388.h"
+//#include "board_pins_config.h" //remove
+
+#ifdef CONFIG_ESP_LYRAT_V4_3_BOARD
+//#include "headphone_detect.h" //remove?
+#endif
+
+//from the example. nessecary info for I2C. common protocol defines
+#define WRITE_BIT                          I2C_MASTER_WRITE /*!< I2C master write */
+#define READ_BIT                           I2C_MASTER_READ  /*!< I2C master read */
+#define ACK_CHECK_EN                       0x1              /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS                      0x0              /*!< I2C master will not check ack from slave */
+#define ACK_VAL                            (i2c_ack_type_t)0x0              /*!< I2C ack value */
+#define NACK_VAL                           (i2c_ack_type_t)0x1              /*!< I2C nack value */
+
+#define I2C_TX_BUF_DISABLE  	0                /*!< I2C master do not need buffer */
+#define I2C_RX_BUF_DISABLE  	0                /*!< I2C master do not need buffer */
+
+#define PA_ENABLE_GPIO          GPIO_NUM_21 //a relevent GPIO pin for the LYRAT 4.2, not sure the purpose
+
+
+esp_err_t es8388::es_write_reg(uint8_t Address, uint8_t Register, uint8_t Data)
+{
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    // first, send device address (indicating write) & register to be written
+    i2c_master_write_byte(cmd, Address | WRITE_BIT, ACK_CHECK_EN);
+    // send register we want
+    i2c_master_write_byte(cmd, Register, ACK_CHECK_EN);
+    // write the data
+    i2c_master_write(cmd, &Data, sizeof(Data), ACK_CHECK_EN);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+    printf("Wrote: Address: %u Register: %u Data: %u\n", Address, Register, Data);
+    return ret;
+}
+/*
+esp_err_t es8388::es8388_write_reg(uint8_t reg_add, uint8_t data)
+{
+    return es_write_reg(ES8388_ADDR, reg_add, data);
+}
+*/
+
+esp_err_t es8388::es_read_reg(uint8_t Register, uint8_t *Data) {
+
+    //from MPU9250 modified for 1 byte length
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    //send the device address with a write indicating register to be read
+    i2c_master_write_byte(cmd, ES8388_ADDR | WRITE_BIT, ACK_CHECK_EN);
+    //send register we want
+    i2c_master_write_byte(cmd, Register, ACK_CHECK_EN);
+    //send repeated start
+
+    i2c_master_start(cmd);
+    // send device address indicating read & read Data
+    i2c_master_write_byte(cmd, ES8388_ADDR | READ_BIT, ACK_CHECK_EN);
+    i2c_master_read_byte(cmd, Data , NACK_VAL); 
+    i2c_master_stop(cmd);
+
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+    //printf("Read: Register: %u Data: %u\n", Register, *Data);
+    return ret;
+}
+
+void es8388::i2c_init(void)
+{
+    int i2c_master_port = I2C_MASTER_NUM;
+    i2c_config_t conf;
+    conf.mode = I2C_MODE_MASTER;
+    conf.sda_io_num = I2C_MASTER_SDA_IO;
+    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.scl_io_num = I2C_MASTER_SCL_IO;
+    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.master.clk_speed = I2C_MASTER_FREQ_HZ;
+    i2c_param_config((i2c_port_t) i2c_master_port, &conf);
+
+    i2c_driver_install((i2c_port_t) i2c_master_port, conf.mode,
+    		I2C_RX_BUF_DISABLE, I2C_TX_BUF_DISABLE, 0);
+
+}
+/**
+ * @brief Read the current values of each register in order and printt them to the screen
+ */
+void es8388::es8388_read_all()
+{
+    for (int i = 0; i < 50; i++) {
+        uint8_t reg = 0;
+        es_read_reg(i, &reg);
+        ets_printf("%x: %x\n", i, reg);
+    }
+}
+
+
+/**
+ * @brief Configure ES8388 ADC and DAC volume. Basicly you can consider this as ADC and DAC gain
+ *
+ * @param mode:             set ADC or DAC or all
+ * @param volume:           -96 ~ 0              for example Es8388SetAdcDacVolume(ES_MODULE_ADC, 30, 6); means set ADC volume -30.5db
+ * @param dot:              whether include 0.5. for example Es8388SetAdcDacVolume(ES_MODULE_ADC, 30, 4); means set ADC volume -30db
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - (0)   Success
+ */
+int es8388::es8388_set_adc_dac_volume(int mode, int volume, int dot)
+{
+    int res = 0;
+    if ( volume < -96 || volume > 0 ) {
+        printf("Warning: volume < -96! or > 0!\n");
+        if (volume < -96)
+            volume = -96;
+        else
+            volume = 0;
+    }
+    dot = (dot >= 5 ? 1 : 0);
+    volume = (-volume << 1) + dot;
+    if (mode == ES_MODULE_ADC || mode == ES_MODULE_ADC_DAC) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL8, volume);
+        res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL9, volume);  //ADC Right Volume=0db
+    }
+    if (mode == ES_MODULE_DAC || mode == ES_MODULE_ADC_DAC) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL5, volume);
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL4, volume);
+    }
+    return res;
+}
+
+
+/**
+ * @brief Power Management
+ *
+ * @param mod:      if ES_POWER_CHIP, the whole chip including ADC and DAC is enabled
+ * @param enable:   false to disable true to enable
+ *
+ * @return
+ *     - (-1)  Error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_start(int mode)
+{
+    esp_err_t res = ESP_OK;
+    uint8_t prev_data = 0, data = 0;
+    es_read_reg(ES8388_DACCONTROL21, &prev_data);
+    if (mode == ES_MODULE_LINE) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL16, 0x09); // 0x00 audio on LIN1&RIN1,  0x09 LIN2&RIN2 by pass enable
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL17, 0x50); // left DAC to left mixer enable  and  LIN signal to left mixer enable 0db  : bupass enable
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL20, 0x50); // right DAC to right mixer enable  and  LIN signal to right mixer enable 0db : bupass enable
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0xC0); //enable adc
+    } else {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x80);   //enable dac
+    }
+    es_read_reg(ES8388_DACCONTROL21, &data);
+    if (prev_data != data) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0xF0);   //start state machine
+        // res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL1, 0x16);
+        // res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL2, 0x50);
+        res |= es_write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0x00);   //start state machine
+    }
+    if (mode == ES_MODULE_ADC || mode == ES_MODULE_ADC_DAC || mode == ES_MODULE_LINE) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0x00);   //power up adc and line in
+    }
+    if (mode == ES_MODULE_DAC || mode == ES_MODULE_ADC_DAC || mode == ES_MODULE_LINE) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x3c);   //power up dac and line out
+        res |= es8388_set_voice_mute(false);
+        printf("es8388_start default is mode:%d\n", mode);
+    }
+
+    return res;
+}
+
+/**
+ * @brief Power Management
+ *
+ * @param mod:      if ES_POWER_CHIP, the whole chip including ADC and DAC is enabled
+ * @param enable:   false to disable true to enable
+ *
+ * @return
+ *     - (-1)  Error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_stop(int mode)
+{
+    esp_err_t res = ESP_OK;
+    if (mode == ES_MODULE_LINE) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x80); //enable dac
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL16, 0x00); // 0x00 audio on LIN1&RIN1,  0x09 LIN2&RIN2
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL17, 0x90); // only left DAC to left mixer enable 0db
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL20, 0x90); // only right DAC to right mixer enable 0db
+        return res;
+    }
+    if (mode == ES_MODULE_DAC || mode == ES_MODULE_ADC_DAC) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, 0x00);
+        res |= es8388_set_voice_mute(true); //res |= Es8388SetAdcDacVolume(ES_MODULE_DAC, -96, 5);      // 0db
+        //res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, 0xC0);  //power down dac and line out
+    }
+    if (mode == ES_MODULE_ADC || mode == ES_MODULE_ADC_DAC) {
+        //res |= Es8388SetAdcDacVolume(ES_MODULE_ADC, -96, 5);      // 0db
+        res |= es_write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0xFF);  //power down adc and line in
+    }
+    if (mode == ES_MODULE_ADC_DAC) {
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x9C);  //disable mclk
+//        res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL1, 0x00);
+//        res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL2, 0x58);
+//        res |= es_write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0xF3);  //stop state machine
+    }
+
+    return res;
+}
+
+
+/**
+ * @brief Config I2s clock in MSATER mode
+ *
+ * @param cfg.sclkDiv:      generate SCLK by dividing MCLK in MSATER mode
+ * @param cfg.lclkDiv:      generate LCLK by dividing MCLK in MSATER mode
+ *
+ * @return
+ *     - (-1)  Error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_i2s_config_clock(es_i2s_clock_t cfg)
+{
+    esp_err_t res = ESP_OK;
+    res |= es_write_reg(ES8388_ADDR, ES8388_MASTERMODE, cfg.sclk_div);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL5, cfg.lclk_div);  //ADCFsMode,singel SPEED,RATIO=256
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL2, cfg.lclk_div);  //ADCFsMode,singel SPEED,RATIO=256
+    return res;
+}
+
+esp_err_t es8388::es8388_deinit(void)
+{
+    int res = 0;
+    res = es_write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0xFF);  //reset and stop es8388
+    //i2c_bus_delete(i2c_handle); //handles are done indivualy within read/write
+#ifdef CONFIG_ESP_LYRAT_V4_3_BOARD
+    headphone_detect_deinit();
+#endif
+
+    return res;
+}
+
+/**
+ * @return
+ *     - (-1)  Error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_init(audio_hal_codec_config_t *cfg)
+{
+    int res = 0;
+    /*
+    #ifdef CONFIG_ESP_LYRAT_V4_3_BOARD
+    h   eadphone_detect_init(get_headphone_detect_gpio());
+    #endif
+    */
+    i2c_init(); // ESP32 in master mode
+
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL3, 0x04);  // 0x04 mute/0x00 unmute&ramp;DAC unmute and  disabled digital volume control soft ramp
+    /* Chip Control and Power Management */
+    res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL2, 0x50);
+    res |= es_write_reg(ES8388_ADDR, ES8388_CHIPPOWER, 0x00); //normal all and power up all
+    res |= es_write_reg(ES8388_ADDR, ES8388_MASTERMODE, cfg->i2s_iface.mode); //CODEC IN I2S SLAVE MODE
+
+    /* dac */
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, 0xC0);  //disable DAC and disable Lout/Rout/1/2
+    res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL1, 0x12);  //Enfr=0,Play&Record Mode,(0x17-both of mic&paly)
+    //    res |= es_write_reg(ES8388_ADDR, ES8388_CONTROL2, 0);  //LPVrefBuf=0,Pdn_ana=0
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL1, 0x18);//1a 0x18:16bit iis , 0x00:24
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL2, 0x02);  //DACFsMode,SINGLE SPEED; DACFsRatio,256
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL16, 0x00); // 0x00 audio on LIN1&RIN1,  0x09 LIN2&RIN2
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL17, 0x90); // only left DAC to left mixer enable 0db
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL20, 0x90); // only right DAC to right mixer enable 0db
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL21, 0x80); //set internal ADC and DAC use the same LRCK clock, ADC LRCK as internal LRCK
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL23, 0x00);   //vroi=0
+    res |= es8388_set_adc_dac_volume(ES_MODULE_DAC, 0, 0);          // 0db
+    int tmp = 0;
+    if (AUDIO_HAL_DAC_OUTPUT_LINE2 == cfg->dac_output) {
+        tmp = DAC_OUTPUT_LOUT1 | DAC_OUTPUT_ROUT1;
+    } else if (AUDIO_HAL_DAC_OUTPUT_LINE1 == cfg->dac_output) {
+        tmp = DAC_OUTPUT_LOUT2 | DAC_OUTPUT_ROUT2;
+    } else {
+        tmp = DAC_OUTPUT_LOUT1 | DAC_OUTPUT_LOUT2 | DAC_OUTPUT_ROUT1 | DAC_OUTPUT_ROUT2;
+    }
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, tmp);  //0x3c Enable DAC and Enable Lout/Rout/1/2
+    /* adc */
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0xFF);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL1, 0xbb); // MIC Left and Right channel PGA gain
+    tmp = 0;
+    if (AUDIO_HAL_ADC_INPUT_LINE1 == cfg->adc_input) {
+        tmp = ADC_INPUT_LINPUT1_RINPUT1;
+    } else if (AUDIO_HAL_ADC_INPUT_LINE2 == cfg->adc_input) {
+        tmp = ADC_INPUT_LINPUT2_RINPUT2;
+    } else {
+        tmp = ADC_INPUT_DIFFERENCE;
+    }
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL2, tmp);  //0x00 LINSEL & RINSEL, LIN1/RIN1 as ADC Input; DSSEL,use one DS Reg11; DSR, LINPUT1-RINPUT1
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL3, 0x02);
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL4, 0x0d); // Left/Right data, Left/Right justified mode, Bits length, I2S format
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL5, 0x02);  //ADCFsMode,singel SPEED,RATIO=256
+    //ALC for Microphone
+    res |= es8388_set_adc_dac_volume(ES_MODULE_ADC, 0, 0);      // 0db
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCPOWER, 0x09); //Power on ADC, Enable LIN&RIN, Power off MICBIAS, set int1lp to low power mode
+    /* enable es8388 PA */
+    es8388_pa_power(true);
+    printf("init,out:%02x, in:%02x\n", cfg->dac_output, cfg->adc_input);
+    return res;
+}
+
+/**
+ * @brief Configure ES8388 I2S format
+ *
+ * @param mode:           set ADC or DAC or all
+ * @param bitPerSample:   see Es8388I2sFmt
+ *
+ * @return
+ *     - (-1) Error
+ *     - (0)  Success
+ */
+esp_err_t es8388::es8388_config_fmt(es_module_t mode, es_i2s_fmt_t fmt)
+{ 
+    esp_err_t res = ESP_OK;
+    uint8_t reg = 0;
+    if (mode == ES_MODULE_ADC || mode == ES_MODULE_ADC_DAC) {
+        res = es_read_reg(ES8388_ADCCONTROL4, &reg);
+        reg = reg & 0xfc;
+        res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL4, reg | fmt);
+    }
+    if (mode == ES_MODULE_DAC || mode == ES_MODULE_ADC_DAC) {
+        res = es_read_reg(ES8388_DACCONTROL1, &reg);
+        reg = reg & 0xf9;
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL1, reg | (fmt << 1));
+    }
+    return res;
+}
+
+/**
+ * @param volume: 0 ~ 100
+ *
+ * @return
+ *     - (-1)  Error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_set_voice_volume(int volume)
+{
+    esp_err_t res = ESP_OK;
+    if (volume < 0)
+        volume = 0;
+    else if (volume > 100)
+        volume = 100;
+    volume /= 3;
+    res = es_write_reg(ES8388_ADDR, ES8388_DACCONTROL24, volume);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL25, volume);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL26, 0);
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL27, 0);
+    return res;
+}
+
+/**
+ *
+ * @return
+ *           volume
+ */
+esp_err_t es8388::es8388_get_voice_volume(int *volume)
+{
+    esp_err_t res = ESP_OK;
+    uint8_t reg = 0;
+    res = es_read_reg(ES8388_DACCONTROL24, &reg);
+    if (res == ESP_FAIL) {
+        *volume = 0;
+    } else {
+        *volume = reg;
+        *volume *= 3;
+        if (*volume == 99)
+            *volume = 100;
+    }
+    return res;
+}
+
+/**
+ * @brief Configure ES8388 data sample bits
+ *
+ * @param mode:             set ADC or DAC or all
+ * @param bitPerSample:   see BitsLength
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_set_bits_per_sample(es_module_t mode, es_bits_length_t bits_length)
+{
+    esp_err_t res = ESP_OK;
+    uint8_t reg = 0;
+    int bits = (int)bits_length;
+
+    if (mode == ES_MODULE_ADC || mode == ES_MODULE_ADC_DAC) {
+        res = es_read_reg(ES8388_ADCCONTROL4, &reg);
+        reg = reg & 0xe3;
+        res |=  es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL4, reg | (bits << 2));
+    }
+    if (mode == ES_MODULE_DAC || mode == ES_MODULE_ADC_DAC) {
+        res = es_read_reg(ES8388_DACCONTROL1, &reg);
+        reg = reg & 0xc7;
+        res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL1, reg | (bits << 3));
+    }
+    return res;
+}
+
+/**
+ * @brief Configure ES8388 DAC mute or not. Basically you can use this function to mute the output or unmute
+ *
+ * @param enable: enable or disable
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_set_voice_mute(bool enable)
+{
+    esp_err_t res = ESP_OK;
+    uint8_t reg = 0;
+    res = es_read_reg(ES8388_DACCONTROL3, &reg);
+    reg = reg & 0xFB;
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACCONTROL3, reg | (((int)enable) << 2));
+    return res;
+}
+
+esp_err_t es8388::es8388_get_voice_mute(bool *enable)
+{
+    esp_err_t res = ESP_OK;
+    uint8_t reg = 0;
+    res = es_read_reg(ES8388_DACCONTROL3, &reg);
+    if (res == ESP_OK) {
+        reg = (reg & 0x04) >> 2;
+        *enable = (bool) reg;
+    }else{
+        *enable = 0; 
+    }
+    return res == ESP_OK;
+}
+
+/**
+ * @param gain: Config DAC Output
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_config_dac_output(es_dac_output_t output)
+{
+    esp_err_t res;
+    uint8_t reg = 0;
+    res = es_read_reg(ES8388_DACPOWER, &reg);
+    reg = reg & 0xc3;
+    res |= es_write_reg(ES8388_ADDR, ES8388_DACPOWER, reg | output);
+    return res;
+}
+
+/**
+ * @param gain: Config ADC input
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_config_adc_input(es_adc_input_t input)
+{
+    esp_err_t res;
+    uint8_t reg = 0;
+    res = es_read_reg(ES8388_ADCCONTROL2, &reg);
+    reg = reg & 0x0f;
+    res |= es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL2, reg | input);
+    return res;
+}
+
+/**
+ * @param gain: see es_mic_gain_t
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - (0)   Success
+ */
+esp_err_t es8388::es8388_set_mic_gain(es_mic_gain_t gain)
+{
+    esp_err_t res, gain_n;
+    gain_n = (int)gain / 3;
+    res = es_write_reg(ES8388_ADDR, ES8388_ADCCONTROL1, gain_n); //MIC PGA
+    return res;
+}
+
+int es8388::es8388_ctrl_state(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state)
+{
+    int res = 0;
+    int es_mode_t = 0;
+    switch (mode) {
+        case AUDIO_HAL_CODEC_MODE_ENCODE:
+            es_mode_t  = ES_MODULE_ADC;
+            break;
+        case AUDIO_HAL_CODEC_MODE_LINE_IN:
+            es_mode_t  = ES_MODULE_LINE;
+            break;
+        case AUDIO_HAL_CODEC_MODE_DECODE:
+            es_mode_t  = ES_MODULE_DAC;
+            break;
+        case AUDIO_HAL_CODEC_MODE_BOTH:
+            es_mode_t  = ES_MODULE_ADC_DAC;
+            break;
+        default:
+            es_mode_t = ES_MODULE_DAC;
+            printf ("Codec mode not support, default is decode mode\n");
+            break;
+    }
+    if (AUDIO_HAL_CTRL_STOP == ctrl_state) {
+        res = es8388_stop(es_mode_t);
+    } else {
+        res = es8388_start(es_mode_t);
+        printf("start default is decode mode:%d\n", es_mode_t);
+    }
+    return res;
+}
+
+esp_err_t es8388::es8388_config_i2s(audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface)
+{
+    esp_err_t res = ESP_OK;
+    int tmp = 0;
+    res |= es8388_config_fmt((es_module_t) ES_MODULE_ADC_DAC, (es_i2s_fmt_t) iface->fmt);
+    if (iface->bits == AUDIO_HAL_BIT_LENGTH_16BITS) {
+        tmp = BIT_LENGTH_16BITS;
+    } else if (iface->bits == AUDIO_HAL_BIT_LENGTH_24BITS) {
+        tmp = BIT_LENGTH_24BITS;
+    } else {
+        tmp = BIT_LENGTH_32BITS;
+    }
+    res |= es8388_set_bits_per_sample((es_module_t) ES_MODULE_ADC_DAC, (es_bits_length_t) tmp);
+    return res;
+}
+
+void es8388::es8388_pa_power(bool enable)
+{
+    gpio_config_t  io_conf;
+    memset(&io_conf, 0, sizeof(io_conf));
+    io_conf.intr_type = (gpio_int_type_t) GPIO_PIN_INTR_DISABLE;
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    io_conf.pin_bit_mask = PA_ENABLE_GPIO; //the GPIO for pa_enable_gpio for the lyrat
+    io_conf.pull_down_en = (gpio_pulldown_t) 0;
+    io_conf.pull_up_en = (gpio_pullup_t) 0;
+    gpio_config(&io_conf);
+    if (enable) {
+        gpio_set_level(PA_ENABLE_GPIO, 1);
+    } else {
+        gpio_set_level(PA_ENABLE_GPIO, 0);
+    }
+}

--- a/architecture/esp32/drivers/es8388/es8388.h
+++ b/architecture/esp32/drivers/es8388/es8388.h
@@ -1,0 +1,330 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef __es8388_H__
+#define __es8388_H__
+
+#include "esp_types.h" 
+#include "driver/i2c.h" 
+#include "adf_structs.h" 
+
+
+#define I2C_MASTER_NUM I2C_NUM_1 /*!< I2C port number for master dev */
+
+#define I2C_MASTER_SCL_IO GPIO_NUM_23//these may be wrong 
+#define I2C_MASTER_SDA_IO GPIO_NUM_18
+
+#define I2C_MASTER_FREQ_HZ 100000
+#define I2C_MASTER_TX_BUF_DISABLE 0
+#define I2C_MASTER_RX_BUF_DISABLE 0
+ 
+
+#define WRITE_BIT I2C_MASTER_WRITE              /*!< I2C master write */
+#define ACK_CHECK_EN 0x1
+
+
+/* ES8388 address */
+#define ES8388_ADDR 0x20  /*!< 0x22:CE=1;0x20:CE=0*/
+
+/* ES8388 registers */
+#define ES8388_CONTROL1         0x00
+#define ES8388_CONTROL2         0x01
+
+#define ES8388_CHIPPOWER        0x02
+
+#define ES8388_ADCPOWER         0x03
+#define ES8388_DACPOWER         0x04
+
+#define ES8388_CHIPLOPOW1       0x05
+#define ES8388_CHIPLOPOW2       0x06
+
+#define ES8388_ANAVOLMANAG      0x07
+
+#define ES8388_MASTERMODE       0x08
+/* ADC */
+#define ES8388_ADCCONTROL1      0x09
+#define ES8388_ADCCONTROL2      0x0a
+#define ES8388_ADCCONTROL3      0x0b
+#define ES8388_ADCCONTROL4      0x0c
+#define ES8388_ADCCONTROL5      0x0d
+#define ES8388_ADCCONTROL6      0x0e
+#define ES8388_ADCCONTROL7      0x0f
+#define ES8388_ADCCONTROL8      0x10
+#define ES8388_ADCCONTROL9      0x11
+#define ES8388_ADCCONTROL10     0x12
+#define ES8388_ADCCONTROL11     0x13
+#define ES8388_ADCCONTROL12     0x14
+#define ES8388_ADCCONTROL13     0x15
+#define ES8388_ADCCONTROL14     0x16
+/* DAC */
+#define ES8388_DACCONTROL1      0x17
+#define ES8388_DACCONTROL2      0x18
+#define ES8388_DACCONTROL3      0x19
+#define ES8388_DACCONTROL4      0x1a
+#define ES8388_DACCONTROL5      0x1b
+#define ES8388_DACCONTROL6      0x1c
+#define ES8388_DACCONTROL7      0x1d
+#define ES8388_DACCONTROL8      0x1e
+#define ES8388_DACCONTROL9      0x1f
+#define ES8388_DACCONTROL10     0x20
+#define ES8388_DACCONTROL11     0x21
+#define ES8388_DACCONTROL12     0x22
+#define ES8388_DACCONTROL13     0x23
+#define ES8388_DACCONTROL14     0x24
+#define ES8388_DACCONTROL15     0x25
+#define ES8388_DACCONTROL16     0x26
+#define ES8388_DACCONTROL17     0x27
+#define ES8388_DACCONTROL18     0x28
+#define ES8388_DACCONTROL19     0x29
+#define ES8388_DACCONTROL20     0x2a
+#define ES8388_DACCONTROL21     0x2b
+#define ES8388_DACCONTROL22     0x2c
+#define ES8388_DACCONTROL23     0x2d
+#define ES8388_DACCONTROL24     0x2e
+#define ES8388_DACCONTROL25     0x2f
+#define ES8388_DACCONTROL26     0x30
+#define ES8388_DACCONTROL27     0x31
+#define ES8388_DACCONTROL28     0x32
+#define ES8388_DACCONTROL29     0x33
+#define ES8388_DACCONTROL30     0x34
+
+
+class es8388 
+{
+public:
+    /**
+     * @brief Initialize ES8388 codec chip
+     *
+     * @param cfg configuration of ES8388
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_init(audio_hal_codec_config_t *cfg);
+
+    /**
+     * @brief Deinitialize ES8388 codec chip
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_deinit(void);
+
+    /**
+     * @brief Configure ES8388 I2S format
+     *
+     * @param mod:  set ADC or DAC or both
+     * @param cfg:   ES8388 I2S format
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_config_fmt(es_module_t mod, es_i2s_fmt_t cfg);
+
+    /**
+     * @brief Configure I2s clock in MSATER mode
+     *
+     * @param cfg:  set bits clock and WS clock
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_i2s_config_clock(es_i2s_clock_t cfg);
+
+    /**
+     * @brief Configure ES8388 data sample bits
+     *
+     * @param mode:  set ADC or DAC or both
+     * @param bit_per_sample:  bit number of per sample
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_set_bits_per_sample(es_module_t mode, es_bits_length_t bit_per_sample);
+
+    /**
+     * @brief  Start ES8388 codec chip
+     *
+     * @param mode:  set ADC or DAC or both
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_start(int mode);
+
+    /**
+     * @brief  Stop ES8388 codec chip
+     *
+     * @param mode:  set ADC or DAC or both
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_stop(int mode);
+
+    /**
+     * @brief  Set voice volume
+     *
+     * @param volume:  voice volume (0~100)
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_set_voice_volume(int volume);
+
+    /**
+     * @brief Get voice volume
+     *
+     * @param[out] *volume:  voice volume (0~100)
+     *
+     * @return
+     *     - ESP_OK
+     *     - ESP_FAIL
+     */
+    esp_err_t es8388_get_voice_volume(int *volume);
+
+    /**
+     * @brief Configure ES8388 DAC mute or not. Basically you can use this function to mute the output or unmute
+     *
+     * @param enable enable(1) or disable(0)
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_set_voice_mute(bool enable);
+
+    /**
+     * @brief Get ES8388 DAC mute status
+     *
+     *  @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_get_voice_mute(bool *enable);
+
+    /**
+     * @brief Set ES8388 mic gain
+     *
+     * @param gain db of mic gain
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_set_mic_gain(es_mic_gain_t gain);
+
+    /**
+     * @brief Set ES8388 adc input mode
+     *
+     * @param input adc input mode
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_config_adc_input(es_adc_input_t input);
+
+    /**
+     * @brief Set ES8388 dac output mode
+     *
+     * @param output dac output mode
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_config_dac_output(es_dac_output_t output);
+
+    /**
+     * @brief Write ES8388 register
+     *
+     * @param reg_add address of register
+     * @param data data of register
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_write_reg(uint8_t reg_add, uint8_t data);
+
+    /**
+     * @brief Print all ES8388 registers
+     *
+     * @return
+     *     - void
+     */
+    void es8388_read_all();
+
+    /**
+     * @brief Configure ES8388 codec mode and I2S interface
+     *
+     * @param mode codec mode
+     * @param iface I2S config
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_config_i2s(audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface);
+
+    /**
+     * likely unneeded by the current iteration
+     * @brief Control ES8388 codec chip
+     *
+     * @param mode codec mode
+     * @param ctrl_state start or stop decode or encode progress
+     *
+     * @return
+     *     - ESP_FAIL Parameter error
+     *     - ESP_OK   Success
+     */
+    esp_err_t es8388_ctrl_state(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state);
+
+    /**
+     * @brief Set ES8388 PA power
+     *
+     * @param enable true for enable PA power, false for disable PA power
+     *
+     * @return
+     *      - void
+     */
+    void es8388_pa_power(bool enable);
+
+private:
+    void i2c_init(void);
+    static esp_err_t es_read_reg(uint8_t Register, uint8_t *Data);
+    static esp_err_t es_write_reg(uint8_t Address, uint8_t Register, uint8_t Data);
+    int es8388_set_adc_dac_volume(int mode, int volume, int dot);
+};
+
+#endif //__ES8388_H__

--- a/architecture/faust/audio/esp32-dsp.h
+++ b/architecture/faust/audio/esp32-dsp.h
@@ -167,6 +167,13 @@ class esp32audio : public audio {
                 .data_out_num = 25,
                 .data_in_num = 35
             };
+        #elif LYRA_T
+            pin_config = {
+                    .bck_io_num = 5,
+                    .ws_io_num = 25,
+                    .data_out_num = 26,
+                    .data_in_num = 35
+                };
         #else // Default
             pin_config = {
                 .bck_io_num = 33,

--- a/tools/faust2appls/faust2esp32
+++ b/tools/faust2appls/faust2esp32
@@ -46,7 +46,7 @@ echoHelp ()
     option -midi
     option -main "add a 'main' entry point"
     option "-nvoices <num>"
-    option "-wm8978 or -ac101" "to choose codec driver"
+    option "-wm8978, -es8338 or -ac101" "to choose codec driver"
     option "Faust options"
 }
 
@@ -89,6 +89,9 @@ do
     # -ac101 (Ai-thinker a1s-board)
     elif [ $p = "-ac101" ] || [ $p = "-AC101" ]; then
     	DRIVER="ac101"
+    # -es8388 (espressif LyraT)
+    elif [ $p = "-es8388" ] || [ $p = "-ES8388" ]; then
+    	DRIVER="es8388"
     # other compile options
     else
         OPTIONS="$OPTIONS $p"
@@ -160,6 +163,10 @@ if [ $LIB -eq 1 ]; then
     elif [[ $DRIVER = "ac101" ]]; then
         cp $FAUSTARCH/esp32/drivers/ac101/AC101.cpp $MODULENAME
         cp $FAUSTARCH/esp32/drivers/ac101/AC101.h $MODULENAME
+    elif [[ $DRIVER = "es8388" ]]; then
+        cp $FAUSTARCH/esp32/drivers/es8388/es8388.cpp $MODULENAME
+        cp $FAUSTARCH/esp32/drivers/es8388/es8388.h $MODULENAME
+        cp $FAUSTARCH/esp32/drivers/es8388/adf_structs.h $MODULENAME
     else
         cp $FAUSTARCH/esp32/drivers/wm8978/WM8978.cpp $MODULENAME
         cp $FAUSTARCH/esp32/drivers/wm8978/WM8978.h $MODULENAME
@@ -185,6 +192,10 @@ if [ $LIB -eq 1 ]; then
 
     if [[ "$DRIVER" == *ac101* ]]; then
     	echo '#define A1S_BOARD true' >> "$MODULENAME/tmp.txt"
+    fi
+
+    if [[ "$DRIVER" == *es8388* ]]; then
+        echo '#define LYRA_T true' >> "$MODULENAME/tmp.txt"
     fi
 
     #if [[ "$OSCDEFS" == *OSC* ]]; then
@@ -230,6 +241,13 @@ if [ $LIB -eq 0 ]; then
         cp $FAUSTARCH/esp32/drivers/ac101/component.mk $MODULENAME/AC101
         cp $FAUSTARCH/esp32/drivers/ac101/AC101.cpp $MODULENAME/AC101
         cp $FAUSTARCH/esp32/drivers/ac101/AC101.h $MODULENAME/AC101/include
+    elif [[ $DRIVER = "es8388" ]]; then
+        mkdir -p $MODULENAME/es8388/include
+        cp $FAUSTARCH/esp32/drivers/es8388/CMakeLists.txt $MODULENAME/es8388
+        cp $FAUSTARCH/esp32/drivers/es8388/component.mk $MODULENAME/es8388
+        cp $FAUSTARCH/esp32/drivers/es8388/es8388.cpp $MODULENAME/es8388
+        cp $FAUSTARCH/esp32/drivers/es8388/es8388.h $MODULENAME/es8388/include
+        cp $FAUSTARCH/esp32/drivers/es8388/adf_structs.h $MODULENAME/es8388/include
     else
         mkdir -p $MODULENAME/WM8978/include
         cp $FAUSTARCH/esp32/drivers/wm8978/CMakeLists.txt $MODULENAME/WM8978
@@ -267,7 +285,11 @@ if [ $LIB -eq 0 ]; then
     	echo '#define A1S_BOARD true' >> "$MODULENAME/tmp.txt"
     fi
 
-    if [[ "$DRIVER" == *wm8798* ]]; then
+    if [[ "$DRIVER" == *es8388* ]]; then
+        echo '#define LYRA_T true' >> "$MODULENAME/tmp.txt"
+    fi
+
+    if [[ "$DRIVER" == *wm8978* ]]; then
     	echo '#define TTGO_TAUDIO true' >> "$MODULENAME/tmp.txt"
     fi
 


### PR DESCRIPTION
This adds support for the es8388 audio codec, the codec used by the espressif LyraT to faust.

-added three driver files, as well as the relevant makefiles to the faust architecture. They configure the es8388 codec based on input from the user and behave similarly to the wm8978 and ac101 drivers. 
-updated the faust2esp32 to include a -es8388 option, which behaves the same as the options for the other drivers while substituting the relevant es8388 files
-added support for the LyraT to esp32-dsp.h
-fixed a small typo wm8798 -> wm8978 in faust2esp32

the driver files are fully functional but still under development