### PR TITLE
Soundfile corrections

### DIFF
--- a/architecture/faust/gui/Soundfile.h
+++ b/architecture/faust/gui/Soundfile.h
@@ -32,7 +32,7 @@
 #define FAUSTFLOAT float
 #endif
 
-#define BUFFER_SIZE 16384
+#define BUFFER_SIZE 1024
 #define SAMPLE_RATE 44100
 #define MAX_CHAN 64
 #define MAX_SOUNDFILE_PARTS 256

--- a/architecture/faust/gui/Soundfile.h
+++ b/architecture/faust/gui/Soundfile.h
@@ -25,7 +25,6 @@
 #ifndef __Soundfile__
 #define __Soundfile__
 
-#include <iostream>
 #include <string.h>
 #include <vector>
 


### PR DESCRIPTION
To clarify, only the first commit is required to use soundfiles on OWL.

The second one is changed to match documented empty buffer size. It's not required for OWL integration, because I've made a slightly simpler replacement for SoundfileReader class (not using exceptions or stdlib classes). I've also changed that custom class to use empty buffers with 0 samples and it works AFAICT. So we'll probably stick to this behavior unless there would be some known use case where allocating buffers would be required.