### PR TITLE
use strings when printing intervals and resolution

### DIFF
--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -117,20 +117,20 @@ static void recdraw(Tree sig, set<Tree>& drawn, ofstream& fout)
     // cerr << --gGlobal->TABBER << "EXIT REC DRAW OF " << sig << endl;
 }
 
-stringstream commonAttr(Type t)
+string commonAttr(Type t)
 {
-    stringstream fout;
+    string sout;
     // nature
     if (t->nature() == kInt) {
-        fout << " color=\"blue\"";
+        sout += " color=\"blue\"";
     } else {
-        fout << " color=\"red\"";
+        sout += " color=\"red\"";
     }
     // vectorability
     if (t->vectorability() == kVect && t->variability() == kSamp) {
-        fout << " style=\"bold\"";
+        sout += " style=\"bold\"";
     }
-    return fout;
+    return sout;
 }
 
 /**
@@ -139,9 +139,13 @@ stringstream commonAttr(Type t)
 
 static string edgeattr(Type t)
 {
-    stringstream fout(commonAttr(t));
-    fout << " label =\"" << t->getInterval() << ", " << t->getRes() << "\"";
-    return fout.str();
+    string sout(commonAttr(t));
+    sout += " label =\"";
+    sout += t->getInterval().toString();
+    sout += ", ";
+    sout += t->getRes().toString();
+    sout += "\"";
+    return sout;
 }
 
 /**
@@ -149,17 +153,17 @@ static string edgeattr(Type t)
  */
 static string nodeattr(Type t)
 {
-    stringstream fout(commonAttr(t));
+    string sout(commonAttr(t));
 
     // variability
     if (t->variability() == kKonst) {
-        fout << " shape=\"box\"";
+        sout += " shape=\"box\"";
     } else if (t->variability() == kBlock) {
-        fout << " shape=\"hexagon\"";
+        sout += " shape=\"hexagon\"";
     } else if (t->variability() == kSamp) {
-        fout << " shape=\"ellipse\"";
+        sout += " shape=\"ellipse\"";
     }
-    return fout.str();
+    return sout;
 }
 
 /**

--- a/compiler/signals/interval.hh
+++ b/compiler/signals/interval.hh
@@ -94,15 +94,31 @@ struct interval : public virtual Garbageable {
         return isconst() && ((n & (-n)) == n);
     }
     bool haszero() { return (lo <= 0) && (0 <= hi); }
+
+    
+    /**
+     * @brief pretty print an interval (string version)
+     * @details usage of stringsteams seems problematic for old versions of gcc
+     * @return a string representing the interval if valid, ??? otherwise
+     */
+    string toString() const
+    {
+        string sout = ("[");
+        if (valid) {
+            sout += to_string(lo);
+            sout += ", ";
+            sout += to_string(hi);
+        } else {
+            sout += "???";
+        }
+        sout += "]";
+        return sout;
+    }
 };
 
 inline ostream& operator<<(ostream& dst, const interval& i)
 {
-    if (i.valid) {
-        return dst << "[" << i.lo << ", " << i.hi << "]";
-    } else {
-        return dst << "[-inf; +inf]";
-    }
+    return dst << i.toString();
 }
 
 inline interval reunion(const interval& x, const interval& y)
@@ -328,15 +344,20 @@ struct res : public virtual Garbageable {
 
     res() : valid(false), index(0) {}
     res(int i) : valid(true), index(i) {}
+
+    string toString() const
+    {
+        string sout;
+        sout += "r(";
+        sout += valid ? to_string(index) : "???";
+        sout += ")";
+        return sout;
+    }
 };
 
 inline ostream& operator<<(ostream& dst, const res& r)
 {
-    if (r.valid) {
-        return dst << "r(" << r.index << ")";
-    } else {
-        return dst << "r(?)";
-    }
+    return dst << r.toString();
 }
 
 #endif


### PR DESCRIPTION
should avoid Return Value Optimization bug with old versions of g++