### PR TITLE
Add faust2feh

### DIFF
--- a/tools/faust2appls/README.md
+++ b/tools/faust2appls/README.md
@@ -77,6 +77,8 @@ NOTE: In the latest Faust versions there's also an alternative VST architecture 
 
 * `faust2firefox <file1.dsp>` : faust2svg with visualization using firefox
 
+* `faust2feh <file1.dsp>` : faust2svg with visualization using feh
+
 * `faust2octave <file.dsp>` : faust2plot with visualization using octave   
 
 

--- a/tools/faust2appls/faust2feh
+++ b/tools/faust2appls/faust2feh
@@ -1,0 +1,12 @@
+#! /bin/bash -e
+
+. usage.sh
+
+if [[ $@ = "-help" ]] || [[ $@ = "-h" ]]; then
+    usage faust2feh "<file.dsp>"
+    echo "Compiles Faust programs to SVG and opens it with feh"
+    exit
+fi
+
+faust2svg $@ || exit
+feh --conversion-timeout 0 ${1%.dsp}-svg/process.svg&


### PR DESCRIPTION
Hello

This adds the script `faust2feh` which is basically a small version of `faust2firefox` that uses `feh` (a popular extremely light weight image viewer on linux) as the image viewer.