### PR TITLE
Faust2juce fixes (mainly for Windows)

### DIFF
--- a/architecture/juce/README.md
+++ b/architecture/juce/README.md
@@ -24,7 +24,7 @@ Two different achitecture files will be used to glue the previously described fi
 
 **faust2juce** is used with the following command: 
 
-`faust2juce [-osc] [-midi] [-soundfile] [-nvoices <num>] [-effect auto|<effect.dsp>] [-standalone] [-jucemodulesdir <dir>] [-jsynth] [-llvm] [additional Faust options (-vec -vs 8...)] file.dsp` 
+`faust2juce [-osc] [-midi] [-soundfile] [-nvoices <num>] [-effect auto|<effect.dsp>] [-standalone] [-jucemodulesdir <dir>] [-vst2sdkdir <dir>] [-disable-splash-screen] [-jsynth] [-llvm] [additional Faust options (-vec -vs 8...)] file.dsp` 
 
 By default it will create a plugin project, with a folder named with the dsp file name, containing a .jucer project with a FaustPluginProcessor.cpp file to be used by JUCE.
 
@@ -44,6 +44,8 @@ Here are the available options:
 - `-effect auto` : to produce a polyphonic DSP connected to a global output effect defined as 'effect' in <file.dsp>, ready to be used with MIDI or OSC 
 - `-standalone` : to produce a standalone project, otherwise a plugin project is generated
 - `-jucemodulesdir <folder>` : to set JUCE modules directory to `<folder>`, such as ~/JUCE/modules
+- `-vst2sdkdir <folder>` : to set VST 2 Legacy Directory to `<folder>`. This is the directory that contains "plugininterfaces/vst2.x/aeffect.h".
+- `-disable-splash-screen` : to disable the JUCE splash screen (license is required).
 - `-jsynth` : to use JUCE polyphonic Synthesizer instead of Faust polyphonic code
 - `-llvm` : to use the LLVM compilation chain (OSX and Linux for now)
 - `-help or -h` : shows the different options 

--- a/architecture/juce/plugin/plugin-llvm.jucer
+++ b/architecture/juce/plugin/plugin-llvm.jucer
@@ -2,14 +2,16 @@
 
 <JUCERPROJECT id="L9dULy" name="APPL_NAME" projectType="audioplug" version="1.0.0"
               bundleIdentifier="com.grame.APPL_NAME" includeBinaryInAppConfig="1"
-              buildVST="1" buildVST3="0" buildAU="1" buildAUv3="1" buildRTAS="0"
-              buildAAX="0" buildStandalone="1" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
+              buildVST="BUILD_VST2_DEFAULT" buildVST3="1" buildAU="1" buildAUv3="1" buildRTAS="0"
+              buildAAX="0" buildStandalone="0" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
               pluginManufacturer="GRAME" pluginManufacturerCode="Manu" pluginCode="SUB_TYPE"
               pluginChannelConfigs="" pluginIsSynth="IS_SYNTH" pluginWantsMidiIn="IS_MIDI"
               pluginProducesMidiOut="IS_MIDI" pluginIsMidiEffectPlugin="0"
               pluginEditorRequiresKeys="0" pluginAUExportPrefix="APPL_NAMEAU"
-              pluginRTASCategory="" aaxIdentifier="com.grame.APPL_NAME" pluginAAXCategory="AAX_ePlugInCategory_Dynamics"
-              jucerVersion="4.3.1">
+              pluginRTASCategory="" aaxIdentifier="com.grame.APPL_NAME" pluginAAXCategory="2"
+              pluginFormats="PLUGIN_FORMATS_DEFAULT"
+              displaySplashScreen="DISPLAY_SPLASH_SCREEN_DEFAULT" jucerFormatVersion="1" enableIAA="0"
+              pluginCharacteristicsValue="PLUGIN_CHARACTERISTICS_DEFAULT">
   <MAINGROUP id="DIThxi" name="APPL_NAME">
     <GROUP id="{3EA8B881-7A5A-9E29-6E83-82528C15E424}" name="Source">
       <FILE id="BecAMR" name="FaustPluginProcessor.cpp" compile="1" resource="0"
@@ -18,7 +20,7 @@
   </MAINGROUP>
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT"
-               extraDefs="PreProcDef" extraLinkerFlags="../../dynamic.o">
+               extraDefs="PreProcDef" vstLegacyFolder="VST2_SDK_DEFAULT" extraLinkerFlags="../../dynamic.o">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
@@ -40,7 +42,7 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="portraitlandscape"
+    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="UIInterfaceOrientationPortrait,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight"
                   extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -63,7 +65,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef">
+    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef"
+            vstLegacyFolder="VST2_SDK_DEFAULT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -87,7 +90,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </VS2015>
-    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT" extraLinkerFlags="../../dynamic.o">
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT"
+                vstLegacyFolder="VST2_SDK_DEFAULT" extraLinkerFlags="../../dynamic.o">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
@@ -133,6 +137,28 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </ANDROIDSTUDIO>
+    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_osc"/>
+        <MODULEPATH id="juce_opengl"/>
+        <MODULEPATH id="juce_gui_extra"/>
+        <MODULEPATH id="juce_gui_basics"/>
+        <MODULEPATH id="juce_graphics"/>
+        <MODULEPATH id="juce_events"/>
+        <MODULEPATH id="juce_data_structures"/>
+        <MODULEPATH id="juce_core"/>
+        <MODULEPATH id="juce_audio_utils"/>
+        <MODULEPATH id="juce_audio_processors"/>
+        <MODULEPATH id="juce_audio_plugin_client"/>
+        <MODULEPATH id="juce_audio_formats"/>
+        <MODULEPATH id="juce_audio_devices"/>
+        <MODULEPATH id="juce_audio_basics"/>
+      </MODULEPATHS>
+    </VS2019>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0"/>
@@ -151,4 +177,7 @@
     <MODULE id="juce_osc" showAllCode="1" useLocalCopy="0"/>
   </MODULES>
   <JUCEOPTIONS JUCE_QUICKTIME="disabled"/>
+  <LIVE_SETTINGS>
+    <WINDOWS/>
+  </LIVE_SETTINGS>
 </JUCERPROJECT>

--- a/architecture/juce/plugin/plugin-llvm.jucer
+++ b/architecture/juce/plugin/plugin-llvm.jucer
@@ -3,7 +3,7 @@
 <JUCERPROJECT id="L9dULy" name="APPL_NAME" projectType="audioplug" version="1.0.0"
               bundleIdentifier="com.grame.APPL_NAME" includeBinaryInAppConfig="1"
               buildVST="BUILD_VST2_DEFAULT" buildVST3="1" buildAU="1" buildAUv3="1" buildRTAS="0"
-              buildAAX="0" buildStandalone="0" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
+              buildAAX="0" buildStandalone="1" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
               pluginManufacturer="GRAME" pluginManufacturerCode="Manu" pluginCode="SUB_TYPE"
               pluginChannelConfigs="" pluginIsSynth="IS_SYNTH" pluginWantsMidiIn="IS_MIDI"
               pluginProducesMidiOut="IS_MIDI" pluginIsMidiEffectPlugin="0"

--- a/architecture/juce/plugin/plugin-llvm.jucer
+++ b/architecture/juce/plugin/plugin-llvm.jucer
@@ -65,8 +65,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef"
-            vstLegacyFolder="VST2_SDK_DEFAULT">
+    <VS2015 targetFolder="Builds/VisualStudio2015" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -137,7 +137,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </ANDROIDSTUDIO>
-    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT">
+    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>
         <CONFIGURATION isDebug="0" name="Release"/>

--- a/architecture/juce/plugin/plugin.jucer
+++ b/architecture/juce/plugin/plugin.jucer
@@ -3,7 +3,7 @@
 <JUCERPROJECT id="L9dULy" name="APPL_NAME" projectType="audioplug" version="1.0.0"
               bundleIdentifier="com.grame.APPL_NAME" includeBinaryInAppConfig="1"
               buildVST="BUILD_VST2_DEFAULT" buildVST3="1" buildAU="1" buildAUv3="1" buildRTAS="0"
-              buildAAX="0" buildStandalone="0" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
+              buildAAX="0" buildStandalone="1" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
               pluginManufacturer="GRAME" pluginManufacturerCode="Manu" pluginCode="SUB_TYPE"
               pluginChannelConfigs="" pluginIsSynth="IS_SYNTH" pluginWantsMidiIn="IS_MIDI"
               pluginProducesMidiOut="IS_MIDI" pluginIsMidiEffectPlugin="0"

--- a/architecture/juce/plugin/plugin.jucer
+++ b/architecture/juce/plugin/plugin.jucer
@@ -65,8 +65,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef"
-            vstLegacyFolder="VST2_SDK_DEFAULT">
+    <VS2015 targetFolder="Builds/VisualStudio2015" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -137,7 +137,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </ANDROIDSTUDIO>
-    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT">
+    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>
         <CONFIGURATION isDebug="0" name="Release"/>

--- a/architecture/juce/plugin/plugin.jucer
+++ b/architecture/juce/plugin/plugin.jucer
@@ -2,14 +2,16 @@
 
 <JUCERPROJECT id="L9dULy" name="APPL_NAME" projectType="audioplug" version="1.0.0"
               bundleIdentifier="com.grame.APPL_NAME" includeBinaryInAppConfig="1"
-              buildVST="1" buildVST3="0" buildAU="1" buildAUv3="1" buildRTAS="0"
-              buildAAX="0" buildStandalone="1" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
+              buildVST="BUILD_VST2_DEFAULT" buildVST3="1" buildAU="1" buildAUv3="1" buildRTAS="0"
+              buildAAX="0" buildStandalone="0" pluginName="APPL_NAME" pluginDesc="APPL_NAME"
               pluginManufacturer="GRAME" pluginManufacturerCode="Manu" pluginCode="SUB_TYPE"
               pluginChannelConfigs="" pluginIsSynth="IS_SYNTH" pluginWantsMidiIn="IS_MIDI"
               pluginProducesMidiOut="IS_MIDI" pluginIsMidiEffectPlugin="0"
               pluginEditorRequiresKeys="0" pluginAUExportPrefix="APPL_NAMEAU"
-              pluginRTASCategory="" aaxIdentifier="com.grame.APPL_NAME" pluginAAXCategory="AAX_ePlugInCategory_Dynamics"
-              jucerVersion="4.3.1">
+              pluginRTASCategory="" aaxIdentifier="com.grame.APPL_NAME" pluginAAXCategory="2"
+              pluginFormats="PLUGIN_FORMATS_DEFAULT"
+              displaySplashScreen="DISPLAY_SPLASH_SCREEN_DEFAULT" jucerFormatVersion="1" enableIAA="0"
+              pluginCharacteristicsValue="PLUGIN_CHARACTERISTICS_DEFAULT">
   <MAINGROUP id="DIThxi" name="APPL_NAME">
     <GROUP id="{3EA8B881-7A5A-9E29-6E83-82528C15E424}" name="Source">
       <FILE id="BecAMR" name="FaustPluginProcessor.cpp" compile="1" resource="0"
@@ -18,7 +20,7 @@
   </MAINGROUP>
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT"
-               extraDefs="PreProcDef">
+               extraDefs="PreProcDef" vstLegacyFolder="VST2_SDK_DEFAULT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
@@ -40,7 +42,7 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="portraitlandscape"
+    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="UIInterfaceOrientationPortrait,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight"
                   extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -63,7 +65,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef">
+    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef"
+            vstLegacyFolder="VST2_SDK_DEFAULT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -87,7 +90,8 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </VS2015>
-    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT"
+                vstLegacyFolder="VST2_SDK_DEFAULT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
@@ -133,6 +137,28 @@
         <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </ANDROIDSTUDIO>
+    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_osc"/>
+        <MODULEPATH id="juce_opengl"/>
+        <MODULEPATH id="juce_gui_extra"/>
+        <MODULEPATH id="juce_gui_basics"/>
+        <MODULEPATH id="juce_graphics"/>
+        <MODULEPATH id="juce_events"/>
+        <MODULEPATH id="juce_data_structures"/>
+        <MODULEPATH id="juce_core"/>
+        <MODULEPATH id="juce_audio_utils"/>
+        <MODULEPATH id="juce_audio_processors"/>
+        <MODULEPATH id="juce_audio_plugin_client"/>
+        <MODULEPATH id="juce_audio_formats"/>
+        <MODULEPATH id="juce_audio_devices"/>
+        <MODULEPATH id="juce_audio_basics"/>
+      </MODULEPATHS>
+    </VS2019>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0"/>
@@ -151,4 +177,7 @@
     <MODULE id="juce_osc" showAllCode="1" useLocalCopy="0"/>
   </MODULES>
   <JUCEOPTIONS JUCE_QUICKTIME="disabled"/>
+  <LIVE_SETTINGS>
+    <WINDOWS/>
+  </LIVE_SETTINGS>
 </JUCERPROJECT>

--- a/architecture/juce/standalone/standalone-llvm.jucer
+++ b/architecture/juce/standalone/standalone-llvm.jucer
@@ -55,7 +55,8 @@
         <MODULEPATH id="juce_audio_utils" path="../../modules"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef">
+    <VS2015 targetFolder="Builds/VisualStudio2015" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -169,7 +170,8 @@
         <MODULEPATH id="juce_audio_utils" path="../../modules"/>
       </MODULEPATHS>
     </CODEBLOCKS_LINUX>
-    <VS2019 targetFolder="Builds/VisualStudio2019">
+    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>
         <CONFIGURATION isDebug="0" name="Release"/>

--- a/architecture/juce/standalone/standalone-llvm.jucer
+++ b/architecture/juce/standalone/standalone-llvm.jucer
@@ -2,20 +2,20 @@
 
 <JUCERPROJECT id="RhW0aI" name="ProjectTitle" projectType="guiapp" version="1.0.0"
               bundleIdentifier="com.grame.ProjectTitle" includeBinaryInAppConfig="1"
-              jucerVersion="4.3.1" companyName="Grame" companyWebsite="faust.grame.fr">
+              companyName="Grame" companyWebsite="faust.grame.fr" displaySplashScreen="DISPLAY_SPLASH_SCREEN_DEFAULT"
+              jucerFormatVersion="1">
   <MAINGROUP id="QPZtN1" name="ProjectTitle">
     <GROUP id="{9BA54E73-8A9C-DD5D-C876-2C85CD9C7B4F}" name="Source">
-      <FILE id="IFCXRB" name="FaustAudioApplication.cpp" compile="1" resource="0" file="FaustAudioApplication.cpp"/>
+      <FILE id="IFCXRB" name="FaustAudioApplication.cpp" compile="1" resource="0"
+            file="FaustAudioApplication.cpp"/>
     </GROUP>
   </MAINGROUP>
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" extraCompilerFlags="-I /usr/local/include/ -I /opt/local/include -DNVOICES=NUM_VOICES"
                extraDefs="PreProcDef" extraLinkerFlags="-L /opt/local/lib ../../dynamic.o">
       <CONFIGURATIONS>
-        <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"
-                       osxSDK="default" osxCompatibility="default"/>
-        <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"
-                       osxSDK="default" osxCompatibility="default"/>
+        <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
+        <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_core" path="../../modules"/>
@@ -33,7 +33,7 @@
         <MODULEPATH id="juce_audio_utils" path="../../modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="portraitlandscape"
+    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="UIInterfaceOrientationPortrait,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight"
                   extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -78,30 +78,8 @@
         <MODULEPATH id="juce_audio_utils" path="../../modules"/>
       </MODULEPATHS>
     </VS2015>
-    <VS2013 targetFolder="Builds/VisualStudio2013" extraDefs="PreProcDef">
-      <CONFIGURATIONS>
-        <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
-                       isDebug="1" optimisation="1" targetName="APPL_NAME"/>
-        <CONFIGURATION name="Release" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
-                       isDebug="0" optimisation="3" targetName="APPL_NAME"/>
-      </CONFIGURATIONS>
-      <MODULEPATHS>
-        <MODULEPATH id="juce_core" path="../../modules"/>
-        <MODULEPATH id="juce_events" path="../../modules"/>
-        <MODULEPATH id="juce_graphics" path="../../modules"/>
-        <MODULEPATH id="juce_data_structures" path="../../modules"/>
-        <MODULEPATH id="juce_gui_basics" path="../../modules"/>
-        <MODULEPATH id="juce_gui_extra" path="../../modules"/>
-        <MODULEPATH id="juce_opengl" path="../../modules"/>
-        <MODULEPATH id="juce_audio_basics" path="../../modules"/>
-        <MODULEPATH id="juce_audio_devices" path="../../modules"/>
-        <MODULEPATH id="juce_audio_formats" path="../../modules"/>
-        <MODULEPATH id="juce_audio_processors" path="../../modules"/>
-        <MODULEPATH id="juce_osc" path="../../modules"/>
-        <MODULEPATH id="juce_audio_utils" path="../../modules"/>
-      </MODULEPATHS>
-    </VS2013>
-    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES" extraLinkerFlags="../../dynamic.o">
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES"
+                extraLinkerFlags="../../dynamic.o">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
@@ -191,6 +169,27 @@
         <MODULEPATH id="juce_audio_utils" path="../../modules"/>
       </MODULEPATHS>
     </CODEBLOCKS_LINUX>
+    <VS2019 targetFolder="Builds/VisualStudio2019">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_osc"/>
+        <MODULEPATH id="juce_opengl"/>
+        <MODULEPATH id="juce_gui_extra"/>
+        <MODULEPATH id="juce_gui_basics"/>
+        <MODULEPATH id="juce_graphics"/>
+        <MODULEPATH id="juce_events"/>
+        <MODULEPATH id="juce_data_structures"/>
+        <MODULEPATH id="juce_core"/>
+        <MODULEPATH id="juce_audio_utils"/>
+        <MODULEPATH id="juce_audio_processors"/>
+        <MODULEPATH id="juce_audio_formats"/>
+        <MODULEPATH id="juce_audio_devices"/>
+        <MODULEPATH id="juce_audio_basics"/>
+      </MODULEPATHS>
+    </VS2019>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0"/>
@@ -210,5 +209,6 @@
   <JUCEOPTIONS/>
   <LIVE_SETTINGS>
     <OSX systemHeaderPath="" extraCompilerFlags="" extraDLLs=""/>
+    <WINDOWS/>
   </LIVE_SETTINGS>
 </JUCERPROJECT>

--- a/architecture/juce/standalone/standalone.jucer
+++ b/architecture/juce/standalone/standalone.jucer
@@ -55,7 +55,8 @@
         <MODULEPATH id="juce_audio_utils" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <VS2015 targetFolder="Builds/VisualStudio2015" extraDefs="PreProcDef">
+    <VS2015 targetFolder="Builds/VisualStudio2015" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -168,7 +169,8 @@
         <MODULEPATH id="juce_audio_utils" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </CODEBLOCKS_LINUX>
-    <VS2019 targetFolder="Builds/VisualStudio2019">
+    <VS2019 targetFolder="Builds/VisualStudio2019" vstLegacyFolder="VST2_SDK_DEFAULT" extraDefs="PreProcDef"
+            extraCompilerFlags="-DNVOICES=NUM_VOICES -DFAUSTFLOAT=FAUST_FLOAT">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>
         <CONFIGURATION isDebug="0" name="Release"/>

--- a/architecture/juce/standalone/standalone.jucer
+++ b/architecture/juce/standalone/standalone.jucer
@@ -2,20 +2,20 @@
 
 <JUCERPROJECT id="RhW0aI" name="ProjectTitle" projectType="guiapp" version="1.0.0"
               bundleIdentifier="com.grame.ProjectTitle" includeBinaryInAppConfig="1"
-              jucerVersion="4.3.1" companyName="Grame" companyWebsite="faust.grame.fr">
+              companyName="Grame" companyWebsite="faust.grame.fr" displaySplashScreen="DISPLAY_SPLASH_SCREEN_DEFAULT"
+              jucerFormatVersion="1">
   <MAINGROUP id="QPZtN1" name="ProjectTitle">
     <GROUP id="{9BA54E73-8A9C-DD5D-C876-2C85CD9C7B4F}" name="Source">
-      <FILE id="IFCXRB" name="FaustAudioApplication.cpp" compile="1" resource="0" file="FaustAudioApplication.cpp"/>
+      <FILE id="IFCXRB" name="FaustAudioApplication.cpp" compile="1" resource="0"
+            file="FaustAudioApplication.cpp"/>
     </GROUP>
   </MAINGROUP>
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" extraCompilerFlags="-I /usr/local/include/ -I /opt/local/include -DNVOICES=NUM_VOICES"
                extraDefs="PreProcDef" extraLinkerFlags="-L /opt/local/lib">
       <CONFIGURATIONS>
-        <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"
-                       osxSDK="default" osxCompatibility="default"/>
-        <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"
-                       osxSDK="default" osxCompatibility="default"/>
+        <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
+        <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="APPL_NAME"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_core" path="JUCE_MODULES_DIR_DEFAULT"/>
@@ -33,7 +33,7 @@
         <MODULEPATH id="juce_audio_utils" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="portraitlandscape"
+    <XCODE_IPHONE targetFolder="Builds/iOS" iosScreenOrientation="UIInterfaceOrientationPortrait,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight"
                   extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -78,29 +78,6 @@
         <MODULEPATH id="juce_audio_utils" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </VS2015>
-    <VS2013 targetFolder="Builds/VisualStudio2013" extraDefs="PreProcDef">
-      <CONFIGURATIONS>
-        <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
-                       isDebug="1" optimisation="1" targetName="APPL_NAME"/>
-        <CONFIGURATION name="Release" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
-                       isDebug="0" optimisation="3" targetName="APPL_NAME"/>
-      </CONFIGURATIONS>
-      <MODULEPATHS>
-        <MODULEPATH id="juce_core" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_events" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_graphics" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_data_structures" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_gui_basics" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_gui_extra" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_opengl" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_audio_basics" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_audio_devices" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_audio_formats" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_audio_processors" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_osc" path="JUCE_MODULES_DIR_DEFAULT"/>
-        <MODULEPATH id="juce_audio_utils" path="JUCE_MODULES_DIR_DEFAULT"/>
-      </MODULEPATHS>
-    </VS2013>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile" extraDefs="PreProcDef" extraCompilerFlags="-I /usr/local/include/ -DNVOICES=NUM_VOICES">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="APPL_NAME"/>
@@ -191,6 +168,27 @@
         <MODULEPATH id="juce_audio_utils" path="JUCE_MODULES_DIR_DEFAULT"/>
       </MODULEPATHS>
     </CODEBLOCKS_LINUX>
+    <VS2019 targetFolder="Builds/VisualStudio2019">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_osc"/>
+        <MODULEPATH id="juce_opengl"/>
+        <MODULEPATH id="juce_gui_extra"/>
+        <MODULEPATH id="juce_gui_basics"/>
+        <MODULEPATH id="juce_graphics"/>
+        <MODULEPATH id="juce_events"/>
+        <MODULEPATH id="juce_data_structures"/>
+        <MODULEPATH id="juce_core"/>
+        <MODULEPATH id="juce_audio_utils"/>
+        <MODULEPATH id="juce_audio_processors"/>
+        <MODULEPATH id="juce_audio_formats"/>
+        <MODULEPATH id="juce_audio_devices"/>
+        <MODULEPATH id="juce_audio_basics"/>
+      </MODULEPATHS>
+    </VS2019>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0"/>
@@ -210,5 +208,6 @@
   <JUCEOPTIONS/>
   <LIVE_SETTINGS>
     <OSX systemHeaderPath="" extraCompilerFlags="" extraDLLs=""/>
+    <WINDOWS/>
   </LIVE_SETTINGS>
 </JUCERPROJECT>

--- a/tools/faust2appls/README.md
+++ b/tools/faust2appls/README.md
@@ -26,6 +26,8 @@ You can use 'sudo make install' to install them.
 
 * `faust2jaqt <file.dsp>` : create JACK/QT application for each input file
 
+* `faust2juce <file.dsp>` : create JUCE Projucer project for each input file
+
 * `faust2ladspa <file.dsp>` : create a LADSPA plugin for each input file
 
 * `faust2lv2 <file.dsp>` : create an LV2 plugin for each input file

--- a/tools/faust2appls/faust2juce
+++ b/tools/faust2appls/faust2juce
@@ -34,7 +34,7 @@ JUCER=""
 VST2_SDK=""  # The directory containing "plugininterfaces/vst2.x/aeffect.h"
 BUILD_VST2="0"  # By default, don't build VST2
 JUCE_MODULES_DIR="\.\.\/\.\.\/modules"  # By default, the generated folder is supposed to be copied in JUCE/examples folder
-PLUGIN_FORMATS="buildAU,buildAUv3,buildVST3"  # can append "buildStandalone" and "buildVST"
+PLUGIN_FORMATS="buildAU,buildAUv3,buildVST3,buildStandalone"  # can append "buildVST"
 PLUGIN_CHARACTERISTICS=""
 DISPLAY_SPLASH_SCREEN="1"
 
@@ -67,7 +67,6 @@ do
         NVOICES=$1
     elif [ $p = "-standalone" ]; then
         STANDALONE="1"
-        PLUGIN_FORMATS+=",buildstandalone"
     elif [ $p = "-effect" ]; then
         DEF+="POLY2 "
         POLY="POLY2"

--- a/tools/faust2appls/faust2juce
+++ b/tools/faust2appls/faust2juce
@@ -148,8 +148,6 @@ else
     IS_SYNTH="0"
 fi
 
-grep "declare nvoices" $FILES && IS_SYNTH="1" 2>/dev/null
-
 # Set PLUGIN_CHARACTERISTICS, and the order matters.
 if [ $IS_SYNTH = "1" ]; then
     PLUGIN_CHARACTERISTICS+=",pluginIsSynth"

--- a/tools/faust2appls/faust2juce
+++ b/tools/faust2appls/faust2juce
@@ -31,7 +31,12 @@ IS_LLVM="0"
 JUCE_POLY="0"
 FAUSTFLOAT="float"
 JUCER=""
+VST2_SDK=""  # The directory containing "plugininterfaces/vst2.x/aeffect.h"
+BUILD_VST2="0"  # By default, don't build VST2
 JUCE_MODULES_DIR="\.\.\/\.\.\/modules"  # By default, the generated folder is supposed to be copied in JUCE/examples folder
+PLUGIN_FORMATS="buildAU,buildAUv3,buildVST3"  # can append "buildStandalone" and "buildVST"
+PLUGIN_CHARACTERISTICS=""
+DISPLAY_SPLASH_SCREEN="1"
 
 while [ $1 ]
 do
@@ -47,7 +52,9 @@ do
         option "-effect <effect.dsp>"
         option "-effect auto"
         option -standalone "to produce a standalone project, otherwise a plugin project is generated"
+        option -"vst2sdkdir <folder>" "to set directory to VST 2 SDK."
         option -"jucemodulesdir <folder>" "to set JUCE modules directory to <folder>, such as ~/JUCE/modules"
+        option -disable-splash-screen "to disable the JUCE splash screen (license is required)."
         option -jsynth "to use JUCE polyphonic Synthesizer instead of Faust polyphonic code"
         option -llvm "to use the LLVM compilation chain (OSX and Linux for now)"
         exit
@@ -60,14 +67,24 @@ do
         NVOICES=$1
     elif [ $p = "-standalone" ]; then
         STANDALONE="1"
+        PLUGIN_FORMATS+=",buildstandalone"
     elif [ $p = "-effect" ]; then
         DEF+="POLY2 "
         POLY="POLY2"
         shift
         EFFECT=$1
+    elif [ $p = "-vst2sdkdir" ]; then
+        shift
+        VST2_SDK=$(echo $1 | sed -e 's/\//\\\//g')
+        if [ $VST2_SDK != "" ]; then
+            PLUGIN_FORMATS+=",buildVST"
+            BUILD_VST2="1"
+        fi
     elif [ $p = "-jucemodulesdir" ]; then
 	    shift
 	    JUCE_MODULES_DIR=$(echo $1 | sed -e 's/\//\\\//g')
+    elif [ $p = "-disable-splash-screen" ]; then
+        DISPLAY_SPLASH_SCREEN="0"
     elif [ $p = "-jsynth" ]; then
         DEF+="JUCE_POLY "
         JUCE_POLY="1"
@@ -122,8 +139,28 @@ if [ $POLY = "POLY2" ] && [ $JUCE_POLY = "1" ]; then
 fi
 
 #look for polyphonic "nvoices" metadata in the DSP file
+if [ $(cat $FILES | grep -c "nvoices:") ] || [ $(cat $FILES | grep -c "declare nvoices") ]
+then
+    # a variation of the string "nvoices" was found
+    IS_SYNTH="1"
+else
+    # "nvoices" was not found
+    IS_SYNTH="0"
+fi
 
 grep "declare nvoices" $FILES && IS_SYNTH="1" 2>/dev/null
+
+# Set PLUGIN_CHARACTERISTICS, and the order matters.
+if [ $IS_SYNTH = "1" ]; then
+    PLUGIN_CHARACTERISTICS+=",pluginIsSynth"
+fi
+if [ $IS_MIDI = "1" ]; then
+    PLUGIN_CHARACTERISTICS+=",pluginProducesMidiOut,pluginWantsMidiIn"
+fi
+# Don't allow PLUGIN_CHARACTERISTICS to start with a comma
+if [ ${PLUGIN_CHARACTERISTICS::1}="," ]; then
+    PLUGIN_CHARACTERISTICS="${PLUGIN_CHARACTERISTICS:1}"
+fi
 
 #-------------------------------------------------------------------
 # compile the *.dsp files
@@ -167,11 +204,24 @@ for p in $FILES; do
     # JUCE_MODULES_DIR
     sed -e "s/JUCE_MODULES_DIR_DEFAULT/$JUCE_MODULES_DIR/g" "$SRCDIR/$dspName/$dspName-temp4.jucer" >> "$SRCDIR/$dspName/$dspName-temp5.jucer"
 
+    # VST2_SDK
+    sed -e "s/VST2_SDK_DEFAULT/$VST2_SDK/g" "$SRCDIR/$dspName/$dspName-temp5.jucer" >> "$SRCDIR/$dspName/$dspName-temp6.jucer"
+    sed -e "s/BUILD_VST2_DEFAULT/$BUILD_VST2/g" "$SRCDIR/$dspName/$dspName-temp6.jucer" >> "$SRCDIR/$dspName/$dspName-temp7.jucer"
+
+    # PLUGIN_FORMATS
+    sed -e "s/PLUGIN_FORMATS_DEFAULT/$PLUGIN_FORMATS/g" "$SRCDIR/$dspName/$dspName-temp7.jucer" >> "$SRCDIR/$dspName/$dspName-temp8.jucer"
+
+    # PLUGIN_CHARACTERISTICS
+    sed -e "s/PLUGIN_CHARACTERISTICS_DEFAULT/$PLUGIN_CHARACTERISTICS/g" "$SRCDIR/$dspName/$dspName-temp8.jucer" >> "$SRCDIR/$dspName/$dspName-temp9.jucer"
+
+    # DISPLAY_SPLASH_SCREEN
+    sed -e "s/DISPLAY_SPLASH_SCREEN_DEFAULT/$DISPLAY_SPLASH_SCREEN/g" "$SRCDIR/$dspName/$dspName-temp9.jucer" >> "$SRCDIR/$dspName/$dspName-temp10.jucer"
+
     # possibly set NVOICES value
     if [ $NVOICES -ge 0 ]; then
-        sed -e "s/NUM_VOICES/$NVOICES/g" "$SRCDIR/$dspName/$dspName-temp5.jucer" >> "$SRCDIR/$dspName/$dspName.jucer"
+        sed -e "s/NUM_VOICES/$NVOICES/g" "$SRCDIR/$dspName/$dspName-temp10.jucer" >> "$SRCDIR/$dspName/$dspName.jucer"
     else
-        cp "$SRCDIR/$dspName/$dspName-temp5.jucer" "$SRCDIR/$dspName/$dspName.jucer"
+        cp "$SRCDIR/$dspName/$dspName-temp10.jucer" "$SRCDIR/$dspName/$dspName.jucer"
     fi
 
     # standalone or plugin mode
@@ -184,7 +234,9 @@ for p in $FILES; do
     rm "$SRCDIR/$dspName/$dspName-temp.jucer"  "$SRCDIR/$dspName/$dspName-temp0.jucer" 
     rm "$SRCDIR/$dspName/$dspName-temp1.jucer" "$SRCDIR/$dspName/$dspName-temp2.jucer"
     rm "$SRCDIR/$dspName/$dspName-temp3.jucer" "$SRCDIR/$dspName/$dspName-temp4.jucer" 
-    rm "$SRCDIR/$dspName/$dspName-temp5.jucer"
+    rm "$SRCDIR/$dspName/$dspName-temp5.jucer" "$SRCDIR/$dspName/$dspName-temp6.jucer"
+    rm "$SRCDIR/$dspName/$dspName-temp7.jucer" "$SRCDIR/$dspName/$dspName-temp8.jucer"
+    rm "$SRCDIR/$dspName/$dspName-temp9.jucer" "$SRCDIR/$dspName/$dspName-temp10.jucer"
 
     # standalone of plugin mode
     if [ $STANDALONE = "0" ]; then
@@ -205,7 +257,7 @@ for p in $FILES; do
 
     if [ $POLY = "POLY2" ]; then
         if [ $EFFECT = "auto" ]; then
-            cat > $SRCDIR/$dspName/effect.dsp << EndOfCode
+            cat > "$SRCDIR/$dspName/effect.dsp" << EndOfCode
             adapt(1,1) = _;
             adapt(2,2) = _,_;
             adapt(1,2) = _ <: _,_;


### PR DESCRIPTION
This PR updates `faust2juce` to Projucer 6.0.8 (build date 22 Mar 2021). As a result, some fields in the Projucer file get renamed, and some get added. Visual Studio 2013 was deprecated and removed. Visual Studio 2019 was added. The `faust2juce` script has a new optional argument `-vst2sdkdir` for a legacy VST 2 SDK folder, which enables the building of dll files as opposed to `.vst3` files. There's a new optional argument `-disable-splash-screen` for disabling JUCE's splash screen. By default, the splash screen is enabled. A bug with `grep "declare nvoices"` was fixed because the metadata might actually be `[nvoices:8]` which wouldn't be found by that grep. I tested on Windows by building a dsp with a process and and effect. The standalone exe, dll, and vst3 all work perfectly. **I have not tested on other platforms.**