### PR TITLE
Convenience for makefile custom settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ windows/*.user
 *.opensdf
 *.sdf
 compiler/faust
+user.mk
 ### VSCode cache
 .*.VC.db
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ version := 2.30.3
 
 system	?= $(shell uname -s)
 
+-include user.mk
 DESTDIR ?=
 PREFIX ?= /usr/local
 INSTALL_LIBDIR ?= lib


### PR DESCRIPTION
Add a convenience for the `make` system, that allows to keep some persistent custom settings in a side file, which is ignored by git versioning.

As an example of `user.mk` file:
`PREFIX = /opt/faust`
