### PR TITLE
Update poly-dsp.h

### DIFF
--- a/architecture/faust/dsp/poly-dsp.h
+++ b/architecture/faust/dsp/poly-dsp.h
@@ -245,6 +245,15 @@ struct dsp_voice : public MapUI, public decorator_dsp {
             }
         }
     }
+ 
+    void instanceClear()
+    {
+        decorator_dsp::instanceClear();
+        fCurNote = kFreeVoice;
+        fNextNote = fNextVel = -1;
+        fLevel = FAUSTFLOAT(0);
+        fDate = fRelease = 0;
+    }
     
     // Keep 'pitch' and 'velocity' to fadeOut the current voice and start next one in the next buffer
     void keyOn(int pitch, int velocity, bool legato = false)


### PR DESCRIPTION
Addressing https://github.com/grame-cncm/faust/issues/628

When voice control is off, instanceClear will be called [here](https://github.com/grame-cncm/faust/blob/e72675398d03747068816d83ac8399fdc71f5439/architecture/faust/dsp/poly-dsp.h#L763), and dsp_struct should implement it while also calling its super class `decorator_dsp::instanceClear()`.