### PR TITLE
Compute just right, signal graph annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ zname := faust-$(version)
 # The main targets
 
 compiler : updatesubmodules
-	$(MAKE) -C $(BUILDLOCATION) cmake BACKENDS=regular.cmake TARGETS=regular.cmake CMAKEOPT=-DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+	$(MAKE) -C $(BUILDLOCATION) cmake BACKENDS=regular.cmake TARGETS=regular.cmake
 	$(MAKE) -C $(BUILDLOCATION)
 
 most : updatesubmodules
@@ -127,7 +127,7 @@ help :
 	@echo 
 	@echo "Other targets"
 	@echo " 'debug'         : similar to 'all' target but with debug info. Output is in $(BUILDLOCATION)/$(DEBUGFOLDER)"
-	@echo " 'wasm'          : builds the Faust WebAssembly libraries"
+ 	@echo " 'wasm'          : builds the Faust WebAssembly libraries"
 	@echo " 'benchmark'     : builds the benchmark tools (see tools/benchmark)"
 	@echo " 'remote'        : builds the libfaustremote.a library and the Faust RemoteServer"
 	@echo " 'sound2faust'   : builds the sound2faust utilities (requires libsndfile)"

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ help :
 	@echo 
 	@echo "Other targets"
 	@echo " 'debug'         : similar to 'all' target but with debug info. Output is in $(BUILDLOCATION)/$(DEBUGFOLDER)"
- 	@echo " 'wasm'          : builds the Faust WebAssembly libraries"
+	@echo " 'wasm'          : builds the Faust WebAssembly libraries"
 	@echo " 'benchmark'     : builds the benchmark tools (see tools/benchmark)"
 	@echo " 'remote'        : builds the libfaustremote.a library and the Faust RemoteServer"
 	@echo " 'sound2faust'   : builds the sound2faust utilities (requires libsndfile)"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ zname := faust-$(version)
 # The main targets
 
 compiler : updatesubmodules
-	$(MAKE) -C $(BUILDLOCATION) cmake BACKENDS=regular.cmake TARGETS=regular.cmake
+	$(MAKE) -C $(BUILDLOCATION) cmake BACKENDS=regular.cmake TARGETS=regular.cmake CMAKEOPT=-DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 	$(MAKE) -C $(BUILDLOCATION)
 
 most : updatesubmodules

--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -142,7 +142,7 @@ stringstream commonAttr(Type t)
 static string edgeattr(Type t)
 {
     stringstream fout(commonAttr(t));
-    fout << " label =\"" << t->getInterval() << ", " << t->getLsb() << "\"";
+    fout << " label =\"" << t->getInterval() << ", " << t->getRes() << "\"";
     return fout.str();
 }
 

--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -52,11 +52,14 @@ void sigToGraph(Tree L, ofstream& fout)
          << "    rankdir=LR; node [fontsize=10];" << endl;
     int out = 0;
     while (isList(L)) {
+        Type ty(getCertifiedSigType(hd(L)));
         recdraw(hd(L), alreadyDrawn, fout);
 
         fout << "OUTPUT_" << out << "[color=\"red2\" style=\"filled\" fillcolor=\"pink\"];" << endl;
         fout << 'S' << hd(L) << " -> "
-             << "OUTPUT_" << out++ << "[" << edgeattr(getCertifiedSigType(hd(L))) << "];" << endl;
+             << "OUTPUT_" << out++ << "[" << edgeattr(ty)
+             << " label=\"" << ty->getInterval() << "," << ty->getLsb() << "\""
+             << "];" << endl;
         L = tl(L);
     }
 
@@ -107,9 +110,8 @@ static void recdraw(Tree sig, set<Tree>& drawn, ofstream& fout)
                 }
 
                 for (int i = 0; i < n; i++) {
-                    Type ty;
+                    Type ty(getCertifiedSigType(subsig[i]));
                     recdraw(subsig[i], drawn, fout);
-                    ty = getCertifiedSigType(subsig[i]);
                     fout << 'S' << subsig[i] << " -> " << 'S' << sig << "[" << edgeattr(ty) << " label=\""
                          << ty->getInterval() << "," << ty->getLsb() << "\"" 
                          << "];" << endl;

--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -111,7 +111,7 @@ static void recdraw(Tree sig, set<Tree>& drawn, ofstream& fout)
                     recdraw(subsig[i], drawn, fout);
                     ty = getCertifiedSigType(subsig[i]);
                     fout << 'S' << subsig[i] << " -> " << 'S' << sig << "[" << edgeattr(ty) << " label=\""
-                         << ty->getInterval() << "\""
+                         << ty->getInterval() << "," << ty->getLsb() << "\"" 
                          << "];" << endl;
                 }
             }

--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -108,14 +108,14 @@ static void recdraw(Tree sig, set<Tree>& drawn, ofstream& fout)
 
                 for (int i = 0; i < n; i++) {
                     recdraw(subsig[i], drawn, fout);
-                    fout << 'S' << subsig[i] << " -> " << 'S' << sig << "[" << edgeattr(getCertifiedSigType(subsig[i])) << "]" << endl;
+                    fout << 'S' << subsig[i] << " -> " << 'S' << sig << "[" << edgeattr(getCertifiedSigType(subsig[i]))
+                         << "]" << endl;
                 }
             }
         }
     }
     // cerr << --gGlobal->TABBER << "EXIT REC DRAW OF " << sig << endl;
 }
-
 
 stringstream commonAttr(Type t)
 {
@@ -126,7 +126,6 @@ stringstream commonAttr(Type t)
     } else {
         fout << " color=\"red\"";
     }
-
     // vectorability
     if (t->vectorability() == kVect && t->variability() == kSamp) {
         fout << " style=\"bold\"";
@@ -137,7 +136,6 @@ stringstream commonAttr(Type t)
 /**
  * Convert a signal type into edge attributes
  */
-
 
 static string edgeattr(Type t)
 {

--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -45,7 +45,7 @@ static string sigLabel(Tree sig);
  * Draw a list of signals as a directed graph using graphviz's dot language
  */
 void sigToGraph(Tree L, ofstream& fout)
-{
+{ 
     set<Tree> alreadyDrawn;
 
     fout << "strict digraph loopgraph {\n"
@@ -107,8 +107,11 @@ static void recdraw(Tree sig, set<Tree>& drawn, ofstream& fout)
                 }
 
                 for (int i = 0; i < n; i++) {
+                    Type ty;
                     recdraw(subsig[i], drawn, fout);
-                    fout << 'S' << subsig[i] << " -> " << 'S' << sig << "[" << edgeattr(getCertifiedSigType(subsig[i]))
+                    ty = getCertifiedSigType(subsig[i]);
+                    fout << 'S' << subsig[i] << " -> " << 'S' << sig << "[" << edgeattr(ty) << " label=\""
+                         << ty->getInterval() << "\""
                          << "];" << endl;
                 }
             }

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -491,7 +491,7 @@ void global::init()
 
     // empty Predefined bit depth
 
-    BD = bDepth();
+    RES = res();
     
     // Predefined symbols CONS and NIL
     CONS = symbol("cons");

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -482,7 +482,7 @@ void global::init()
     TEXEC = makeSimpleType(kInt, kKonst, kExec, kVect, kNum, interval());
 
     // More predefined types
-    TINPUT   = makeSimpleType(kReal, kSamp, kExec, kVect, kNum, interval(), bDepth(24));
+    TINPUT   = makeSimpleType(kReal, kSamp, kExec, kVect, kNum, interval());
     TGUI     = makeSimpleType(kReal, kBlock, kExec, kVect, kNum, interval());
     TGUI01   = makeSimpleType(kReal, kBlock, kExec, kVect, kNum, interval(0, 1));
     INT_TGUI = makeSimpleType(kInt, kBlock, kExec, kVect, kNum, interval());

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -487,7 +487,7 @@ void global::init()
     TGUI01   = makeSimpleType(kReal, kBlock, kExec, kVect, kNum, interval(0, 1));
     INT_TGUI = makeSimpleType(kInt, kBlock, kExec, kVect, kNum, interval());
 
-    TREC = makeSimpleType(kInt, kSamp, kInit, kScal, kNum, interval());
+    TREC = makeSimpleType(kInt, kSamp, kInit, kScal, kNum, interval(0,0));
 
     // empty Predefined bit depth
 

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -482,13 +482,17 @@ void global::init()
     TEXEC = makeSimpleType(kInt, kKonst, kExec, kVect, kNum, interval());
 
     // More predefined types
-    TINPUT   = makeSimpleType(kReal, kSamp, kExec, kVect, kNum, interval());
+    TINPUT   = makeSimpleType(kReal, kSamp, kExec, kVect, kNum, interval(), bDepth(24));
     TGUI     = makeSimpleType(kReal, kBlock, kExec, kVect, kNum, interval());
     TGUI01   = makeSimpleType(kReal, kBlock, kExec, kVect, kNum, interval(0, 1));
     INT_TGUI = makeSimpleType(kInt, kBlock, kExec, kVect, kNum, interval());
 
     TREC = makeSimpleType(kInt, kSamp, kInit, kScal, kNum, interval());
 
+    // empty Predefined bit depth
+
+    BD = bDepth();
+    
     // Predefined symbols CONS and NIL
     CONS = symbol("cons");
     NIL  = symbol("nil");

--- a/compiler/global.hh
+++ b/compiler/global.hh
@@ -422,6 +422,8 @@ struct global {
     // Trying to accelerate type convergence
     Type TREC;  // kVect ou kScal ?
 
+    bDepth BD;
+    
     Sym  CONS;
     Sym  NIL;
     Tree nil;

--- a/compiler/global.hh
+++ b/compiler/global.hh
@@ -422,7 +422,7 @@ struct global {
     // Trying to accelerate type convergence
     Type TREC;  // kVect ou kScal ?
 
-    bDepth BD;
+    res RES;
     
     Sym  CONS;
     Sym  NIL;

--- a/compiler/signals/interval.hh
+++ b/compiler/signals/interval.hh
@@ -315,4 +315,22 @@ inline interval abs(const interval& x)
     }
 }
 
+
+struct bDepth : public virtual Garbageable {
+    bool valid; ///< true if it is a valid bit depth
+    int  index;   ///< the index of the lsb, if any
+
+    bDepth(): valid(false), index(0){}
+    bDepth(int i): valid(true), index(i){}
+};
+
+inline ostream& operator<<(ostream& dst, const bDepth& bd)
+{
+    if (bd.valid) {
+        return dst << "lsb(" << bd.index << ")";
+    } else {
+        return dst << "lsb(?)";
+    }
+}
+
 #endif

--- a/compiler/signals/interval.hh
+++ b/compiler/signals/interval.hh
@@ -315,20 +315,19 @@ inline interval abs(const interval& x)
     }
 }
 
-
 /**
  * @struct res
- * 
- *
- *
+ * the fixed-point resolution of the signal
+ * i.e. the index of the least significant bit of the fixed-point representation of the signal.
+ * which is a _relative_ number.
  */
 
 struct res : public virtual Garbageable {
-    bool valid; ///< true if it is a valid bit depth
-    int  index;   ///< the index of the lsb, if any
+    bool valid;  ///< true if a resolution has indeed been compiled
+    int  index;  ///< the index of the lsb, if any
 
-    res(): valid(false), index(0){}
-    res(int i): valid(true), index(i){}
+    res() : valid(false), index(0) {}
+    res(int i) : valid(true), index(i) {}
 };
 
 inline ostream& operator<<(ostream& dst, const res& r)

--- a/compiler/signals/interval.hh
+++ b/compiler/signals/interval.hh
@@ -99,9 +99,9 @@ struct interval : public virtual Garbageable {
 inline ostream& operator<<(ostream& dst, const interval& i)
 {
     if (i.valid) {
-        return dst << "interval(" << i.lo << ", " << i.hi << ")";
+        return dst << "[" << i.lo << ", " << i.hi << "]";
     } else {
-        return dst << "interval()";
+        return dst << "[-inf; +inf]";
     }
 }
 
@@ -316,20 +316,27 @@ inline interval abs(const interval& x)
 }
 
 
-struct bDepth : public virtual Garbageable {
+/**
+ * @struct res
+ * 
+ *
+ *
+ */
+
+struct res : public virtual Garbageable {
     bool valid; ///< true if it is a valid bit depth
     int  index;   ///< the index of the lsb, if any
 
-    bDepth(): valid(false), index(0){}
-    bDepth(int i): valid(true), index(i){}
+    res(): valid(false), index(0){}
+    res(int i): valid(true), index(i){}
 };
 
-inline ostream& operator<<(ostream& dst, const bDepth& bd)
+inline ostream& operator<<(ostream& dst, const res& r)
 {
-    if (bd.valid) {
-        return dst << "lsb(" << bd.index << ")";
+    if (r.valid) {
+        return dst << "r(" << r.index << ")";
     } else {
-        return dst << "lsb(?)";
+        return dst << "r(?)";
     }
 }
 

--- a/compiler/signals/sigtype.cpp
+++ b/compiler/signals/sigtype.cpp
@@ -366,16 +366,16 @@ static Tree codeSimpleType(SimpleType* st)
     elems.push_back(tree(st->getInterval().lo));
     elems.push_back(tree(st->getInterval().hi));
 
-    elems.push_back(tree(st->getLsb().valid));
-    elems.push_back(tree(st->getLsb().index));
+    elems.push_back(tree(st->getRes().valid));
+    elems.push_back(tree(st->getRes().index));
     return CTree::make(gGlobal->SIMPLETYPE, elems);
 }
 
 AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i){
-    return makeSimpleType(n, v, c, vec, b, i, gGlobal->BD);
+    return makeSimpleType(n, v, c, vec, b, i, gGlobal->RES);
 }
 
-AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i, const bDepth& lsb)
+AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i, const res& lsb)
 {
     SimpleType prototype(n, v, c, vec, b, i, lsb);
     Tree       code = codeAudioType(&prototype);

--- a/compiler/signals/sigtype.cpp
+++ b/compiler/signals/sigtype.cpp
@@ -366,12 +366,18 @@ static Tree codeSimpleType(SimpleType* st)
     elems.push_back(tree(st->getInterval().lo));
     elems.push_back(tree(st->getInterval().hi));
 
+    elems.push_back(tree(st->getLsb().valid));
+    elems.push_back(tree(st->getLsb().index));
     return CTree::make(gGlobal->SIMPLETYPE, elems);
 }
 
-AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i)
+AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i){
+    return makeSimpleType(n, v, c, vec, b, i, gGlobal->BD);
+}
+
+AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i, const bDepth& lsb)
 {
-    SimpleType prototype(n, v, c, vec, b, i);
+    SimpleType prototype(n, v, c, vec, b, i, lsb);
     Tree       code = codeAudioType(&prototype);
 
     AudioType* t;
@@ -379,7 +385,7 @@ AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i
         return t;
     } else {
         gGlobal->gAllocationCount++;
-        t = new SimpleType(n, v, c, vec, b, i);
+        t = new SimpleType(n, v, c, vec, b, i, lsb);
         gGlobal->gMemoizedTypes->set(code, t);
         t->setCode(code);
         return t;

--- a/compiler/signals/sigtype.hh
+++ b/compiler/signals/sigtype.hh
@@ -94,12 +94,12 @@ class AudioType : public virtual Garbageable {
     int fBoolean;        ///< when a signal stands for a boolean value
 
     interval fInterval;  ///< Minimal and maximal values the signal can take
-    bDepth   fLsb;       ///< Least Significant Bit (fixed-point)
+    res   fRes;       ///< Resolution (fixed-point)
     Tree     fCode;      ///< Tree representation (for memoization purposes)
 
    public:
-    AudioType(int n, int v, int c, int vec = kVect, int b = kNum, interval i = interval(), bDepth fLsb = bDepth())
-        : fNature(n), fVariability(v), fComputability(c), fVectorability(vec), fBoolean(b), fInterval(i), fLsb(fLsb), fCode(0)
+    AudioType(int n, int v, int c, int vec = kVect, int b = kNum, interval i = interval(), res r = res())
+        : fNature(n), fVariability(v), fComputability(c), fVectorability(vec), fBoolean(b), fInterval(i), fRes(r), fCode(0)
     {
     }                        ///< constructs an abstract audio type
     virtual ~AudioType() {}  ///< not really useful here, but make compiler happier
@@ -117,7 +117,7 @@ class AudioType : public virtual Garbageable {
     int boolean() const { return fBoolean; }              ///< returns when a signal stands for a boolean value
 
     interval getInterval() const { return fInterval; }  ///< returns the interval (min dn max values) of a signal
-    bDepth getLsb() const { return fLsb; } ///< return the Least Significant Bit of the signal (fixed)
+    res getRes() const { return fRes; } ///< return the resolution of the signal (fixed)
     
     void setCode(Tree code) { fCode = code; }  ///< returns the interval (min dn max values) of a signal
     Tree getCode() { return fCode; }           ///< returns the interval (min dn max values) of a signal
@@ -218,7 +218,7 @@ inline interval mergeinterval(const vector<Type>& v)
 }
 
 AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i);
-AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i, const bDepth& lsb);
+AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i, const res& lsb);
 //didn't use a default arg, would have created a cyclic dependancy with global.hh
 
 AudioType* makeTableType(const Type& ct);
@@ -236,7 +236,7 @@ AudioType* makeTupletType(const vector<Type>& vt, int n, int v, int c, int vec, 
  */
 class SimpleType : public AudioType {
    public:
-    SimpleType(int n, int v, int c, int vec, int b, const interval& i, const bDepth& lsb) : AudioType(n, v, c, vec, b, i, lsb)
+    SimpleType(int n, int v, int c, int vec, int b, const interval& i, const res& lsb) : AudioType(n, v, c, vec, b, i, lsb)
     {
         // cerr << "new simple type " << i << " -> " << *this << endl;
     }  ///< constructs a SimpleType from a nature a variability and a computability

--- a/compiler/signals/sigtype.hh
+++ b/compiler/signals/sigtype.hh
@@ -94,11 +94,12 @@ class AudioType : public virtual Garbageable {
     int fBoolean;        ///< when a signal stands for a boolean value
 
     interval fInterval;  ///< Minimal and maximal values the signal can take
+    bDepth   fLsb;       ///< Least Significant Bit (fixed-point)
     Tree     fCode;      ///< Tree representation (for memoization purposes)
 
    public:
-    AudioType(int n, int v, int c, int vec = kVect, int b = kNum, interval i = interval())
-        : fNature(n), fVariability(v), fComputability(c), fVectorability(vec), fBoolean(b), fInterval(i), fCode(0)
+    AudioType(int n, int v, int c, int vec = kVect, int b = kNum, interval i = interval(), bDepth fLsb = bDepth())
+        : fNature(n), fVariability(v), fComputability(c), fVectorability(vec), fBoolean(b), fInterval(i), fLsb(fLsb), fCode(0)
     {
     }                        ///< constructs an abstract audio type
     virtual ~AudioType() {}  ///< not really useful here, but make compiler happier
@@ -116,7 +117,8 @@ class AudioType : public virtual Garbageable {
     int boolean() const { return fBoolean; }              ///< returns when a signal stands for a boolean value
 
     interval getInterval() const { return fInterval; }  ///< returns the interval (min dn max values) of a signal
-
+    bDepth getLsb() const { return fLsb; } ///< return the Least Significant Bit of the signal (fixed)
+    
     void setCode(Tree code) { fCode = code; }  ///< returns the interval (min dn max values) of a signal
     Tree getCode() { return fCode; }           ///< returns the interval (min dn max values) of a signal
 
@@ -216,6 +218,8 @@ inline interval mergeinterval(const vector<Type>& v)
 }
 
 AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i);
+AudioType* makeSimpleType(int n, int v, int c, int vec, int b, const interval& i, const bDepth& lsb);
+//didn't use a default arg, would have created a cyclic dependancy with global.hh
 
 AudioType* makeTableType(const Type& ct);
 AudioType* makeTableType(const Type& ct, int n, int v, int c, int vec);
@@ -232,7 +236,7 @@ AudioType* makeTupletType(const vector<Type>& vt, int n, int v, int c, int vec, 
  */
 class SimpleType : public AudioType {
    public:
-    SimpleType(int n, int v, int c, int vec, int b, const interval& i) : AudioType(n, v, c, vec, b, i)
+    SimpleType(int n, int v, int c, int vec, int b, const interval& i, const bDepth& lsb) : AudioType(n, v, c, vec, b, i, lsb)
     {
         // cerr << "new simple type " << i << " -> " << *this << endl;
     }  ///< constructs a SimpleType from a nature a variability and a computability

--- a/compiler/signals/sigtyperules.cpp
+++ b/compiler/signals/sigtyperules.cpp
@@ -83,11 +83,13 @@ void typeAnnotation(Tree sig, bool causality)
     gGlobal->gCausality = causality;
     Tree sl             = symlist(sig);
     int  n              = len(sl);
-
+    int  itnum          = 12;  //<<< maximal number of iterations for program analysis
+    bool finished = false;
+    
     vector<Tree> vrec, vdef;
     vector<Type> vtype;
 
-    // cerr << "Symlist " << *sl << endl;
+    cerr << "Symlist " << *sl << endl;
     for (Tree l = sl; isList(l); l = tl(l)) {
         Tree id, body;
         faustassert(isRec(hd(l), id, body));
@@ -107,8 +109,8 @@ void typeAnnotation(Tree sig, bool causality)
     faustassert(int(vdef.size()) == n);
     faustassert(int(vtype.size()) == n);
 
-    // cerr << "find least fixpoint" << endl;
-    for (bool finished = false; !finished;) {
+    cerr << "find least fixpoint" << endl;
+    for (int i = 0; !finished && i < itnum; i++) {
         // init recursive types
         CTree::startNewVisit();
         for (int i = 0; i < n; i++) {
@@ -124,9 +126,16 @@ void typeAnnotation(Tree sig, bool causality)
         // check finished
         finished = true;
         for (int i = 0; i < n; i++) {
-            // cerr << i << "-" << *vrec[i] << ":" << *getSigType(vrec[i]) << " => " << *vtype[i] << endl;
+            cerr << i << "-" << *vrec[i] << ":" << *getSigType(vrec[i]) << " => " << *vtype[i] << endl;
             finished = finished && (getSigType(vrec[i]) == vtype[i]);
         }
+    }
+
+    for (int i=0; i < n; i++){
+        if (getSigType(vrec[i]) != vtype[i]){
+            cerr << i << "-" << *vrec[i] << ":" << *getSigType(vrec[i]) << " != " << *vtype[i] << " FAILURE" << endl;
+            faustassert(1==2);
+        }    
     }
 
     // type full term


### PR DESCRIPTION
Add annotations for each signal of the signal graph (generated with `-sg`) and a new field the types to handle the fixed-point resolution of the signals.