### PR TITLE
Add header gards to JuceGUI.h

### DIFF
--- a/architecture/faust/gui/JuceGUI.h
+++ b/architecture/faust/gui/JuceGUI.h
@@ -22,6 +22,9 @@
  architecture section is not modified.
  ************************************************************************/
 
+#ifndef JUCE_GUI_H
+#define JUCE_GUI_H
+
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
 #endif
@@ -2050,4 +2053,6 @@ class JuceGUI : public GUI, public MetaDataUI, public juce::Component
         }
     
 };
+
+#endif
 /**************************  END  JuceGUI.h **************************/


### PR DESCRIPTION
Other header files feature guards, so I doubt the omission was voluntary.