### PR TITLE
LLVM 14 preprocessor fixes

### DIFF
--- a/compiler/generator/llvm/llvm_code_container.cpp
+++ b/compiler/generator/llvm/llvm_code_container.cpp
@@ -77,7 +77,8 @@ void LLVMCodeContainer::init(const string& name, int numInputs, int numOutputs, 
     
     // Set "-fast-math"
     FastMathFlags FMF;
-#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || \
+    defined(LLVM_130) || defined(LLVM_140)
     FMF.setFast();  // has replaced the following function
 #else
     FMF.setUnsafeAlgebra();

--- a/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
@@ -65,7 +65,7 @@
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 
-#if defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
 #include <llvm/InitializePasses.h>
 #include <llvm/Support/CodeGen.h>
 #endif
@@ -114,7 +114,8 @@ void llvm_dynamic_dsp_factory_aux::write(ostream* out, bool binary, bool small)
     string res;
     raw_string_ostream out_str(res);
     if (binary) {
-#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || \
+    defined(LLVM_130) || defined(LLVM_140)
         WriteBitcodeToFile(*fModule, out_str);
 #else
         WriteBitcodeToFile(fModule, out_str);
@@ -130,7 +131,8 @@ string llvm_dynamic_dsp_factory_aux::writeDSPFactoryToBitcode()
 {
     string res;
     raw_string_ostream out(res);
-#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || \
+    defined(LLVM_130) || defined(LLVM_140)
     WriteBitcodeToFile(*fModule, out);
 #else
     WriteBitcodeToFile(fModule, out);
@@ -147,7 +149,8 @@ bool llvm_dynamic_dsp_factory_aux::writeDSPFactoryToBitcodeFile(const string& bi
         cerr << "ERROR : writeDSPFactoryToBitcodeFile could not open file : " << err.message();
         return false;
     }
-#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || \
+    defined(LLVM_130) || defined(LLVM_140)
     WriteBitcodeToFile(*fModule, out);
 #else
     WriteBitcodeToFile(fModule, out);
@@ -285,11 +288,12 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
     targetOptions.GuaranteedTailCallOpt = true;
     targetOptions.NoTrappingFPMath      = true;
     
-#if defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || \
+    defined(LLVM_140)
     targetOptions.NoSignedZerosFPMath   = true;
 #endif
     
-#if defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
     targetOptions.setFPDenormalMode(DenormalMode::getIEEE());
 #else
     targetOptions.FPDenormalMode = FPDenormal::IEEE;
@@ -299,7 +303,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
     
     string debug_var = (getenv("FAUST_DEBUG")) ? string(getenv("FAUST_DEBUG")) : "";
     if ((debug_var != "") && (debug_var.find("FAUST_LLVM3") != string::npos)) {
-    #if !defined(LLVM_120) && !defined(LLVM_130)
+#if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
         targetOptions.PrintMachineCode = true;
     #endif
     }
@@ -430,7 +434,7 @@ bool llvm_dynamic_dsp_factory_aux::writeDSPFactoryToObjectcodeFileAux(const stri
     }
 
     legacy::PassManager pass;
-#if defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
     if (TheTargetMachine->addPassesToEmitFile(pass, dest, nullptr, CGFT_ObjectFile)) {
 #elif defined(LLVM_80) || defined(LLVM_90)
     if (TheTargetMachine->addPassesToEmitFile(pass, dest, nullptr, TargetMachine::CGFT_ObjectFile)) {

--- a/compiler/generator/llvm/llvm_instructions.hh
+++ b/compiler/generator/llvm/llvm_instructions.hh
@@ -88,32 +88,32 @@ struct LLVMTypeHelper {
         fTypeMap[Typed::kFloat]         = getFloatTy();
         fTypeMap[Typed::kFloat_ptr]     = getTyPtr(fTypeMap[Typed::kFloat]);
         fTypeMap[Typed::kFloat_ptr_ptr] = getTyPtr(fTypeMap[Typed::kFloat_ptr]);
-    #if !defined(LLVM_120) && !defined(LLVM_130)
+    #if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
         fTypeMap[Typed::kFloat_vec]     = VectorType::get(fTypeMap[Typed::kFloat], gGlobal->gVecSize);
         fTypeMap[Typed::kFloat_vec_ptr] = getTyPtr(fTypeMap[Typed::kFloat_vec]);
     #endif
         fTypeMap[Typed::kDouble]         = getDoubleTy();
         fTypeMap[Typed::kDouble_ptr]     = getTyPtr(fTypeMap[Typed::kDouble]);
         fTypeMap[Typed::kDouble_ptr_ptr] = getTyPtr(fTypeMap[Typed::kDouble_ptr]);
-    #if !defined(LLVM_120) && !defined(LLVM_130)
+    #if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
         fTypeMap[Typed::kDouble_vec]     = VectorType::get(fTypeMap[Typed::kDouble], gGlobal->gVecSize);
         fTypeMap[Typed::kDouble_vec_ptr] = getTyPtr(fTypeMap[Typed::kDouble_vec]);
     #endif
         fTypeMap[Typed::kInt32]         = getInt32Ty();
         fTypeMap[Typed::kInt32_ptr]     = getTyPtr(fTypeMap[Typed::kInt32]);
-    #if !defined(LLVM_120) && !defined(LLVM_130)
+    #if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
         fTypeMap[Typed::kInt32_vec]     = VectorType::get(fTypeMap[Typed::kInt32], gGlobal->gVecSize);
         fTypeMap[Typed::kInt32_vec_ptr] = getTyPtr(fTypeMap[Typed::kInt32_vec]);
     #endif
         fTypeMap[Typed::kInt64]         = getInt64Ty();
         fTypeMap[Typed::kInt64_ptr]     = getTyPtr(fTypeMap[Typed::kInt64]);
-    #if !defined(LLVM_120) && !defined(LLVM_130)
+    #if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
         fTypeMap[Typed::kInt64_vec]     = VectorType::get(fTypeMap[Typed::kInt64], gGlobal->gVecSize);
         fTypeMap[Typed::kInt64_vec_ptr] = getTyPtr(fTypeMap[Typed::kInt64_vec]);
     #endif
         fTypeMap[Typed::kBool]         = getInt1Ty();
         fTypeMap[Typed::kBool_ptr]     = getTyPtr(fTypeMap[Typed::kBool]);
-    #if !defined(LLVM_120) && !defined(LLVM_130)
+    #if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
         fTypeMap[Typed::kBool_vec]     = VectorType::get(fTypeMap[Typed::kBool], gGlobal->gVecSize);
         fTypeMap[Typed::kBool_vec_ptr] = getTyPtr(fTypeMap[Typed::kBool_vec]);
     #endif
@@ -170,7 +170,7 @@ struct LLVMTypeHelper {
     LLVMType getStructType(const string& name, const LLVMVecTypes& types)
     {
         // We want to have a unique creation for struct types, so check if the given type has already been created
-    #if defined(LLVM_120) || defined(LLVM_130)
+    #if defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
         StructType* struct_type = StructType::getTypeByName(fModule->getContext(), name);
     #else
         StructType* struct_type = fModule->getTypeByName(name);
@@ -195,7 +195,7 @@ struct LLVMTypeHelper {
         if (basic_typed) {
             return fTypeMap[basic_typed->fType];
         } else if (named_typed) {
-        #if defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
             LLVMType type = StructType::getTypeByName(fModule->getContext(), "struct.dsp" + named_typed->fName);
         #else
             LLVMType type = fModule->getTypeByName("struct.dsp" + named_typed->fName);
@@ -208,7 +208,7 @@ struct LLVMTypeHelper {
                        ? fTypeMap[array_typed->getType()]
                        : ArrayType::get(fTypeMap[Typed::getTypeFromPtr(array_typed->getType())], array_typed->fSize);
         } else if (vector_typed) {
-        #if !defined(LLVM_120) && !defined(LLVM_130)
+        #if !defined(LLVM_120) && !defined(LLVM_130) && !defined(LLVM_140)
             return VectorType::get(fTypeMap[vector_typed->fType->fType], vector_typed->fSize);
         #else
             faustassert(false);
@@ -246,7 +246,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
     list<string> fMathLibTable;                 // All standard math functions
 
-#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
     map<string, Intrinsic::ID> fUnaryIntrinsicTable;    // LLVM unary intrinsic
     map<string, Intrinsic::ID> fBinaryIntrinsicTable;   // LLVM binary intrinsic
 #endif
@@ -320,7 +320,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
         fTypeMap[Typed::kObj_ptr] = dsp_ptr;
         fAllocaBuilder            = new IRBuilder<>(fModule->getContext());
  
-    #if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+    #if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
         
         /* This does not work in visit(FunCallInst* inst) for intrinsic, which are deactivated for now
         call_inst->addAttribute(AttributeList::FunctionIndex, Attribute::Builtin);
@@ -840,6 +840,14 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
         fCurValue = nullptr;
     }
 
+#ifndef ADD_ATTRIBUTE_AT_INDEX(a, b, c)
+    #if defined(LLVM_140)
+        #define ADD_ATTRIBUTE_AT_INDEX(a, b, c) a->addAttributeAtIndex(b, c);
+    #else
+        #define ADD_ATTRIBUTE_AT_INDEX(a, b, c) a->addAttribute(b, c);
+    #endif
+#endif
+
     virtual void visit(FunCallInst* inst)
     {
         // Compile function arguments
@@ -855,21 +863,20 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             fCurValue = generateFunPolymorphicMinMax(fun_args[0], fun_args[1], kLT);
         } else if (checkMax(inst->fName) && fun_args.size() == 2) {
             fCurValue = generateFunPolymorphicMinMax(fun_args[0], fun_args[1], kGT);
-    #if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130)
+#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
         // LLVM unary intrinsic
         } else if (fUnaryIntrinsicTable.find(inst->fName) != fUnaryIntrinsicTable.end()) {
             
             CallInst* call_inst = fBuilder->CreateUnaryIntrinsic(fUnaryIntrinsicTable[inst->fName], fun_args[0]);
-            call_inst->addAttribute(AttributeList::FunctionIndex, Attribute::Builtin);
+            ADD_ATTRIBUTE_AT_INDEX(call_inst, AttributeList::FunctionIndex, Attribute::Builtin)
             fCurValue = call_inst;
             
         // LLVM binary intrinsic
         } else if (fBinaryIntrinsicTable.find(inst->fName) != fBinaryIntrinsicTable.end()) {
             
             CallInst* call_inst = fBuilder->CreateBinaryIntrinsic(fBinaryIntrinsicTable[inst->fName], fun_args[0], fun_args[1]);
-            call_inst->addAttribute(AttributeList::FunctionIndex, Attribute::Builtin);
-            fCurValue = call_inst;
-            
+            ADD_ATTRIBUTE_AT_INDEX(call_inst, AttributeList::FunctionIndex, Attribute::Builtin)
+            fCurValue = call_inst;  
     #endif
         } else {
             // Get function in the module
@@ -878,7 +885,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
         
             // Result is function call
             CallInst* call_inst = CreateFuncall(function, fun_args);
-            call_inst->addAttribute(AttributeList::FunctionIndex, Attribute::Builtin);
+            ADD_ATTRIBUTE_AT_INDEX(call_inst, AttributeList::FunctionIndex, Attribute::Builtin)
             fCurValue = call_inst;
         }
     }


### PR DESCRIPTION
I added LLVM_140 in several places and compiled successfully for 14.0. I think other versions will continue to work. Note the new macro for `ADD_ATTRIBUTE_AT_INDEX(a, b, c)` which could have been done multiple ways. Feel free to suggest a better way.