### PR TITLE
Additional functions for WM8978

### DIFF
--- a/architecture/esp32/drivers/wm8978/WM8978.cpp
+++ b/architecture/esp32/drivers/wm8978/WM8978.cpp
@@ -29,10 +29,10 @@ uint8_t WM8978::init(void)
     uint8_t res;
     res = writeReg(0,0);// WM8978 reset
     if(res) return 1;
-    writeReg(1,0X9B);   // R1, OUT4MIXEN, MICEN (MIC), BIASEN, VMIDSEL[1:0]
-    writeReg(2,0X1B0);  // R2, ROUT1, LOUT1, BOOSTENR, BOOSTENL
+    writeReg(1,0X9B);   // R1, OUT4MIXEN, MICEN (MIC), BIASEN, VMIDSEL[1:0] 
+    writeReg(2,0X1B0);  // R2, ROUT1, LOUT1, BOOSTENR, BOOSTENL 
     writeReg(3,0X16C);  // R3, OUT4EN, LOUT2EN, ROUT2EN, RMIXEN, LMIXEN 
-    writeReg(6,0);      // R6, MCLK
+    writeReg(6,0);      // R6, MCLK 
     writeReg(43,1<<4);  // R43, INVROUT2
     writeReg(47,1<<8);  // R47, PGABOOSTL, MIC
     writeReg(48,1<<8);  // R48, PGABOOSTR, MIC
@@ -97,7 +97,7 @@ void WM8978::addaCfg(uint8_t dacen,uint8_t adcen)
 {
     uint16_t regval;
     regval = readReg(3);        // R3
-    if(dacen)regval |= 3<<0;    // R3 DACR & DACL 
+    if(dacen)regval |= 3<<0;    // R3 DACR & DACL  
     else regval &= ~(3<<0);     // R3 DACR & DACL
     writeReg(3,regval);         // R3
     regval=readReg(2);          // R2
@@ -343,31 +343,61 @@ https://github.com/ohmic-net/pico_dsp
 // 1 to enable device standby mode 
 void WM8978::sleep(uint8_t enable)
 { 
-    uint16_t regval; 
+    uint16_t regval;
     regval = (enable<<6);
     writeReg(2,regval);   // R2, sleep
 }
 
 // Resume / wake up from sleep 
-void WM8978::resume(void)    
+void WM8978::resume(void)
 { 
-    uint16_t regval; 
-    regval = ~(1<<6); 
+    uint16_t regval;
+    regval = ~(1<<6);
     writeReg(2,regval);
 }
 
 // OUT4 (Mono Output) enable
 void WM8978::monoOut(uint8_t enable)
 { 
-    uint16_t regval; 
+    uint16_t regval;
     regval = (enable<<3);
-    writeReg(57,regval); //LDAC2OUT4
+    writeReg(57,regval);//LDAC2OUT4
 }
 
 // Speaker boost 
 void WM8978::spkBoost(uint8_t enable)
 {
-    uint16_t regval; 
+    uint16_t regval;
     regval = (enable<<2);
-    writeReg(49,regval); 
+    writeReg(49,regval);
 }
+
+// Set Sample Rate
+// srate: 0~5 , 48kHz, 32kHz, 24kHz, 16kHz, 12kHz, 8kHz
+void WM8978::sampleRate(uint8_t srate)
+{
+    uint16_t regval = 0;            // 48kHz, default
+    if(srate==1) regval = 0x2;
+    if(srate==2) regval = 0x4;
+    if(srate==3) regval = 0x6;
+    if(srate==4) regval = 0x8;
+    if(srate==5) regval = 0xA;
+    writeReg(7,regval);             // R7, Additional Ctrl
+}
+
+// Loopback, ADC data output is fed directly into DAC data input
+void WM8978::loopback(uint8_t enable)
+{
+    uint16_t regval;
+    regval = enable;
+    writeReg(5,regval);
+}
+
+// DAC Automute (after 1024 consective zeros)
+void WM8978::aMute(uint8_t enable)
+{
+    uint16_t regval;
+    regval = enable<<2;
+    writeReg(10,regval);
+}
+

--- a/architecture/esp32/drivers/wm8978/WM8978.h
+++ b/architecture/esp32/drivers/wm8978/WM8978.h
@@ -76,6 +76,9 @@ public:
     void resume(void); 
     void monoOut(uint8_t enable); 
     void spkBoost(uint8_t enable); 
+    void sampleRate(uint8_t srate);
+    void loopback(uint8_t enable);
+    void aMute(uint8_t enable);
 };
 
 #endif


### PR DESCRIPTION
Additional functions for WM8978 codec; power saving, enable mono output, change sample rate, speaker boost, loopback and automute. 