### PR TITLE
Fix linux httpd build

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,5 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install libmicrohttpd
+      run: sudo apt-get install libmicrohttpd-dev
     - name: Build Faust
       run: make

--- a/build/http/CMakeLists.txt
+++ b/build/http/CMakeLists.txt
@@ -165,7 +165,7 @@ if (HTTPDYNAMIC)
 	elseif(MSYS)
 		target_link_libraries (httpdynamic ${LIBMICROHTTPD__LDFLAGS})
 	else()
-		target_link_libraries (httpdynamic ws2_32 microhttpd)
+		target_link_libraries (httpdynamic microhttpd)
 		set_target_properties (httpdynamic PROPERTIES 
 			COMPILE_FLAGS  "${LIBMICROHTTPD__CFLAGS}"
 			LINK_FLAGS     "${LIBMICROHTTPD__LDFLAGS}")


### PR DESCRIPTION
libws2_32 was added to target_link_libraries for non-windows platforms
despite being a windows only library. This commit removes it and adds
libmicrohttpd to the ubuntu CI to make sure this target is actually
built.

Originally raised in while testing fix for #649.