### PR TITLE
@(0) is valid

### DIFF
--- a/documentation/faust-manual/src/syntax.md
+++ b/documentation/faust-manual/src/syntax.md
@@ -948,8 +948,8 @@ process = @(10);
 
 will delay the incoming signal by 10 samples. 
 
-A delay expressed with `@` doesn't have to be fixed but it must be positive 
-and bounded. Therefore, the values of a slider are perfectly acceptable:
+A delay expressed with `@` doesn't have to be fixed but it must be bounded 
+and cannot be negative. Therefore, the values of a slider are perfectly acceptable:
 
 <!-- faust-run -->
 ```


### PR DESCRIPTION
`@` can delay its input by 0 samples, so saying that it "must be positive" could be confusing (especially since the example immediately following this paragraph uses a slider that starts at 0!)

"cannot be negative" seems more precise to me.