### PR TITLE
faust2juce: Change background colour to black

### DIFF
--- a/architecture/juce/juce-plugin.cpp
+++ b/architecture/juce/juce-plugin.cpp
@@ -767,7 +767,7 @@ FaustPlugInAudioProcessorEditor::FaustPlugInAudioProcessorEditor (FaustPlugInAud
 //==============================================================================
 void FaustPlugInAudioProcessorEditor::paint (juce::Graphics& g)
 {
-    g.fillAll (juce::Colours::white);
+    g.fillAll (juce::Colours::black);
 }
 
 void FaustPlugInAudioProcessorEditor::resized()

--- a/architecture/juce/juce-standalone.cpp
+++ b/architecture/juce/juce-standalone.cpp
@@ -209,7 +209,7 @@ class FaustComponent : public juce::AudioAppComponent, private juce::Timer
 
         void paint (juce::Graphics& g) override
         {
-            g.fillAll (juce::Colour (juce::Colours::white));
+            g.fillAll (juce::Colour (juce::Colours::black));
         }
 
         void resized() override


### PR DESCRIPTION
Fixes https://github.com/grame-cncm/faust/issues/631

This is what it looked like before:
![2021-08-03-16:14:57-screenshot](https://user-images.githubusercontent.com/22474608/128144696-0f9f14db-d2bf-4341-8b7b-89f2357b8afb.png)

This is what it looks like now:
![2021-08-04-10:00:15-screenshot](https://user-images.githubusercontent.com/22474608/128144572-571ac2d7-24bf-411d-8ce6-6f1ab0e2ec76.png)

(sorry if this is a bit lazy - but I've got limited time for this ATM. Best!)
