### PR TITLE
MSVC compiler bug

### DIFF
--- a/compiler/evaluate/eval.cpp
+++ b/compiler/evaluate/eval.cpp
@@ -849,47 +849,44 @@ static string evalLabel(const char* src, Tree visited, Tree localValEnv)
     string format;     // current format
 
     while (state != -1) {
-        char c = *src++;
-
         if (state == 0) {
-            if (c == 0) {
+            if (*src == 0) {
                 state = -1;
-            } else if (c == '%') {
+            } else if (*src == '%') {
                 ident  = "";
                 format = "";
                 state  = 1;
+                src++;
             } else {
-                dst += c;
+                dst += *src++;
                 state = 0;
             }
 
         } else if (state == 1) {
-            if (c == 0) {
+            if (*src == 0) {
                 // fin et pas d'indentifiant, abandon
                 dst += '%';
                 dst += format;
                 state = -1;
-            } else if (isDigitChar(c)) {
-                format += c;
+            } else if (isDigitChar(*src)) {
+                format += *src++;
                 state = 1;
-            } else if (isIdentChar(c)) {
-                ident += c;
+            } else if (isIdentChar(*src)) {
+                ident += *src++;
                 state = 2;
             } else {
                 // caractere de ponctuation et pas d'indentifiant, abandon
                 dst += '%';
                 dst += format;
-                src--;
                 state = 0;
             }
 
         } else if (state == 2) {
-            if (isIdentChar(c)) {
-                ident += c;
+            if (isIdentChar(*src)) {
+                ident += *src++;
                 state = 2;
             } else {
                 writeIdentValue(dst, format, ident, visited, localValEnv);
-                src--;
                 state = 0;
             }
 


### PR DESCRIPTION
The bug causes the little state machine in evalLabel (eval.cpp) to "stutter" in some cases (e.g., `%k` becomes `%kk`). Apparently that's because in Release mode the compiler (MSVC from Visual Studio 2019, i.e., the latest one) optimizes the loop so aggressively that it misses out the increment of the `src` pointer when switching to state 2 after the first IdentChar is detected.

We work around this by just dropping the local `char c` variable and using the `src` pointer directly throughout the loop, incrementing it whenever necessary. This solves the issue.

NOTE: This PR is relative to the 2.27.1 release (actually 2.27.2, which is what I'm using as a submodule right now while working on pd-faustgen), but the changeset applies cleanly to master-dev as well. I can rebase it on master-dev if you want, just let me know.