### PR TITLE
Support option -ns with D language

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -124,7 +124,7 @@ Code generation options:
 
   **-mapp**      **--math-approximation**         simpler/faster versions of 'floor/ceil/fmod/remainder' functions.
 
-  **-ns** \<name> **--namespace** \<name>           generate C++ code in a namespace \<name>.
+  **-ns** \<name> **--namespace** \<name>           generate C++ or D code in a namespace \<name>.
 
 
 Block diagram options:

--- a/compiler/generator/dlang/dlang_code_container.cpp
+++ b/compiler/generator/dlang/dlang_code_container.cpp
@@ -134,19 +134,30 @@ void DLangCodeContainer::produceInit(int tabs)
 
 void DLangCodeContainer::printHeader()
 {
-    int n = 0;
-    tab(n, *fOut);
-    // *fOut << "#!/usr/bin/env dub\n";
-    *fOut << "/+ dub.sdl:";
-    tab(n + 1, *fOut);
-    *fOut << "name \"" << dModuleName(fKlassName) << "\"";
-    tab(n + 1, *fOut);
-    *fOut << "dependency \"dplug:core\" version=\"*\"";
-    tab(n, *fOut);
-    *fOut << "+/\n";
+    if (gGlobal->gArchFile == "")
+        printDRecipeComment(*fOut, fKlassName);
     CodeContainer::printHeader(*fOut);
     if (gGlobal->gArchFile == "")
-        *fOut << "module " << dModuleName(fKlassName) << ";\n";
+        printDModuleStmt(*fOut, fKlassName);
+}
+
+void DLangCodeContainer::printDRecipeComment(ostream& dst, const string& klassName)
+{
+    int n = 0;
+    tab(n, dst);
+    // dst << "#!/usr/bin/env dub\n";
+    dst << "/+ dub.sdl:";
+    tab(n + 1, dst);
+    dst << "name \"" << dModuleName(klassName) << "\"";
+    tab(n + 1, dst);
+    dst << "dependency \"dplug:core\" version=\"*\"";
+    tab(n, dst);
+    dst << "+/\n";
+}
+
+void DLangCodeContainer::printDModuleStmt(ostream& dst, const string& klassName)
+{
+    dst << "module " << dModuleName(klassName) << ";\n";
 }
 
 void DLangCodeContainer::produceInternal()

--- a/compiler/generator/dlang/dlang_code_container.cpp
+++ b/compiler/generator/dlang/dlang_code_container.cpp
@@ -145,7 +145,8 @@ void DLangCodeContainer::printHeader()
     tab(n, *fOut);
     *fOut << "+/\n";
     CodeContainer::printHeader(*fOut);
-    *fOut << "module " << dModuleName(fKlassName) << ";\n";
+    if (gGlobal->gArchFile == "")
+        *fOut << "module " << dModuleName(fKlassName) << ";\n";
 }
 
 void DLangCodeContainer::produceInternal()
@@ -233,11 +234,13 @@ void DLangCodeContainer::produceInternal()
     tab(n, *fOut);
 }
 
-string DLangCodeContainer::dModuleName(string fKlassName)
+string DLangCodeContainer::dModuleName(const string& klassName)
 {
-    string moduleName = fKlassName;
+    string moduleName = klassName;
     transform(moduleName.begin(), moduleName.end(), moduleName.begin(), ::tolower);
-    return gGlobal->gNameSpace + moduleName;
+    if (gGlobal->gNameSpace != "")
+        moduleName = gGlobal->gNameSpace + "." + moduleName;
+    return moduleName;
 }
 
 void DLangCodeContainer::produceClass()

--- a/compiler/generator/dlang/dlang_code_container.hh
+++ b/compiler/generator/dlang/dlang_code_container.hh
@@ -65,6 +65,9 @@ class DLangCodeContainer : public virtual CodeContainer {
 
     virtual void printHeader();
 
+    static void printDRecipeComment(ostream& dst, const string& klassName);
+    static void printDModuleStmt(ostream& dst, const string& klassName);
+
 
     CodeContainer* createScalarContainer(const string& name, int sub_container_type);
 

--- a/compiler/generator/dlang/dlang_code_container.hh
+++ b/compiler/generator/dlang/dlang_code_container.hh
@@ -59,7 +59,7 @@ class DLangCodeContainer : public virtual CodeContainer {
     virtual void produceInternal();
   
     void generateImports(int tab);
-    string dModuleName(string fKlassName);
+    static string dModuleName(const string& klassName);
 
     virtual dsp_factory_base* produceFactory();
 

--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -1561,8 +1561,10 @@ static void generateCode(Tree signals, int numInputs, int numOutputs, bool gener
                 if (gGlobal->gNameSpace != "" && gGlobal->gOutputLang == "cpp")
                     *dst.get() << "namespace " << gGlobal->gNameSpace << " {" << endl;
 #ifdef DLANG_BUILD
-                else if (gGlobal->gOutputLang == "dlang")
-                    *dst.get() << "module " << DLangCodeContainer::dModuleName(container->getClassName()) << ";" << endl;
+                else if (gGlobal->gOutputLang == "dlang") {
+                    DLangCodeContainer::printDRecipeComment(*dst.get(), container->getClassName());
+                    DLangCodeContainer::printDModuleStmt(*dst.get(), container->getClassName());
+                }
 #endif
 
                 // Possibly inject code


### PR DESCRIPTION
This implements the flag `-ns` in dlang.
The behavior is that if the option is `-ns foo`, then the module is `foo.mydsp`.

This matches to a file named `foo/mydsp.d` in D's search path for imports; since D's file paths and module naming have to match, having this option is important.

It's slightly different from the bit of implementation present before, which wouldn't introduce the `.` character, but I thought it made more consistency with the cpp one.

Implements also the special case depending whether an architecture file is used or not.