### PR TITLE
Teensy 4.1 PSRAM support

### DIFF
--- a/architecture/teensy/teensy.cpp
+++ b/architecture/teensy/teensy.cpp
@@ -83,8 +83,8 @@
 
 /*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
 
-#define MULT_16 2147483647
-#define DIV_16 4.6566129e-10
+#define MULT_16 2147483648
+#define DIV_16 4.656612873077392578e-10 
 
 unsigned __exidx_start;
 unsigned __exidx_end;
@@ -93,6 +93,35 @@ unsigned __exidx_end;
 std::list<GUI*> GUI::fGuiList;
 ztimedmap GUI::gTimedZoneMap;
 #endif
+
+static const audio_block_t zeroblock = {
+0, 0, 0, {
+0, 0, 0, 0, 0, 0, 0, 0,
+#if AUDIO_BLOCK_SAMPLES > 8
+0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 16
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 32
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 48
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 64
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 80
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 96
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 112
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+#endif
+} };
 
 #ifdef USEPSRAM
 constexpr size_t bufSize = sizeof(mydsp);
@@ -178,14 +207,16 @@ void AudioFaust::updateImp(void)
 #endif
     
     if (INPUTS > 0) {
-        audio_block_t* inBlock[INPUTS];
+        const audio_block_t* inBlock[INPUTS];
         for (int channel = 0; channel < INPUTS; channel++) {
             inBlock[channel] = receiveReadOnly(channel);
+            if (inBlock[channel] == NULL)
+                inBlock[channel] = &zeroblock;
             for (int i = 0; i < AUDIO_BLOCK_SAMPLES; i++) {
                 int32_t val = inBlock[channel]->data[i] << 16;
                 fInChannel[channel][i] = val*DIV_16;
             }
-            release(inBlock[channel]);
+            if (inBlock[channel] != &zeroblock)release((audio_block_t *)inBlock[channel]);
         }
     }
     

--- a/architecture/teensy/teensy.cpp
+++ b/architecture/teensy/teensy.cpp
@@ -94,6 +94,11 @@ std::list<GUI*> GUI::fGuiList;
 ztimedmap GUI::gTimedZoneMap;
 #endif
 
+#ifdef USEPSRAM
+constexpr size_t bufSize = sizeof(mydsp);
+EXTMEM uint8_t myHeap[bufSize];
+#endif
+
 AudioFaust::AudioFaust() : AudioStream(FAUST_INPUTS, new audio_block_t*[FAUST_INPUTS])
 {
 #ifdef NVOICES
@@ -101,7 +106,11 @@ AudioFaust::AudioFaust() : AudioStream(FAUST_INPUTS, new audio_block_t*[FAUST_IN
     mydsp_poly* dsp_poly = new mydsp_poly(new mydsp(), nvoices, true, true);
     fDSP = dsp_poly;
 #else
-    fDSP = new mydsp();
+    #ifdef USEPSRAM
+        fDSP = new(myHeap) mydsp();
+    #else
+        fDSP = new mydsp();
+    #endif
 #endif
     
     fDSP->init(AUDIO_SAMPLE_RATE_EXACT);

--- a/tools/faust2appls/faust2teensy
+++ b/tools/faust2appls/faust2teensy
@@ -20,6 +20,7 @@ set -e
 LIB="0"
 NVOICES=0
 MIDI=0
+EXT="0"
 
 echoHelp ()
 {
@@ -28,6 +29,7 @@ echoHelp ()
     option
     option -lib "generates a package containing an object compatible with the Teensy audio library."
     option -midi
+    option -ext "uses external PSRAM available on Teensy 4.1"
     option "-nvoices <num>"
     option "Faust options"
 }
@@ -48,6 +50,8 @@ do
         NVOICES=$1
     elif [ $p = "-midi" ]; then
         MIDI=1
+    elif [ $p = "-ext" ]; then
+        EXT=1
     elif [[ -f "$p" ]]; then
         FILE="$p"
     elif [ $p = "-lib" ]; then
@@ -85,6 +89,9 @@ if [ $LIB -eq 1 ]; then
     if [ $MIDI -eq 1 ]; then
         echo '#define MIDICTRL' >> $MODULENAME/$MODULENAME.h
     fi
+    if [ $EXT -eq 1 ]; then
+        echo '#define USEPSRAM' >> $MODULENAME/$MODULENAME.h
+    fi    
     cat $FAUSTARCH/teensy/teensy.h >> $MODULENAME/$MODULENAME.h
     TMP=$(awk -v modName="$MODULENAME" '{gsub(/AudioFaust/,modName)}1' $MODULENAME/$MODULENAME.cpp)
     echo "$TMP" > $MODULENAME/$MODULENAME.cpp


### PR DESCRIPTION
This adds the `-ext` option to the faust2teensy applet which makes use of the external memory, soldered to the back of the Teensy 4.1. Opposed to the internal RAM2 section (which is limited to 512Kb) you can get up to 16MB with 2x ESP-PSRAM64H. This allows for much larger and more buffers, however also increases CPU usage. Still quite a usable option to be included in my opinion.