### PR TITLE
Sublime Text 4 completions and snippets

### DIFF
--- a/syntax-highlighting/README.md
+++ b/syntax-highlighting/README.md
@@ -80,3 +80,8 @@ Copy the directory `atom/language-faust` into `~/.atom/packages/` and follow the
 3. Click Install to automatically download and install the extension.
 
 NB: This is the latest version of [faust extension](https://marketplace.visualstudio.com/items?itemName=glen-anderson.vscode-faust) created by Glen Anderson, cf. https://github.com/hellbent/vscode-faust.
+
+## Sublime Text 4 completions and snippets
+
+Copy the folder [sublime-text/Faust](sublime-text/Faust) to your `Packages/User` directory. To find the right directory, use Preferences > Browse Packages...  
+More info in [sublime-text/Faust/README.md](sublime-text/Faust/README.md)

--- a/syntax-highlighting/sublime-text/Faust/README.md
+++ b/syntax-highlighting/sublime-text/Faust/README.md
@@ -1,0 +1,17 @@
+# Sublime Text 4 completions and snippets
+
+Copy this folder (`Faust`) to your `Packages/User` directory. On Linux it's `$HOME/.config/sublime-text/Packages/User`.
+To find the right directory, use Preferences > Browse Packages..., you will find or create the User folder here.
+
+This only provides completions for the standard library. The available snippets are taken from the atom syntax highlighting provided in this repo.
+You can use https://github.com/nuchi/faust-sublime-syntax for syntax highlighting.
+
+This was made for ST4. I (@Simon-L) haven't tested on ST3 or earlier.
+
+The `*.sublime-snippet` files each contain one snippet.
+The `faust.sublime-completions` contains all the completions generated with `faust2sublimecompletions`.
+
+The provided `faust.sublime-completions` file here has been generated on Dec. 6 2021 using the command:
+`./faust2sublimecompletions aanl.lib all.lib analyzers.lib basics.lib compressors.lib delays.lib demos.lib dx7.lib envelopes.lib fds.lib filters.lib hoa.lib interpolators.lib maths.lib mi.lib misceffects.lib oscillators.lib noises.lib phaflangers.lib platform.lib physmodels.lib quantizers.lib reducemaps.lib reverbs.lib routes.lib spats.lib signals.lib soundfiles.lib synths.lib vaeffects.lib version.lib webaudio.lib wdmodels.lib > faust.sublime-completions`
+
+The libraries included above being these included in `stdfaust.lib`.

--- a/syntax-highlighting/sublime-text/Faust/all_lib.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/all_lib.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>all.lib</tabTrigger>
+    <content><![CDATA[import("all.lib");$0]]></content>
+    <description>import all.lib</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/button.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/button.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>button</tabTrigger>
+    <content><![CDATA[button("${1:title}")$0]]></content>
+    <description>button</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/checkbox.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/checkbox.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>checkbox</tabTrigger>
+    <content><![CDATA[checkbox("${1:title}")$0]]></content>
+    <description>checkbox</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/component.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/component.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>component</tabTrigger>
+    <content><![CDATA[component("${1:name}.lib")$0]]></content>
+    <description>component</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/def.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/def.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>def</tabTrigger>
+    <content><![CDATA[${1:name} = ${2:expression};$0]]></content>
+    <description>definition</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/doc.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/doc.sublime-snippet
@@ -1,0 +1,17 @@
+<snippet>
+    <scope>source.faust</scope>
+    <description>doc</description>
+    <tabTrigger>doc</tabTrigger>
+    <content><![CDATA[
+    //--------------- ${1:func} ----------------
+    // ${2:presentation}
+    //
+    // ### Usage:
+    //    `${3:example}`
+    //
+    // #### Where:
+    // + ${4:arg1} = ${5:role and value}
+    //
+    //------------------------------------------
+    ]]></content>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/environment.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/environment.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>environment</tabTrigger>
+    <content><![CDATA[environment {${1:definitions};}$0]]></content>
+    <description>environment</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/faust.sublime-completions
+++ b/syntax-highlighting/sublime-text/Faust/faust.sublime-completions
@@ -1,0 +1,5353 @@
+{
+    "completions": [
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.clip",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aaclip'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.clip"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Rsqrt",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aarsqrt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Rsqrt"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Rlog",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aarlog'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Rlog"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Rtan",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aartan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Rtan"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Racos",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aaracos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Racos"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Rasin",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aarasin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Rasin"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Racosh",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aaracosh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Racosh"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Rcosh",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aarcosh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Rcosh"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Rsinh",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aarsinh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Rsinh"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.Ratanh",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aaratanh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.Ratanh"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.ADAA1",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aaadaa1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.ADAA1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.ADAA2",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/aanl/#aaadaa2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.ADAA2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.hardclip",
+            "details": "<code>_ : aa.hardclip : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aahardclip'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.hardclip"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.hardclip2",
+            "details": "<code>_ : aa.hardclip2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aahardclip2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.hardclip2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.cubic1",
+            "details": "<code>_ : aa.cubic1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aacubic1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.cubic1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.parabolic",
+            "details": "<code>_ : aa.parabolic : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaparabolic'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.parabolic"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.parabolic2",
+            "details": "<code>_ : aa.parabolic : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaparabolic2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.parabolic2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.hyperbolic",
+            "details": "<code>_ : aa.hyperbolic : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aahyperbolic'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.hyperbolic"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.hyperbolic2",
+            "details": "<code>_ : aa.hyperbolic2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aahyperbolic2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.hyperbolic2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.sinarctan",
+            "details": "<code>_ : aa.sinatan : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aasinarctan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.sinarctan"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.sinarctan2",
+            "details": "<code>_ : aa.sinarctan2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aasinarctan2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.sinarctan2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.tanh1",
+            "details": "<code>_ : aa.tanh1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aatanh1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.tanh1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.arctan",
+            "details": "<code>_ : aa.arctan : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaarctan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.arctan"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.arctan2",
+            "details": "<code>_ : aa.arctan2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaarctan2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.arctan2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.asinh1",
+            "details": "<code>_ : aa.asinh1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaasinh1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.asinh1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.asinh2",
+            "details": "<code>_ : aa.asinh2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaasinh2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.asinh2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.cosine1",
+            "details": "<code>_ : aa.cosine1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aacosine1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.cosine1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.cosine2",
+            "details": "<code>_ : aa.cosine2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aacosine2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.cosine2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.arccos",
+            "details": "<code>_ : aa.arccos : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaarccos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.arccos"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.arccos2",
+            "details": "<code>_ : aa.arccos2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaarccos2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.arccos2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.acosh1",
+            "details": "<code>_ : aa.acosh1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaacosh1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.acosh1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.acosh2",
+            "details": "<code>_ : aa.acosh2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaacosh2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.acosh2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.sine",
+            "details": "<code>_ : aa.sine : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aasine'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.sine"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.sine2",
+            "details": "<code>_ : aa.sine2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aasine2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.sine2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.arcsin",
+            "details": "<code>_ : aa.arcsin : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaarcsin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.arcsin"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.arcsin2",
+            "details": "<code>_ : aa.arcsin2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaarcsin2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.arcsin2"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.tangent",
+            "details": "<code>_ : aa.tangent : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aatangent'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.tangent"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.atanh1",
+            "details": "<code>_ : aa.atanh1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaatanh1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.atanh1"
+        },
+        {
+            "annotation": "aanl.lib",
+            "contents": "aa.atanh2",
+            "details": "<code>_ : aa.atanh2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/aanl/#aaatanh2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "aa.atanh2"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.abs_envelope_rect",
+            "details": "<code>_ : abs_envelope_rect(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anabs_envelope_rect'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.abs_envelope_rect"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.abs_envelope_tau",
+            "details": "<code>_ : abs_envelope_tau(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anabs_envelope_tau'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.abs_envelope_tau"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.abs_envelope_t60",
+            "details": "<code>_ : abs_envelope_t60(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anabs_envelope_t60'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.abs_envelope_t60"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.abs_envelope_t19",
+            "details": "<code>_ : abs_envelope_t19(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anabs_envelope_t19'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.abs_envelope_t19"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.amp_follower",
+            "details": "<code>_ : amp_follower(rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anamp_follower'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.amp_follower"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.amp_follower_ud",
+            "details": "<code>   _ : amp_follower_ud(att,rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anamp_follower_ud'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.amp_follower_ud"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.amp_follower_ar",
+            "details": "<code>_ : amp_follower_ar(att,rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anamp_follower_ar'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.amp_follower_ar"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.ms_envelope_rect",
+            "details": "<code>_ : ms_envelope_rect(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anms_envelope_rect'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.ms_envelope_rect"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.ms_envelope_tau",
+            "details": "<code>_ : ms_envelope_tau(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anms_envelope_tau'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.ms_envelope_tau"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.ms_envelope_t60",
+            "details": "<code>_ : ms_envelope_t60(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anms_envelope_t60'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.ms_envelope_t60"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.ms_envelope_t19",
+            "details": "<code>_ : ms_envelope_t19(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anms_envelope_t19'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.ms_envelope_t19"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.rms_envelope_rect",
+            "details": "<code>_ : rms_envelope_rect(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anrms_envelope_rect'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.rms_envelope_rect"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.rms_envelope_tau",
+            "details": "<code>_ : rms_envelope_tau(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anrms_envelope_tau'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.rms_envelope_tau"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.rms_envelope_t60",
+            "details": "<code>_ : rms_envelope_t60(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anrms_envelope_t60'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.rms_envelope_t60"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.rms_envelope_t19",
+            "details": "<code>_ : rms_envelope_t19(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anrms_envelope_t19'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.rms_envelope_t19"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.mth_octave_analyzer",
+            "details": "<code>_ : mth_octave_analyzer(O,M,ftop,N) : par(i,N,_) // Oth-order Butterworth</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anmth_octave_analyzer'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.mth_octave_analyzer"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.mth_octave_spectral_level6e",
+            "details": "<code>_ : mth_octave_spectral_level6e(M,ftop,NBands,tau,dB_offset) : _</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anmth_octave_spectral_level6e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.mth_octave_spectral_level6e"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.[third|half]_octave_[analyzer|filterbank]",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/analyzers/#an[third|half]_octave_[analyzer|filterbank]'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.[third|half]_octave_[analyzer|filterbank]"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.analyzer",
+            "details": "<code>_ : analyzer(O,freqs) : par(i,N,_) // No delay equalizer</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#ananalyzer'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.analyzer"
+        },
+        {
+            "annotation": "analyzers.lib",
+            "contents": "an.ifft",
+            "details": "<code>si.cbus(N) : ifft(N) : si.cbus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/analyzers/#anifft'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "an.ifft"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.samp2sec",
+            "details": "<code>samp2sec(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#basamp2sec'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.samp2sec"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.sec2samp",
+            "details": "<code>sec2samp(d) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#basec2samp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.sec2samp"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.db2linear",
+            "details": "<code>db2linear(l) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#badb2linear'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.db2linear"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.linear2db",
+            "details": "<code>linear2db(g) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#balinear2db'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.linear2db"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.lin2LogGain",
+            "details": "<code>lin2LogGain(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#balin2loggain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.lin2LogGain"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.log2LinGain",
+            "details": "<code>log2LinGain(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#balog2lingain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.log2LinGain"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.tau2pole",
+            "details": "<code>_ : smooth(tau2pole(tau)) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#batau2pole'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.tau2pole"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pole2tau",
+            "details": "<code>pole2tau(pole) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapole2tau'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pole2tau"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.midikey2hz",
+            "details": "<code>midikey2hz(mk) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bamidikey2hz'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.midikey2hz"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.hz2midikey",
+            "details": "<code>hz2midikey(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bahz2midikey'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.hz2midikey"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.semi2ratio",
+            "details": "<code>semi2ratio(semi) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#basemi2ratio'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.semi2ratio"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.ratio2semi",
+            "details": "<code>ratio2semi(ratio) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baratio2semi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.ratio2semi"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pianokey2hz",
+            "details": "<code>pianokey2hz(pk) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapianokey2hz'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pianokey2hz"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.hz2pianokey",
+            "details": "<code>hz2pianokey(f) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bahz2pianokey'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.hz2pianokey"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.countdown",
+            "details": "<code>countdown(n,trig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bacountdown'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.countdown"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.countup",
+            "details": "<code>countup(n,trig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bacountup'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.countup"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.sweep",
+            "details": "<code>sweep(period,run) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#basweep'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.sweep"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.time",
+            "details": "<code>time : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#batime'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.time"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.ramp",
+            "details": "<code>_ : ramp(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baramp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.ramp"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.line",
+            "details": "<code>_ : line(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baline'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.line"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.tempo",
+            "details": "<code>tempo(t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#batempo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.tempo"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.period",
+            "details": "<code>period(p) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baperiod'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.period"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pulse",
+            "details": "<code>pulse(p) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapulse'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pulse"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pulsen",
+            "details": "<code>pulsen(n,p) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapulsen'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pulsen"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.cycle",
+            "details": "<code>_ : cycle(n) : si.bus(n)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bacycle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.cycle"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.beat",
+            "details": "<code>beat(t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#babeat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.beat"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pulse_countup",
+            "details": "<code>_ : pulse_countup(trig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapulse_countup'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pulse_countup"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pulse_countdown",
+            "details": "<code>_ : pulse_countdown(trig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapulse_countdown'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pulse_countdown"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pulse_countup_loop",
+            "details": "<code>_ : pulse_countup_loop(n,trig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapulse_countup_loop'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pulse_countup_loop"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.resetCtr",
+            "details": "<code>_ : resetCtr(n,m) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baresetctr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.resetCtr"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.pulse_countdown_loop",
+            "details": "<code>_ : pulse_countdown_loop(n,trig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapulse_countdown_loop'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.pulse_countdown_loop"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.count",
+            "details": "<code>count(l)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bacount'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.count"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.take",
+            "details": "<code>take(P,l)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#batake'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.take"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.subseq",
+            "details": "<code>subseq(l, P, N)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#basubseq'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.subseq"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.tabulate",
+            "details": "<code>tabulate(C, fun, size, r0, r1, x).(val|lin|cub) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#batabulate'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.tabulate"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.if",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/basics/#baif'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.if"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.selector",
+            "details": "<code>selector(I,N)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baselector'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.selector"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.select2stereo",
+            "details": "<code>_,_,_,_ : select2stereo(bpc) : _,_    </code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baselect2stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.select2stereo"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.selectn",
+            "details": "<code>selectn(N,i)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baselectn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.selectn"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.selectmulti",
+            "details": "<code>selectmulti(n,lgen,id)</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baselectmulti'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.selectmulti"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.selectoutn",
+            "details": "<code>_ : selectoutn(N, i) : _,_,...N</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baselectoutn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.selectoutn"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.latch",
+            "details": "<code>_ : latch(clocksig) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#balatch'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.latch"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.sAndH",
+            "details": "<code>_ : sAndH(t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#basandh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.sAndH"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.downSample",
+            "details": "<code>_ : downSample(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#badownsample'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.downSample"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.peakhold",
+            "details": "<code>_ : peakhold(mode) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapeakhold'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.peakhold"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.peakholder",
+            "details": "<code>_ : peakholder(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#bapeakholder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.peakholder"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.impulsify",
+            "details": "<code>button(\"gate\") : impulsify;</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baimpulsify'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.impulsify"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.automat",
+            "details": "<code>hslider(...) : automat(bps, size, init) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baautomat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.automat"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.bpf",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/basics/#babpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.bpf"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.listInterp",
+            "details": "<code>index = 1.69; // range is 0-4</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#balistinterp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.listInterp"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.bypass1",
+            "details": "<code>_ : bypass1(bpc,e) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#babypass1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.bypass1"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.bypass2",
+            "details": "<code>_,_ : bypass2(bpc,e) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#babypass2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.bypass2"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.bypass1to2",
+            "details": "<code>_ : bypass1to2(bpc,e) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#babypass1to2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.bypass1to2"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.bypass_fade",
+            "details": "<code>_ : bypass_fade(n,b,e) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#babypass_fade'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.bypass_fade"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.toggle",
+            "details": "<code>_ : toggle : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#batoggle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.toggle"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.on_and_off",
+            "details": "<code>_,_ : on_and_off : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baon_and_off'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.on_and_off"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingReduce",
+            "details": "<code>_ : slidingReduce(op,N,maxN,disabledVal) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingreduce'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingReduce"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingSum",
+            "details": "<code>_ : slidingSum(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingsum'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingSum"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingSump",
+            "details": "<code>_ : slidingSump(N,maxN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingsump'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingSump"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingMax",
+            "details": "<code>_ : slidingMax(N,maxN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingmax'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingMax"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingMin",
+            "details": "<code>_ : slidingMin(N,maxN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingmin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingMin"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingMean",
+            "details": "<code>_ : slidingMean(N,maxN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingmean'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingMean"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingMeanp",
+            "details": "<code>_ : slidingMeanp(N,maxN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingmeanp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingMeanp"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.slidingRMSp",
+            "details": "<code>_ : slidingRMSp(N,maxN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baslidingrmsp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.slidingRMSp"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.parallelOp",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/basics/#baparallelop'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.parallelOp"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.parallelMax",
+            "details": "<code>si.bus(n) : parallelMax(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baparallelmax'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.parallelMax"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.parallelMin",
+            "details": "<code>si.bus(n) : parallelMin(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baparallelmin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.parallelMin"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.parallelMean",
+            "details": "<code>si.bus(n) : parallelMean(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baparallelmean'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.parallelMean"
+        },
+        {
+            "annotation": "basics.lib",
+            "contents": "ba.parallelRMS",
+            "details": "<code>si.bus(n) : parallelRMS(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/basics/#baparallelrms'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ba.parallelRMS"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.peak_compression_gain_mono",
+            "details": "<code>_ : peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#copeak_compression_gain_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.peak_compression_gain_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.peak_compression_gain_N_chan",
+            "details": "<code>si.bus(N) : peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#copeak_compression_gain_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.peak_compression_gain_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.FFcompressor_N_chan",
+            "details": "<code>si.bus(N) : FFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#coffcompressor_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.FFcompressor_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.FBcompressor_N_chan",
+            "details": "<code>si.bus(N) : FBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#cofbcompressor_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.FBcompressor_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.FBFFcompressor_N_chan",
+            "details": "<code>si.bus(N) : FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#cofbffcompressor_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.FBFFcompressor_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.RMS_compression_gain_mono",
+            "details": "<code>_ : RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost) : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#corms_compression_gain_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.RMS_compression_gain_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.RMS_compression_gain_N_chan",
+            "details": "<code>si.bus(N) : RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#corms_compression_gain_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.RMS_compression_gain_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.RMS_FBFFcompressor_N_chan",
+            "details": "<code>si.bus(N) : RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#corms_fbffcompressor_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.RMS_FBFFcompressor_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.RMS_FBcompressor_peak_limiter_N_chan",
+            "details": "<code>si.bus(N) : RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#corms_fbcompressor_peak_limiter_n_chan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.RMS_FBcompressor_peak_limiter_N_chan"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.compressor_lad_mono",
+            "details": "<code>_ : compressor_lad_mono(lad,ratio,thresh,att,rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#cocompressor_lad_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.compressor_lad_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.compressor_mono",
+            "details": "<code>_ : compressor_mono(ratio,thresh,att,rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#cocompressor_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.compressor_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.compressor_stereo",
+            "details": "<code>_,_ : compressor_stereo(ratio,thresh,att,rel) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#cocompressor_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.compressor_stereo"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.compression_gain_mono",
+            "details": "<code>_ : compression_gain_mono(ratio,thresh,att,rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#cocompression_gain_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.compression_gain_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_1176_R4_mono",
+            "details": "<code> _ : limiter_1176_R4_mono : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_1176_r4_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_1176_R4_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_1176_R4_stereo",
+            "details": "<code> _,_ : limiter_1176_R4_stereo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_1176_r4_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_1176_R4_stereo"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_lad_N",
+            "details": "<code>si.bus(N) : limiter_lad_N(N, LD, ceiling, attack, hold, release) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_lad_n'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_lad_N"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_lad_mono",
+            "details": "<code>_ : limiter_lad_mono(LD, ceiling, attack, hold, release) : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_lad_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_lad_mono"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_lad_stereo",
+            "details": "<code>_,_ : limiter_lad_stereo(LD, ceiling, attack, hold, release) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_lad_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_lad_stereo"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_lad_quad",
+            "details": "<code>si.bus(4) : limiter_lad_quad(LD, ceiling, attack, hold, release) : si.bus(4)</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_lad_quad'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_lad_quad"
+        },
+        {
+            "annotation": "compressors.lib",
+            "contents": "co.limiter_lad_bw",
+            "details": "<code>_ : limiter_lad_bw : _</code> - <a href='https://faustlibraries.grame.fr/libs/compressors/#colimiter_lad_bw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "co.limiter_lad_bw"
+        },
+        {
+            "annotation": "delays.lib",
+            "contents": "de.delay",
+            "details": "<code>_ : delay(n,d) : _</code> - <a href='https://faustlibraries.grame.fr/libs/delays/#dedelay'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "de.delay"
+        },
+        {
+            "annotation": "delays.lib",
+            "contents": "de.sdelay",
+            "details": "<code>_ : sdelay(n,it,dt) : _</code> - <a href='https://faustlibraries.grame.fr/libs/delays/#desdelay'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "de.sdelay"
+        },
+        {
+            "annotation": "delays.lib",
+            "contents": "de.fdelay[n]",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/delays/#defdelay[n]'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "de.fdelay[n]"
+        },
+        {
+            "annotation": "delays.lib",
+            "contents": "de.fdelay[n]a",
+            "details": "<code>_ : fdelay[N]a(maxdelay, delay, inputsignal) : _</code> - <a href='https://faustlibraries.grame.fr/libs/delays/#defdelay[n]a'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "de.fdelay[n]a"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.mth_octave_spectral_level_demo",
+            "details": "<code>_ : mth_octave_spectral_level_demo(BandsPerOctave) : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmmth_octave_spectral_level_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.mth_octave_spectral_level_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.parametric_eq_demo",
+            "details": "<code>_ : parametric_eq_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmparametric_eq_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.parametric_eq_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.spectral_tilt_demo",
+            "details": "<code>_ : spectral_tilt_demo(N) : _ </code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmspectral_tilt_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.spectral_tilt_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.cubicnl_demo",
+            "details": "<code>_ : cubicnl_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmcubicnl_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.cubicnl_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.gate_demo",
+            "details": "<code>_,_ : gate_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmgate_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.gate_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.compressor_demo",
+            "details": "<code>_,_ : compressor_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmcompressor_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.compressor_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.moog_vcf_demo",
+            "details": "<code>_ : moog_vcf_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmmoog_vcf_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.moog_vcf_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.wah4_demo",
+            "details": "<code>_ : wah4_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmwah4_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.wah4_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.crybaby_demo",
+            "details": "<code>_ : crybaby_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmcrybaby_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.crybaby_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.flanger_demo",
+            "details": "<code>_,_ : flanger_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmflanger_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.flanger_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.phaser2_demo",
+            "details": "<code>_,_ : phaser2_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmphaser2_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.phaser2_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.freeverb_demo",
+            "details": "<code>_,_ : freeverb_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmfreeverb_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.freeverb_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.stereo_reverb_tester",
+            "details": "<code>_ : stereo_reverb_tester : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmstereo_reverb_tester'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.stereo_reverb_tester"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.fdnrev0_demo",
+            "details": "<code>_,_ : fdnrev0_demo(N,NB,BBSO) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmfdnrev0_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.fdnrev0_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.zita_rev_fdn_demo",
+            "details": "<code>si.bus(8) : zita_rev_fdn_demo : si.bus(8)</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmzita_rev_fdn_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.zita_rev_fdn_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.zita_light",
+            "details": "<code>_,_ : zita_light : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmzita_light'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.zita_light"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.zita_rev1",
+            "details": "<code>_,_ : zita_rev1 : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmzita_rev1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.zita_rev1"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.dattorro_rev_demo",
+            "details": "<code>_,_ : dattorro_rev_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmdattorro_rev_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.dattorro_rev_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.jprev_demo",
+            "details": "<code>_,_ : jprev_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmjprev_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.jprev_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.greyhole_demo",
+            "details": "<code>_,_ : greyhole_demo : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmgreyhole_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.greyhole_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.sawtooth_demo",
+            "details": "<code>sawtooth_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmsawtooth_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.sawtooth_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.virtual_analog_oscillator_demo",
+            "details": "<code>virtual_analog_oscillator_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmvirtual_analog_oscillator_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.virtual_analog_oscillator_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.velvet_noise_demo",
+            "details": "<code>velvet_noise_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmvelvet_noise_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.velvet_noise_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.latch_demo",
+            "details": "<code>echo 'import(\"stdfaust.lib\");' > latch_demo.dsp</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmlatch_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.latch_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.envelopes_demo",
+            "details": "<code>echo 'import(\"stdfaust.lib\");' > envelopes_demo.dsp</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmenvelopes_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.envelopes_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.fft_spectral_level_demo",
+            "details": "<code>echo 'import(\"stdfaust.lib\");' > fft_spectral_level_demo.dsp</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmfft_spectral_level_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.fft_spectral_level_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.reverse_echo_demo(nChans)",
+            "details": "<code>echo 'import(\"stdfaust.lib\");' > reverse_echo_demo.dsp</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmreverse_echo_demo(nchans)'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.reverse_echo_demo(nChans)"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.pospass_demo",
+            "details": "<code>echo 'import(\"stdfaust.lib\");' > pospass_demo.dsp</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmpospass_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.pospass_demo"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.exciter",
+            "details": "<code>_ : exciter : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmexciter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.exciter"
+        },
+        {
+            "annotation": "demos.lib",
+            "contents": "dm.vocoder_demo",
+            "details": "<code>_ : vocoder_demo : _</code> - <a href='https://faustlibraries.grame.fr/libs/demos/#dmvocoder_demo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dm.vocoder_demo"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_ampf",
+            "details": "<code>dx7AmpPreset : dx7_ampf_bpf : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_ampf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_ampf"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_egraterisef",
+            "details": "<code>dx7envelopeRise : dx7_egraterisef : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_egraterisef'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_egraterisef"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_egraterisepercf",
+            "details": "<code>dx7envelopePercRise : dx7_egraterisepercf : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_egraterisepercf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_egraterisepercf"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_egratedecayf",
+            "details": "<code>dx7envelopeDecay : dx7_egratedecayf : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_egratedecayf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_egratedecayf"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_egratedecaypercf",
+            "details": "<code>dx7envelopePercDecay : dx7_egratedecaypercf : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_egratedecaypercf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_egratedecaypercf"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_eglv2peakf",
+            "details": "<code>dx7Level : dx7_eglv2peakf : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_eglv2peakf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_eglv2peakf"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_velsensf",
+            "details": "<code>dx7Velocity  : dx7_velsensf : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_velsensf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_velsensf"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_fdbkscalef",
+            "details": "<code>dx7Feedback  : dx7_fdbkscalef : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_fdbkscalef'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_fdbkscalef"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_op",
+            "details": "<code>dx7_op(freq,phaseMod,outLev,R1,R2,R3,R4,L1,L2,L3,L4,keyVel,rateScale,type,gain,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_op'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_op"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_algo",
+            "details": "<code>dx7_algo(algN,egR1,egR2,egR3,egR4,egL1,egL2,egL3,egL4,outLevel,keyVelSens,ampModSens,opMode,opFreq,opDetune,opRateScale,feedback,lfoDelay,lfoDepth,lfoSpeed,freq,gain,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_algo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_algo"
+        },
+        {
+            "annotation": "dx7.lib",
+            "contents": "dx.dx7_ui",
+            "details": "<code>dx7_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/dx7/#dxdx7_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "dx.dx7_ui"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.smoothEnvelope",
+            "details": "<code>smoothEnvelope(ar,t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#ensmoothenvelope'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.smoothEnvelope"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.ar",
+            "details": "<code>ar(at,rt,t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enar'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.ar"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.arfe",
+            "details": "<code>arfe(a,r,f,t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enarfe'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.arfe"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.are",
+            "details": "<code>are(a,r,g) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enare'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.are"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.asr",
+            "details": "<code>asr(at,sl,rt,t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enasr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.asr"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.adsr",
+            "details": "<code>adsr(at,dt,sl,rt,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enadsr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.adsr"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.adsre",
+            "details": "<code>adsre(a,d,s,r,g) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enadsre'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.adsre"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.asre",
+            "details": "<code>asre(a,s,r,g) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#enasre'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.asre"
+        },
+        {
+            "annotation": "envelopes.lib",
+            "contents": "en.dx7envelope",
+            "details": "<code>dx7_envelope(R1,R2,R3,R4,L1,L2,L3,L4,t) : _</code> - <a href='https://faustlibraries.grame.fr/libs/envelopes/#endx7envelope'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "en.dx7envelope"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.model1D",
+            "details": "<code>si.bus(points) : model1D(points,R,T,scheme) : si.bus(points)</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdmodel1d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.model1D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.model2D",
+            "details": "<code>si.bus(pointsX*pointsY) : model2D(pointsX,pointsY,R,T,scheme) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdmodel2d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.model2D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.stairsInterp1D",
+            "details": "<code>si.bus(points) : stairsInterp1D(points,point) : si.bus(points)</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdstairsinterp1d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.stairsInterp1D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.stairsInterp2D",
+            "details": "<code>si.bus(pointsX*pointsY) : stairsInterp2D(pointsX,pointsY,pointX,pointY) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdstairsinterp2d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.stairsInterp2D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.linInterp1D",
+            "details": "<code>si.bus(points) : linInterp1D(points,point) : si.bus(points)</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdlininterp1d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.linInterp1D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.linInterp2D",
+            "details": "<code>si.bus(pointsX*pointsY) : linInterp2D(pointsX,pointsY,pointX,pointY) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdlininterp2d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.linInterp2D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.stairsInterp1DOut",
+            "details": "<code>si.bus(points) : stairsInterp1DOut(points,point) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdstairsinterp1dout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.stairsInterp1DOut"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.stairsInterp2DOut",
+            "details": "<code>si.bus(pointsX*pointsY) : stairsInterp2DOut(pointsX,pointsY,pointX,pointY) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdstairsinterp2dout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.stairsInterp2DOut"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.linInterp1DOut",
+            "details": "<code>si.bus(points) : linInterp1DOut(points,point) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdlininterp1dout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.linInterp1DOut"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.stairsInterp2DOut",
+            "details": "<code>si.bus(pointsX*pointsY) : linInterp2DOut(pointsX,pointsY,pointX,pointY) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdstairsinterp2dout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.stairsInterp2DOut"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.route1D",
+            "details": "<code>si.bus((2*R+1)*(T+1)*points),si.bus(points*2) : route1D(points, R, T) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdroute1d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.route1D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.route2D",
+            "details": "<code>si.bus((2*R+1)^2*(T+1)*pointsX*pointsY),si.bus(pointsX*pointsY*2) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdroute2d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.route2D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.schemePoint",
+            "details": "<code>_,si.bus((2*R+1)^D*(T+1)),si.bus((2*R+1)^D) : schemePoint(R,T,D) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdschemepoint'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.schemePoint"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.buildScheme1D",
+            "details": "<code>si.bus((1 + ((2*R+1)*(T+1)) + (2*R+1))*points) : buildScheme1D(points,R,T) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdbuildscheme1d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.buildScheme1D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.buildScheme2D",
+            "details": "<code>si.bus((1 + ((2*R+1)^2*(T+1)) + (2*R+1)^2)*pointsX*pointsY) :</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdbuildscheme2d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.buildScheme2D"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.hammer",
+            "details": "<code>_ :hammer(coeff,omega0Sqr,sigma0,kH,alpha,k,offset,fIn) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdhammer'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.hammer"
+        },
+        {
+            "annotation": "fds.lib",
+            "contents": "fd.bow",
+            "details": "<code>_ :bow(coeff,alpha,k,vb) : _</code> - <a href='https://faustlibraries.grame.fr/libs/fds/#fdbow'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fd.bow"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.zero",
+            "details": "<code>_ : zero(z) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fizero'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.zero"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.pole",
+            "details": "<code>_ : pole(p) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fipole'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.pole"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.integrator",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/filters/#fiintegrator'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.integrator"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.dcblockerat",
+            "details": "<code>_ : dcblockerat(fb) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fidcblockerat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.dcblockerat"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.dcblocker",
+            "details": "<code>_ : dcblocker : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fidcblocker'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.dcblocker"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.lptN",
+            "details": "<code>_ : lptN(N, tN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filptn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.lptN"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.ff_comb",
+            "details": "<code>_ : ff_comb(maxdel,intdel,b0,bM) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiff_comb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.ff_comb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.ff_fcomb",
+            "details": "<code>_ : ff_fcomb(maxdel,del,b0,bM) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiff_fcomb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.ff_fcomb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.ffcombfilter",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/filters/#fiffcombfilter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.ffcombfilter"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.fb_comb",
+            "details": "<code>_ : fb_comb(maxdel,intdel,b0,aN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fifb_comb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.fb_comb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.fb_fcomb",
+            "details": "<code>_ : fb_fcomb(maxdel,del,b0,aN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fifb_fcomb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.fb_fcomb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.rev1",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/filters/#firev1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.rev1"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpass_comb",
+            "details": "<code>_ : allpass_comb(maxdel,intdel,aN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpass_comb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpass_comb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpass_fcomb",
+            "details": "<code>_ : allpass_comb(maxdel,intdel,aN) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpass_fcomb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpass_fcomb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.rev2",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/filters/#firev2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.rev2"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.iir",
+            "details": "<code>_ : iir(bcoeffs,acoeffs) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiiir'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.iir"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.fir",
+            "details": "<code>_ : fir(bv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fifir'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.fir"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.notchw",
+            "details": "<code>_ : notchw(width,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#finotchw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.notchw"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.av2sv",
+            "details": "<code>sv = av2sv(av)</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiav2sv'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.av2sv"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.bvav2nuv",
+            "details": "<code>nuv = bvav2nuv(bv,av)</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fibvav2nuv'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.bvav2nuv"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.iir_lat2",
+            "details": "<code>_ : iir_lat2(bv,av) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiiir_lat2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.iir_lat2"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassnt",
+            "details": "<code>_ : allpassnt(n,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassnt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassnt"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.iir_kl",
+            "details": "<code>_ : iir_kl(bv,av) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiiir_kl'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.iir_kl"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassnklt",
+            "details": "<code>_ : allpassnklt(n,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassnklt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassnklt"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.iir_lat1",
+            "details": "<code>_ : iir_lat1(bv,av) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiiir_lat1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.iir_lat1"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassn1mt",
+            "details": "<code>_ : allpassn1mt(N,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassn1mt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassn1mt"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.iir_nl",
+            "details": "<code>_ : iir_nl(bv,av) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiiir_nl'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.iir_nl"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassnnlt",
+            "details": "<code>_ : allpassnnlt(N,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassnnlt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassnnlt"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.tf2np",
+            "details": "<code>_ : tf2np(b0,b1,b2,a1,a2) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fitf2np'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.tf2np"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.wgr",
+            "details": "<code>_ : wgr(f,r) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiwgr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.wgr"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.nlf2",
+            "details": "<code>_ : nlf2(f,r) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#finlf2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.nlf2"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.apnl",
+            "details": "<code>_ : apnl(a1,a2) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiapnl'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.apnl"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassn",
+            "details": "<code>_ : allpassn(n,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassn"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassnn",
+            "details": "<code>_ : allpassnn(n,tv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassnn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassnn"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpassnkl",
+            "details": "<code>_ : allpassnkl(n,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpassnkl'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpassnkl"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.allpass1m",
+            "details": "<code>_ : allpassn1m(n,sv) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiallpass1m'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.allpass1m"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.tf1snp",
+            "details": "<code>_ : tf1snp(b1,b0,a0) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fitf1snp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.tf1snp"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.tf3slf",
+            "details": "<code>_ : tf3slf(b3,b2,b1,b0,a3,a2,a1,a0) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fitf3slf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.tf3slf"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.tf1s",
+            "details": "<code>_ : tf1s(b1,b0,a0,w1) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fitf1s'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.tf1s"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.tf2sb",
+            "details": "<code>_ : tf2sb(b2,b1,b0,a1,a0,w1,wc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fitf2sb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.tf2sb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.tf1sb",
+            "details": "<code>_ : tf1sb(b1,b0,a0,w1,wc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fitf1sb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.tf1sb"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.resonlp",
+            "details": "<code>_ : resonlp(fc,Q,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#firesonlp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.resonlp"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.resonhp",
+            "details": "<code>_ : resonlp(fc,Q,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#firesonhp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.resonhp"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.resonbp",
+            "details": "<code>_ : resonlp(fc,Q,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#firesonbp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.resonbp"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.lowpass",
+            "details": "<code>_ : lowpass(N,fc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filowpass'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.lowpass"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.highpass",
+            "details": "<code>_ : highpass(N,fc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fihighpass'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.highpass"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.lowpass3e",
+            "details": "<code>_ : lowpass3e(fc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filowpass3e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.lowpass3e"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.lowpass6e",
+            "details": "<code>_ : lowpass6e(fc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filowpass6e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.lowpass6e"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.highpass3e",
+            "details": "<code>_ : highpass3e(fc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fihighpass3e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.highpass3e"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.highpass6e",
+            "details": "<code>_ : highpass6e(fc) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fihighpass6e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.highpass6e"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.bandpass",
+            "details": "<code>_ : bandpass(Nh,fl,fu) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fibandpass'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.bandpass"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.bandstop",
+            "details": "<code>_ : bandstop(Nh,fl,fu) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fibandstop'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.bandstop"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.bandpass6e",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/filters/#fibandpass6e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.bandpass6e"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.bandpass12e",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/filters/#fibandpass12e'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.bandpass12e"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.pospass",
+            "details": "<code>_ : pospass(N,fc) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fipospass'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.pospass"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.low_shelf",
+            "details": "<code>_ : lowshelf(N,L0,fx) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filow_shelf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.low_shelf"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.high_shelf",
+            "details": "<code>_ : highshelf(N,Lpi,fx) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fihigh_shelf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.high_shelf"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.peak_eq",
+            "details": "<code>_ : peak_eq(Lfx,fx,B) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fipeak_eq'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.peak_eq"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.peak_eq_cq",
+            "details": "<code>_ : peak_eq_cq(Lfx,fx,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fipeak_eq_cq'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.peak_eq_cq"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.peak_eq_rm",
+            "details": "<code>_ : peak_eq_rm(Lfx,fx,tanPiBT) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fipeak_eq_rm'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.peak_eq_rm"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.spectral_tilt",
+            "details": "<code>_ : spectral_tilt(N,f0,bw,alpha) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fispectral_tilt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.spectral_tilt"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.levelfilter",
+            "details": "<code>_ : levelfilter(L,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filevelfilter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.levelfilter"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.levelfilterN",
+            "details": "<code>_ : levelfilterN(N,freq,L) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#filevelfiltern'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.levelfilterN"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.mth_octave_filterbank[n]",
+            "details": "<code>_ : mth_octave_filterbank(O,M,ftop,N) : par(i,N,_)     // Oth-order</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fimth_octave_filterbank[n]'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.mth_octave_filterbank[n]"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.filterbank",
+            "details": "<code>_ : filterbank (O,freqs) : par(i,N,_) // Butterworth band-splits</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fifilterbank'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.filterbank"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.filterbanki",
+            "details": "<code>_ : filterbanki(O,freqs) : par(i,N,_) // Inverted-dc version</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fifilterbanki'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.filterbanki"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.svf",
+            "details": "<code>_ : svf.xx(freq, Q, [gain]) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fisvf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.svf"
+        },
+        {
+            "annotation": "filters.lib",
+            "contents": "fi.avg_rect",
+            "details": "<code>_ : avg_rect(period) : _</code> - <a href='https://faustlibraries.grame.fr/libs/filters/#fiavg_rect'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "fi.avg_rect"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.encoder",
+            "details": "<code>encoder(n, x, a) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hoencoder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.encoder"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.decoder",
+            "details": "<code>_ : decoder(n, p) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hodecoder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.decoder"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.decoderStereo",
+            "details": "<code>_ : decoderStereo(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hodecoderstereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.decoderStereo"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.optimBasic",
+            "details": "<code>_ : optimBasic(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hooptimbasic'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.optimBasic"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.optimMaxRe",
+            "details": "<code>_ : optimMaxRe(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hooptimmaxre'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.optimMaxRe"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.optimInPhase",
+            "details": "<code>_ : optimInPhase(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hooptiminphase'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.optimInPhase"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.wider",
+            "details": "<code>_ : wider(n,w) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#howider'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.wider"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.map",
+            "details": "<code>map(n, x, r, a)</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#homap'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.map"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.rotate",
+            "details": "<code>_ : rotate(n, a) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#horotate'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.rotate"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.encoder3D",
+            "details": "<code>encoder3D(n, x, a, e) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hoencoder3d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.encoder3D"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.optimBasic3D",
+            "details": "<code>_ : optimBasic3D(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hooptimbasic3d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.optimBasic3D"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.optimMaxRe3D",
+            "details": "<code>_ : optimMaxRe3D(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hooptimmaxre3d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.optimMaxRe3D"
+        },
+        {
+            "annotation": "hoa.lib",
+            "contents": "ho.optimInPhase3D",
+            "details": "<code>_ : optimInPhase3D(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/hoa/#hooptiminphase3d'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ho.optimInPhase3D"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolate_linear",
+            "details": "<code>interpolate_linear(dv,v0,v1) : _</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolate_linear'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolate_linear"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolate_cosine",
+            "details": "<code>interpolate_cosine(dv,v0,v1) : _</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolate_cosine'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolate_cosine"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolate_cubic",
+            "details": "<code>interpolate_cubic(dv,v0,v1,v2,v3) : _</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolate_cubic'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolate_cubic"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolator_two_points",
+            "details": "<code>interpolator_two_points(gen, idv, interpolate_two_points) : si.bus(outputs(gen))</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolator_two_points'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolator_two_points"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolator_linear",
+            "details": "<code>interpolator_linear(gen, idv) : si.bus(outputs(gen))</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolator_linear'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolator_linear"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolator_cosine",
+            "details": "<code>interpolator_cosine(gen, idv) : si.bus(outputs(gen))</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolator_cosine'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolator_cosine"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolator_four_points",
+            "details": "<code>interpolator_four_points(gen, idv, interpolate_four_points) : si.bus(outputs(gen))</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolator_two_points'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolator_four_points"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolator_cubic",
+            "details": "<code>interpolator_cubic(gen, idv) : si.bus(outputs(gen))</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolator_cubic'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolator_cubic"
+        },
+        {
+            "annotation": "interpolators.lib",
+            "contents": "it.interpolator_select",
+            "details": "<code>interpolator_select(gen, idv, sel) : _,_... (equal to N = outputs(gen))</code> - <a href='https://faustlibraries.grame.fr/libs/interpolators/#itinterpolator_select'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "it.interpolator_select"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.SR",
+            "details": "<code>SR : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#masr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.SR"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.T",
+            "details": "<code>T : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.T"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.BS",
+            "details": "<code>BS : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mabs'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.BS"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.PI",
+            "details": "<code>PI : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mapi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.PI"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.E",
+            "details": "<code>E : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mae'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.E"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.EPSILON",
+            "details": "<code>EPSILON : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maepsilon'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.EPSILON"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.MIN",
+            "details": "<code>MIN : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mamin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.MIN"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.MAX",
+            "details": "<code>MAX : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mamax'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.MAX"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.FTZ",
+            "details": "<code>_ : FTZ : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maftz'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.FTZ"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.copysign",
+            "details": "<code>_,_ : copysign : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#macopysign'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.copysign"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.neg",
+            "details": "<code>_ : neg : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maneg'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.neg"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.sub(x,y)",
+            "details": "<code>_,_ : sub : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#masub(x,y)'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.sub(x,y)"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.inv",
+            "details": "<code>_ : inv : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mainv'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.inv"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.cbrt",
+            "details": "<code>_ : cbrt : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#macbrt'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.cbrt"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.hypot",
+            "details": "<code>_,_ : hypot : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mahypot'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.hypot"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.ldexp",
+            "details": "<code>_,_ : ldexp : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maldexp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.ldexp"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.scalb",
+            "details": "<code>_,_ : scalb : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mascalb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.scalb"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.log1p",
+            "details": "<code>_ : log1p : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#malog1p'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.log1p"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.logb",
+            "details": "<code>_ : logb : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#malogb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.logb"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.ilogb",
+            "details": "<code>_ : ilogb : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mailogb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.ilogb"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.log2",
+            "details": "<code>_ : log2 : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#malog2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.log2"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.expm1",
+            "details": "<code>_ : expm1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maexpm1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.expm1"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.acosh",
+            "details": "<code>_ : acosh : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maacosh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.acosh"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.asinh",
+            "details": "<code>_ : asinh : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maasinh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.asinh"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.atanh",
+            "details": "<code>_ : atanh : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maatanh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.atanh"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.sinh",
+            "details": "<code>_ : sinh : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#masinh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.sinh"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.cosh",
+            "details": "<code>_ : cosh : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#macosh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.cosh"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.tanh",
+            "details": "<code>_ : tanh : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#matanh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.tanh"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.erf",
+            "details": "<code>_ : erf : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maerf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.erf"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.erfc",
+            "details": "<code>_ : erfc : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maerfc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.erfc"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.gamma",
+            "details": "<code>_ : gamma : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#magamma'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.gamma"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.lgamma",
+            "details": "<code>_ : lgamma : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#malgamma'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.lgamma"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.J0",
+            "details": "<code>_ : J0 : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maj0'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.J0"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.J1",
+            "details": "<code>_ : J1 : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maj1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.J1"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.Jn",
+            "details": "<code>_,_ : Jn : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#majn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.Jn"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.Y0",
+            "details": "<code>_ : Y0 : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#may0'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.Y0"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.Y1",
+            "details": "<code>_ : Y0 : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#may1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.Y1"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.Yn",
+            "details": "<code>_,_ : Yn : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mayn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.Yn"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.np2",
+            "details": "<code>np2(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#manp2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.np2"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.frac",
+            "details": "<code>frac(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mafrac'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.frac"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.modulo",
+            "details": "<code>modulo(x,y) : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mamodulo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.modulo"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.isnan",
+            "details": "<code>isnan(x)</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maisnan'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.isnan"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.isinf",
+            "details": "<code>isinf(x)</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#maisinf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.isinf"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.chebychev",
+            "details": "<code>_ : chebychev(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#machebychev'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.chebychev"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.chebychevpoly",
+            "details": "<code>_ : chebychevpoly((c0,c1,...,cn)) : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#machebychevpoly'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.chebychevpoly"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.diffn",
+            "details": "<code>_ : diffn : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#madiffn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.diffn"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.signum",
+            "details": "<code>_ : signum : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#masignum'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.signum"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.nextpow2",
+            "details": "<code>2^nextpow2(n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#manextpow2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.nextpow2"
+        },
+        {
+            "annotation": "maths.lib",
+            "contents": "ma.zc",
+            "details": "<code>_ : zc : _</code> - <a href='https://faustlibraries.grame.fr/libs/maths/#mazc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ma.zc"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.initState",
+            "details": "<code>x: initState(x0) : _</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#miinitstate'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.initState"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.mass",
+            "details": "<code>mass(m, grav, x0, xr0),_ : _</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#mimass'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.mass"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.oscil",
+            "details": "<code>oscil(m, k, z, grav, x0, xr0),_ : _</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#mioscil'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.oscil"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.ground",
+            "details": "<code>ground(x0),_ : _</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#miground'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.ground"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.posInput",
+            "details": "<code>posInput(x0),_,_ : _</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#miposinput'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.posInput"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.spring",
+            "details": "<code>spring(k, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#mispring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.spring"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.damper",
+            "details": "<code>damper(z, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#midamper'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.damper"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.springDamper",
+            "details": "<code>springDamper(k, z, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#mispringdamper'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.springDamper"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.nlSpringDamper2",
+            "details": "<code>nlSpringDamper2(k, q, z, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#minlspringdamper2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.nlSpringDamper2"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.nlSpringDamper3",
+            "details": "<code>nlSpringDamper3(k, q, z, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#minlspringdamper3'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.nlSpringDamper3"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.nlSpringDamperClipped",
+            "details": "<code>nlSpringDamperClipped(s, c, k, z, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#minlspringdamperclipped'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.nlSpringDamperClipped"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.nlPluck",
+            "details": "<code>nlPluck(knl, scale, z, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#minlpluck'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.nlPluck"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.nlBow",
+            "details": "<code>nlBow(znl, scale, type, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#minlbow'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.nlBow"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.collision",
+            "details": "<code>collision(k, z, thres, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#micollision'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.collision"
+        },
+        {
+            "annotation": "mi.lib",
+            "contents": "mi.nlCollisionClipped",
+            "details": "<code>nlCollisionClipped(s, c, k, z, thres, x1r, x2r),_,_ : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/mi/#minlcollisionclipped'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "mi.nlCollisionClipped"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.cubicnl",
+            "details": "<code>_ : cubicnl(drive,offset) : _</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efcubicnl'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.cubicnl"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.gate_mono",
+            "details": "<code>_ : gate_mono(thresh,att,hold,rel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efgate_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.gate_mono"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.gate_stereo",
+            "details": "<code> _,_ : gate_stereo(thresh,att,hold,rel) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efgate_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.gate_stereo"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.speakerbp",
+            "details": "<code>speakerbp(f1,f2)</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efspeakerbp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.speakerbp"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.piano_dispersion_filter",
+            "details": "<code>piano_dispersion_filter(M,B,f0)</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efpiano_dispersion_filter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.piano_dispersion_filter"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.stereo_width",
+            "details": "<code>_,_ : stereo_width(w) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efstereo_width'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.stereo_width"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.mesh_square",
+            "details": "<code>bus(4*N) : mesh_square(N) : bus(4*N)</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efmesh_square'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.mesh_square"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.reverseEchoN(nChans,delay)",
+            "details": "<code>_ : ef.reverseEchoN(N,delay) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efreverseechon(nchans,delay)'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.reverseEchoN(nChans,delay)"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.reverseDelayRamped(delay,phase)",
+            "details": "<code>_ : ef.reverseDelayRamped(delay,phase) : _</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efreversedelayramped(delay,phase)'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.reverseDelayRamped(delay,phase)"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.uniformPanToStereo(nChans)",
+            "details": "<code>si.bus(N) : ef.uniformPanToStereo(N) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efuniformpantostereo(nchans)'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.uniformPanToStereo(nChans)"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.echo",
+            "details": "<code>_ : echo(maxDuration,duration,feedback) : _</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#efecho'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.echo"
+        },
+        {
+            "annotation": "misceffects.lib",
+            "contents": "ef.transpose",
+            "details": "<code>_ : transpose(w, x, s) : _</code> - <a href='https://faustlibraries.grame.fr/libs/misceffects/#eftranspose'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ef.transpose"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.sinwaveform",
+            "details": "<code>sinwaveform(tablesize) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ossinwaveform'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.sinwaveform"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.coswaveform",
+            "details": "<code>coswaveform(tablesize) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oscoswaveform'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.coswaveform"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.phasor",
+            "details": "<code>phasor(tablesize,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osphasor'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.phasor"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.hs_phasor",
+            "details": "<code>hs_phasor(tablesize,freq,reset) :  _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oshs_phasor'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.hs_phasor"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.hsp_phasor",
+            "details": "<code>hsp_phasor(tablesize,freq,reset,phase)</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oshsp_phasor'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.hsp_phasor"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscsin",
+            "details": "<code>oscsin(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcsin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscsin"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.hs_oscsin",
+            "details": "<code>hs_oscsin(freq,reset) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oshs_oscsin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.hs_oscsin"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.osccos",
+            "details": "<code>osccos(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososccos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.osccos"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.hs_osccos",
+            "details": "<code>hs_osccos(freq,reset) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oshs_osccos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.hs_osccos"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscp",
+            "details": "<code>oscp(freq,phase) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscp"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.osci",
+            "details": "<code>osci(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososci'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.osci"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.osc",
+            "details": "<code>osc(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.osc"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_imptrain",
+            "details": "<code>lf_imptrain(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_imptrain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_imptrain"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_pulsetrainpos",
+            "details": "<code>lf_pulsetrainpos(freq, duty) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_pulsetrainpos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_pulsetrainpos"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_pulsetrain",
+            "details": "<code>lf_pulsetrain(freq,duty) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_pulsetrain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_pulsetrain"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_squarewavepos",
+            "details": "<code>lf_squarewavepos(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_squarewavepos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_squarewavepos"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_squarewave",
+            "details": "<code>lf_squarewave(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_squarewave'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_squarewave"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_trianglepos",
+            "details": "<code>lf_trianglepos(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_trianglepos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_trianglepos"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_triangle",
+            "details": "<code>lf_triangle(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_triangle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_triangle"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_rawsaw",
+            "details": "<code>lf_rawsaw(periodsamps) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_rawsaw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_rawsaw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_sawpos",
+            "details": "<code>lf_sawpos(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_sawpos'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_sawpos"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_sawpos_phase",
+            "details": "<code>lf_sawpos_phase(freq, phase) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_sawpos_phase'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_sawpos_phase"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_sawpos_reset",
+            "details": "<code>lf_sawpos_reset(freq,reset) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_sawpos_reset'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_sawpos_reset"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_sawpos_phase_reset",
+            "details": "<code>lf_sawpos_phase_reset(freq,phase,reset) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_sawpos_phase_reset'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_sawpos_phase_reset"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.lf_saw",
+            "details": "<code>lf_saw(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#oslf_saw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.lf_saw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.sawNp",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ossawnp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.sawNp"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.saw2dpw",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ossaw2dpw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.saw2dpw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.saw3",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ossaw3'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.saw3"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.sawtooth",
+            "details": "<code>sawtooth(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ossawtooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.sawtooth"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.saw2f2",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ossaw2f2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.saw2f2"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.saw2f4",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ossaw2f4'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.saw2f4"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.pulsetrainN",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ospulsetrainn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.pulsetrainN"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.pulsetrain",
+            "details": "<code>pulsetrain(freq, duty) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ospulsetrain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.pulsetrain"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.squareN",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ossquaren'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.squareN"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.square",
+            "details": "<code>square(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ossquare'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.square"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.impulse",
+            "details": "<code>impulse : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osimpulse'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.impulse"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.imptrainN",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#osimptrainn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.imptrainN"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.imptrain",
+            "details": "<code>imptrain(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osimptrain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.imptrain"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.triangleN",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/oscillators/#ostrianglen'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.triangleN"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.triangle",
+            "details": "<code>triangle(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ostriangle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.triangle"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscb",
+            "details": "<code>oscb(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscb"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscrq",
+            "details": "<code>oscrq(freq) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcrq'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscrq"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscrs",
+            "details": "<code>oscrs(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcrs'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscrs"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscrc",
+            "details": "<code>oscrc(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcrc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscrc"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscs",
+            "details": "<code>oscs(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcs'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscs"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.quadosc",
+            "details": "<code>quadosc(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osquadosc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.quadosc"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscwc",
+            "details": "<code>oscwc(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcwc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscwc"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscws",
+            "details": "<code>oscws(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcws'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscws"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscq",
+            "details": "<code>oscq(freq) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcq'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscq"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.oscw",
+            "details": "<code>oscw(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososcw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.oscw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZsaw",
+            "details": "<code>CZsaw(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczsaw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZsaw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZsawP",
+            "details": "<code>CZsawP(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczsawp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZsawP"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZsquare",
+            "details": "<code>CZsquare(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczsquare'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZsquare"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZsquareP",
+            "details": "<code>CZsquareP(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczsquarep'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZsquareP"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZpulse",
+            "details": "<code>CZpulse(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczpulse'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZpulse"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZpulseP",
+            "details": "<code>CZpulseP(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczpulsep'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZpulseP"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZsinePulse",
+            "details": "<code>CZsinePulse(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczsinepulse'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZsinePulse"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZsinePulseP",
+            "details": "<code>CZsinePulseP(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczsinepulsep'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZsinePulseP"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZhalfSine",
+            "details": "<code>CZhalfSine(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczhalfsine'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZhalfSine"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZhalfSineP",
+            "details": "<code>CZhalfSineP(fund,index) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczhalfsinep'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZhalfSineP"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZresSaw",
+            "details": "<code>CZresSaw(fund,res) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczressaw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZresSaw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZresTriangle",
+            "details": "<code>CZresTriangle(fund,res) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczrestriangle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZresTriangle"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.CZresTrap",
+            "details": "<code>CZresTrap(fund,res) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#osczrestrap'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.CZresTrap"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.polyblep",
+            "details": "<code>polyblep(Q,phase) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ospolyblep'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.polyblep"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.polyblep_saw",
+            "details": "<code>polyblep_saw(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ospolyblep_saw'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.polyblep_saw"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.polyblep_square",
+            "details": "<code>polyblep_square(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ospolyblep_square'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.polyblep_square"
+        },
+        {
+            "annotation": "oscillators.lib",
+            "contents": "os.polyblep_triangle",
+            "details": "<code>polyblep_triangle(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ospolyblep_triangle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "os.polyblep_triangle"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.noise",
+            "details": "<code>noise : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nonoise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.noise"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.multirandom",
+            "details": "<code>multirandom(N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nomultirandom'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.multirandom"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.multinoise",
+            "details": "<code>multinoise(N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nomultinoise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.multinoise"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.noises",
+            "details": "<code>noises(N,i) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nonoises'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.noises"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.randomseed",
+            "details": "<code>randomseed : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#norandomseed'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.randomseed"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.rnoise",
+            "details": "<code>rnoise : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nornoise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.rnoise"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.rmultirandom",
+            "details": "<code>rmultirandom(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#normultirandom'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.rmultirandom"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.rmultinoise",
+            "details": "<code>rmultinoise(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#normultinoise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.rmultinoise"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.rnoises",
+            "details": "<code>rnoises(N,i) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nornoises'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.rnoises"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.pink_noise",
+            "details": "<code>pink_noise : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nopink_noise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.pink_noise"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.pink_noise_vm",
+            "details": "<code>pink_noise_vm(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nopink_noise_vm'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.pink_noise_vm"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.sparse_noise",
+            "details": "<code>sparse_noise(f0) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nosparse_noise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.sparse_noise"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.velvet_noise_vm",
+            "details": "<code>velvet_noise(amp, f0) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#novelvet_noise_vm'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.velvet_noise_vm"
+        },
+        {
+            "annotation": "noises.lib",
+            "contents": "no.gnoise",
+            "details": "<code>gnoise(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/noises/#nognoise'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "no.gnoise"
+        },
+        {
+            "annotation": "phaflangers.lib",
+            "contents": "pf.flanger_mono",
+            "details": "<code>_ : flanger_mono(dmax,curdel,depth,fb,invert) : _</code> - <a href='https://faustlibraries.grame.fr/libs/phaflangers/#pfflanger_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pf.flanger_mono"
+        },
+        {
+            "annotation": "phaflangers.lib",
+            "contents": "pf.flanger_stereo",
+            "details": "<code>_,_ : flanger_stereo(dmax,curdel1,curdel2,depth,fb,invert) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/phaflangers/#pfflanger_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pf.flanger_stereo"
+        },
+        {
+            "annotation": "phaflangers.lib",
+            "contents": "pf.phaser2_mono",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/phaflangers/#pfphaser2_mono'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pf.phaser2_mono"
+        },
+        {
+            "annotation": "phaflangers.lib",
+            "contents": "pf.phaser2_stereo",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/phaflangers/#pfphaser2_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pf.phaser2_stereo"
+        },
+        {
+            "annotation": "platform.lib",
+            "contents": "pl.SR",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/platform/#plsr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pl.SR"
+        },
+        {
+            "annotation": "platform.lib",
+            "contents": "pl.BS",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/platform/#plbs'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pl.BS"
+        },
+        {
+            "annotation": "platform.lib",
+            "contents": "pl.tablesize",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/platform/#pltablesize'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pl.tablesize"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.speedOfSound",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/physmodels/#pmspeedofsound'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.speedOfSound"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.maxLength",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmaxlength'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.maxLength"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.f2l",
+            "details": "<code>f2l(freq) : distanceInMeters</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmf2l'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.f2l"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.l2f",
+            "details": "<code>l2f(length) : freq</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pml2f'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.l2f"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.l2s",
+            "details": "<code>l2s(l) : numberOfSamples</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pml2s'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.l2s"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.basicBlock",
+            "details": "<code>chain(basicBlock : basicBlock : etc.)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbasicblock'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.basicBlock"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.chain",
+            "details": "<code>leftGoingWaves,rightGoingWaves,mixedOutput : chain( A : B ) : leftGoingWaves,rightGoingWaves,mixedOutput</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmchain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.chain"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.inLeftWave",
+            "details": "<code>model(x) = chain(A : inLeftWave(x) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pminleftwave'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.inLeftWave"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.inRightWave",
+            "details": "<code>model(x) = chain(A : inRightWave(x) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pminrightwave'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.inRightWave"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.in",
+            "details": "<code>model(x) = chain(A : in(x) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.in"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.outLeftWave",
+            "details": "<code>chain(A : outLeftWave : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmoutleftwave'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.outLeftWave"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.outRightWave",
+            "details": "<code>chain(A : outRightWave : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmoutrightwave'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.outRightWave"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.out",
+            "details": "<code>chain(A : out : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.out"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.terminations",
+            "details": "<code>terminations(a,b,c)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmterminations'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.terminations"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.lTermination",
+            "details": "<code>lTerminations(a,b)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmltermination'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.lTermination"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.rTermination",
+            "details": "<code>rTerminations(b,c)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmrtermination'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.rTermination"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.closeIns",
+            "details": "<code>closeIns : chain(...) : _,_,_</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmcloseins'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.closeIns"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.closeOuts",
+            "details": "<code>_,_,_ : chain(...) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmcloseouts'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.closeOuts"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.endChain",
+            "details": "<code>endChain(chain(...)) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmendchain'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.endChain"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.waveguideN",
+            "details": "<code>chain(A : waveguideUd(nMax,n) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmwaveguiden'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.waveguideN"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.waveguide",
+            "details": "<code>chain(A : waveguide(nMax,n) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmwaveguide'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.waveguide"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.bridgeFilter",
+            "details": "<code>_ : bridge(brightness,absorption) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbridgefilter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.bridgeFilter"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.modeFilter",
+            "details": "<code>_ : modeFilter(freq,t60,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmodefilter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.modeFilter"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.stringSegment",
+            "details": "<code>chain(A : stringSegment(maxLength,length) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmstringsegment'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.stringSegment"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.openString",
+            "details": "<code>chain(... : openString(length,stiffness,pluckPosition,excitation) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmopenstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.openString"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.nylonString",
+            "details": "<code>chain(... : nylonString(length,pluckPosition,excitation) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmnylonstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.nylonString"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.steelString",
+            "details": "<code>chain(... : steelString(length,pluckPosition,excitation) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsteelstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.steelString"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.openStringPick",
+            "details": "<code>chain(... : openStringPick(length,stiffness,pluckPosition,excitation) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmopenstringpick'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.openStringPick"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.openStringPickUp",
+            "details": "<code>chain(... : openStringPickUp(length,stiffness,pluckPosition,excitation) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmopenstringpickup'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.openStringPickUp"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.openStringPickDown",
+            "details": "<code>chain(... : openStringPickDown(length,stiffness,pluckPosition,excitation) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmopenstringpickdown'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.openStringPickDown"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.ksReflexionFilter",
+            "details": "<code>terminations(_,chain(...),ksReflexionFilter)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmksreflexionfilter'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.ksReflexionFilter"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.rStringRigidTermination",
+            "details": "<code>chain(rStringRigidTermination : stringSegment : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmrstringrigidtermination'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.rStringRigidTermination"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.lStringRigidTermination",
+            "details": "<code>chain(... : stringSegment : lStringRigidTermination)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmlstringrigidtermination'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.lStringRigidTermination"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.elecGuitarBridge",
+            "details": "<code>chain(... : stringSegment : elecGuitarBridge)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmelecguitarbridge'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.elecGuitarBridge"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.elecGuitarNuts",
+            "details": "<code>chain(elecGuitarNuts : stringSegment : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmelecguitarnuts'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.elecGuitarNuts"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.guitarBridge",
+            "details": "<code>chain(... : stringSegment : guitarBridge)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmguitarbridge'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.guitarBridge"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.guitarNuts",
+            "details": "<code>chain(guitarNuts : stringSegment : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmguitarnuts'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.guitarNuts"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.idealString",
+            "details": "<code>1-1' : idealString(length,reflexion,xPosition,excitation)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmidealstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.idealString"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.ks",
+            "details": "<code>ks(length,damping,excitation) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmks'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.ks"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.ks_ui_MIDI",
+            "details": "<code>ks_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmks_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.ks_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.elecGuitarModel",
+            "details": "<code>elecGuitarModel(length,pluckPosition,mute,excitation) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmelecguitarmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.elecGuitarModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.elecGuitar",
+            "details": "<code>elecGuitar(length,pluckPosition,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmelecguitar'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.elecGuitar"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.elecGuitar_ui_MIDI",
+            "details": "<code>elecGuitar_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmelecguitar_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.elecGuitar_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.guitarBody",
+            "details": "<code>chain(... : guitarBody)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmguitarbody'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.guitarBody"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.guitarModel",
+            "details": "<code>guitarModel(length,pluckPosition,excitation) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmguitarmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.guitarModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.guitar",
+            "details": "<code>guitar(length,pluckPosition,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmguitar'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.guitar"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.guitar_ui_MIDI",
+            "details": "<code>guitar_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmguitar_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.guitar_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.nylonGuitarModel",
+            "details": "<code>nylonGuitarModel(length,pluckPosition,excitation) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmnylonguitarmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.nylonGuitarModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.nylonGuitar",
+            "details": "<code>nylonGuitar(length,pluckPosition,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmnylonguitar'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.nylonGuitar"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.nylonGuitar_ui_MIDI",
+            "details": "<code>nylonGuitar_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmnylonguitar_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.nylonGuitar_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.modeInterpRes",
+            "details": "<code>_ : modeInterpRes(nModes,x,y) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmodeinterpres'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.modeInterpRes"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.modularInterpBody",
+            "details": "<code>chain(... : modularInterpBody(nModes,shape,scale) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmodularinterpbody'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.modularInterpBody"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.modularInterpStringModel",
+            "details": "<code>modularInterpStringModel(length,pluckPosition,shape,scale,bodyExcitation,stringExcitation) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmodularinterpstringmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.modularInterpStringModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.modularInterpInstr",
+            "details": "<code>modularInterpInstr(stringLength,pluckPosition,shape,scale,gain,tapBody,triggerString) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmodularinterpinstr'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.modularInterpInstr"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.modularInterpInstr_ui_MIDI",
+            "details": "<code>modularInterpInstr_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmodularinterpinstr_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.modularInterpInstr_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.bowTable",
+            "details": "<code>excitation : bowTable(offeset,slope) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbowtable'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.bowTable"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinBowTable",
+            "details": "<code>bowVelocity : violinBowTable(bowPressure) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinbowtable'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinBowTable"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.bowInteraction",
+            "details": "<code>chain(... : stringSegment : bowInteraction(bowTable) : stringSegment : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbowinteraction'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.bowInteraction"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinBow",
+            "details": "<code>chain(... : stringSegment : violinBow(bowPressure,bowVelocity) : stringSegment : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinbow'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinBow"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinBowedString",
+            "details": "<code>chain(nuts : violinBowedString(stringLength,bowPressure,bowVelocity,bowPosition) : bridge)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinbowedstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinBowedString"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinNuts",
+            "details": "<code>chain(violinNuts : stringSegment : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinnuts'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinNuts"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinBridge",
+            "details": "<code>chain(... : stringSegment : violinBridge</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinbridge'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinBridge"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinBody",
+            "details": "<code>chain(... : stringSegment : violinBridge : violinBody)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinbody'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinBody"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violinModel",
+            "details": "<code>violinModel(stringLength,bowPressure,bowVelocity,bridgeReflexion,</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolinmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violinModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violin_ui",
+            "details": "<code>violinModel_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolin_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violin_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.violin_ui_MIDI",
+            "details": "<code>violin_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmviolin_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.violin_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.openTube",
+            "details": "<code>chain(A : openTube(maxLength,length) : B)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmopentube'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.openTube"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.reedTable",
+            "details": "<code>excitation : reedTable(offeset,slope) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmreedtable'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.reedTable"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fluteJetTable",
+            "details": "<code>excitation : fluteJetTable : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflutejettable'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fluteJetTable"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.brassLipsTable",
+            "details": "<code>excitation : brassLipsTable(tubeLength,lipsTension) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbrasslipstable'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.brassLipsTable"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.clarinetReed",
+            "details": "<code>excitation : clarinetReed(stiffness) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmclarinetreed'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.clarinetReed"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.clarinetMouthPiece",
+            "details": "<code>chain(clarinetMouthPiece(reedStiffness,pressure) : tube : etc.)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmclarinetmouthpiece'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.clarinetMouthPiece"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.brassLips",
+            "details": "<code>chain(brassLips(tubeLength,lipsTension,pressure) : tube : etc.)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbrasslips'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.brassLips"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fluteEmbouchure",
+            "details": "<code>chain(... : tube : fluteEmbouchure(pressure) : tube : etc.)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfluteembouchure'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fluteEmbouchure"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.wBell",
+            "details": "<code>chain(... : wBell(opening))</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmwbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.wBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fluteHead",
+            "details": "<code>chain(fluteHead : tube : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflutehead'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fluteHead"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fluteFoot",
+            "details": "<code>chain(... : tube : fluteFoot)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflutefoot'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fluteFoot"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.clarinetModel",
+            "details": "<code>clarinetModel(length,pressure,reedStiffness,bellOpening) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmclarinetmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.clarinetModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.clarinetModel_ui",
+            "details": "<code>clarinetModel_ui(pressure) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmclarinetmodel_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.clarinetModel_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.clarinet_ui",
+            "details": "<code>clarinet_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmclarinet_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.clarinet_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.clarinet_ui_MIDI",
+            "details": "<code>clarinet_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmclarinet_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.clarinet_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.brassModel",
+            "details": "<code>brassModel(tubeLength,lipsTension,mute,pressure) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbrassmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.brassModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.brassModel_ui",
+            "details": "<code>brassModel_ui(pressure) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbrassmodel_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.brassModel_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.brass_ui",
+            "details": "<code>brass_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbrass_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.brass_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.brass_ui_MIDI",
+            "details": "<code>brass_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmbrass_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.brass_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fluteModel",
+            "details": "<code>fluteModel(tubeLength,mouthPosition,pressure) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflutemodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fluteModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fluteModel_ui",
+            "details": "<code>fluteModel_ui(pressure) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflutemodel_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fluteModel_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.flute_ui",
+            "details": "<code>flute_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflute_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.flute_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.flute_ui_MIDI",
+            "details": "<code>flute_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmflute_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.flute_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.impulseExcitation",
+            "details": "<code>gate = button('gate');</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmimpulseexcitation'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.impulseExcitation"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.strikeModel",
+            "details": "<code>gate = button('gate');</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmstrikemodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.strikeModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.strike",
+            "details": "<code>gate = button('gate');</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmstrike'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.strike"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.pluckString",
+            "details": "<code>trigger = button('gate');</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmpluckstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.pluckString"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.blower",
+            "details": "<code>blower(pressure,breathGain,breathCutoff) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmblower'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.blower"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.blower_ui",
+            "details": "<code>blower : somethingToBeBlown</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmblower_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.blower_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.djembeModel",
+            "details": "<code>excitation : djembeModel(freq)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmdjembemodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.djembeModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.djembe",
+            "details": "<code>djembe(freq,strikePosition,strikeSharpness,gain,trigger)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmdjembe'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.djembe"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.djembe_ui_MIDI",
+            "details": "<code>djembe_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmdjembe_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.djembe_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.marimbaBarModel",
+            "details": "<code>excitation : marimbaBarModel(freq,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmarimbabarmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.marimbaBarModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.marimbaResTube",
+            "details": "<code>marimbaResTube(tubeLength,excitation)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmarimbarestube'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.marimbaResTube"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.marimbaModel",
+            "details": "<code>excitation : marimbaModel(freq,exPos) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmarimbamodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.marimbaModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.marimba",
+            "details": "<code>excitation : marimba(freq,strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmarimba'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.marimba"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.marimba_ui_MIDI",
+            "details": "<code>marimba_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmmarimba_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.marimba_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.churchBellModel",
+            "details": "<code>excitation : churchBellModel(nModes,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmchurchbellmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.churchBellModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.churchBell",
+            "details": "<code>excitation : churchBell(strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmchurchbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.churchBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.churchBell_ui",
+            "details": "<code>churchBell_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmchurchbell_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.churchBell_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.englishBellModel",
+            "details": "<code>excitation : englishBellModel(nModes,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmenglishbellmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.englishBellModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.englishBell",
+            "details": "<code>excitation : englishBell(strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmenglishbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.englishBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.englishBell_ui",
+            "details": "<code>englishBell_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmenglishbell_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.englishBell_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.frenchBellModel",
+            "details": "<code>excitation : frenchBellModel(nModes,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfrenchbellmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.frenchBellModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.frenchBell",
+            "details": "<code>excitation : frenchBell(strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfrenchbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.frenchBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.frenchBell_ui",
+            "details": "<code>frenchBell_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfrenchbell_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.frenchBell_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.germanBellModel",
+            "details": "<code>excitation : germanBellModel(nModes,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmgermanbellmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.germanBellModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.germanBell",
+            "details": "<code>excitation : germanBell(strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmgermanbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.germanBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.germanBell_ui",
+            "details": "<code>germanBell_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmgermanbell_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.germanBell_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.russianBellModel",
+            "details": "<code>excitation : russianBellModel(nModes,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmrussianbellmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.russianBellModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.russianBell",
+            "details": "<code>excitation : russianBell(strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmrussianbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.russianBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.russianBell_ui",
+            "details": "<code>russianBell_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmrussianbell_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.russianBell_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.standardBellModel",
+            "details": "<code>excitation : standardBellModel(nModes,exPos,t60,t60DecayRatio,t60DecaySlope)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmstandardbellmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.standardBellModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.standardBell",
+            "details": "<code>excitation : standardBell(strikePosition,strikeCutoff,strikeSharpness,gain,trigger) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmstandardbell'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.standardBell"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.standardBell_ui",
+            "details": "<code>standardBell_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmstandardbell_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.standardBell_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantValues",
+            "details": "<code>ba.take(j+1,formantValues.f(i)) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantvalues'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantValues"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.voiceGender",
+            "details": "<code>voiceGender(voiceType) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmvoicegender'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.voiceGender"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.skirtWidthMultiplier",
+            "details": "<code>skirtWidthMultiplier(vowel,freq,gender) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmskirtwidthmultiplier'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.skirtWidthMultiplier"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.autobendFreq",
+            "details": "<code>_ : autobendFreq(n,freq,voiceType) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmautobendfreq'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.autobendFreq"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.vocalEffort",
+            "details": "<code>_ : vocalEffort(freq,gender) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmvocaleffort'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.vocalEffort"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fof",
+            "details": "<code>_ : fof(fc,bw,a,g) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfof'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fof"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fofSH",
+            "details": "<code>_ : fofSH(fc,bw,a,g) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfofsh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fofSH"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fofCycle",
+            "details": "<code>_ : fofCycle(fc,bw,a,g,n) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfofcycle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fofCycle"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.fofSmooth",
+            "details": "<code>_ : fofSmooth(fc,bw,sw,g,tau) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmfofsmooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.fofSmooth"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterFofCycle",
+            "details": "<code>_ : formantFilterFofCycle(voiceType,vowel,nFormants,i,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterfofcycle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterFofCycle"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterFofSmooth",
+            "details": "<code>_ : formantFilterFofSmooth(voiceType,vowel,nFormants,i,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterfofsmooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterFofSmooth"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterBP",
+            "details": "<code>_ : formantFilterBP(voiceType,vowel,nFormants,i,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterbp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterBP"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterbank",
+            "details": "<code>_ : formantFilterbank(voiceType,vowel,formantGen,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterbank'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterbank"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterbankFofCycle",
+            "details": "<code>_ : formantFilterbankFofCycle(voiceType,vowel,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterbankfofcycle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterbankFofCycle"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterbankFofSmooth",
+            "details": "<code>_ : formantFilterbankFofSmooth(voiceType,vowel,freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterbankfofsmooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterbankFofSmooth"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.formantFilterbankBP",
+            "details": "<code>_ : formantFilterbankBP(voiceType,vowel) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmformantfilterbankbp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.formantFilterbankBP"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModel",
+            "details": "<code>SFFormantModel(voiceType,vowel,exType,freq,gain,source,filterbank,isFof) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModel"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelFofCycle",
+            "details": "<code>SFFormantModelFofCycle(voiceType,vowel,freq,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelfofcycle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelFofCycle"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelFofSmooth",
+            "details": "<code>SFFormantModelFofSmooth(voiceType,vowel,freq,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelfofsmooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelFofSmooth"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelBP",
+            "details": "<code>SFFormantModelBP(voiceType,vowel,exType,freq,gain) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelbp'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelBP"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelFofCycle_ui",
+            "details": "<code>SFFormantModelFofCycle_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelfofcycle_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelFofCycle_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelFofSmooth_ui",
+            "details": "<code>SFFormantModelFofSmooth_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelfofsmooth_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelFofSmooth_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelBP_ui",
+            "details": "<code>SFFormantModelBP_ui : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelbp_ui'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelBP_ui"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelFofCycle_ui_MIDI",
+            "details": "<code>SFFormantModelFofCycle_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelfofcycle_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelFofCycle_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelFofSmooth_ui_MIDI",
+            "details": "<code>SFFormantModelFofSmooth_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelfofsmooth_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelFofSmooth_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.SFFormantModelBP_ui_MIDI",
+            "details": "<code>SFFormantModelBP_ui_MIDI : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmsfformantmodelbp_ui_midi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.SFFormantModelBP_ui_MIDI"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm.allpassNL",
+            "details": "<code>chain(... : allpassNL(nonlinearity) : ...)</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pmallpassnl'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm.allpassNL"
+        },
+        {
+            "annotation": "physmodels.lib",
+            "contents": "pm)modalModel",
+            "details": "<code>_ : modalModel(n, freqs, t60s, gains) : _</code> - <a href='https://faustlibraries.grame.fr/libs/physmodels/#pm)modalmodel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "pm)modalModel"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.quantize",
+            "details": "<code>_ : quantize(rf,nl) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#ququantize'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.quantize"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.quantizeSmoothed",
+            "details": "<code>_ : quantizeSmoothed(rf,nl) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#ququantizesmoothed'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.quantizeSmoothed"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.ionian",
+            "details": "<code>_ : quantize(rf,ionian) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#quionian'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.ionian"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.dorian",
+            "details": "<code>_ : quantize(rf,dorian) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qudorian'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.dorian"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.phrygian",
+            "details": "<code>_ : quantize(rf,phrygian) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#quphrygian'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.phrygian"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.lydian",
+            "details": "<code>_ : quantize(rf,lydian) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qulydian'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.lydian"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.mixo",
+            "details": "<code>_ : quantize(rf,mixo) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qumixo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.mixo"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.eolian",
+            "details": "<code>_ : quantize(rf,eolian) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#queolian'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.eolian"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.locrian",
+            "details": "<code>_ : quantize(rf,locrian) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qulocrian'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.locrian"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.pentanat",
+            "details": "<code>_ : quantize(rf,pentanat) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qupentanat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.pentanat"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.kumoi",
+            "details": "<code>_ : quantize(rf,kumoi) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qukumoi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.kumoi"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.natural",
+            "details": "<code>_ : quantize(rf,natural) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qunatural'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.natural"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.dodeca",
+            "details": "<code>_ : quantize(rf,dodeca) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qudodeca'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.dodeca"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.dimin",
+            "details": "<code>_ : quantize(rf,dimin) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qudimin'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.dimin"
+        },
+        {
+            "annotation": "quantizers.lib",
+            "contents": "qu.penta",
+            "details": "<code>_ : quantize(rf,penta) : _</code> - <a href='https://faustlibraries.grame.fr/libs/quantizers/#qupenta'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "qu.penta"
+        },
+        {
+            "annotation": "reducemaps.lib",
+            "contents": "rm.reduce",
+            "details": "<code>reduce(op, n, x)</code> - <a href='https://faustlibraries.grame.fr/libs/reducemaps/#rmreduce'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "rm.reduce"
+        },
+        {
+            "annotation": "reducemaps.lib",
+            "contents": "rm.reducemap",
+            "details": "<code>reducemap(op, foo, n, x)</code> - <a href='https://faustlibraries.grame.fr/libs/reducemaps/#rmreducemap'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "rm.reducemap"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.jcrev",
+            "details": "<code>_ : jcrev : _,_,_,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#rejcrev'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.jcrev"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.satrev",
+            "details": "<code>_ : satrev : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#resatrev'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.satrev"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.fdnrev0",
+            "details": "<code><1,2,4,...,N signals> <:</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#refdnrev0'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.fdnrev0"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.zita_rev_fdn",
+            "details": "<code>si.bus(8) : zita_rev_fdn(f1,f2,t60dc,t60m,fsmax) : si.bus(8)</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#rezita_rev_fdn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.zita_rev_fdn"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.zita_rev1_stereo",
+            "details": "<code>_,_ : zita_rev1_stereo(rdel,f1,f2,t60dc,t60m,fsmax) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#rezita_rev1_stereo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.zita_rev1_stereo"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.zita_rev1_ambi",
+            "details": "<code>_,_ : zita_rev1_ambi(rgxyz,rdel,f1,f2,t60dc,t60m,fsmax) : _,_,_,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#rezita_rev1_ambi'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.zita_rev1_ambi"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.mono_freeverb",
+            "details": "<code>_ : mono_freeverb(fb1, fb2, damp, spread) : _</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#remono_freeverb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.mono_freeverb"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.stereo_freeverb",
+            "details": "<code>_,_ : stereo_freeverb(fb1, fb2, damp, spread) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#restereo_freeverb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.stereo_freeverb"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.dattorro_rev",
+            "details": "<code>_,_ : dattorro_rev(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#redattorro_rev'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.dattorro_rev"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.dattorro_rev_default",
+            "details": "<code>_,_ : dattorro_rev_default : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#redattorro_rev_default'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.dattorro_rev_default"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.jpverb",
+            "details": "<code>_,_ : jpverb(t60, damp, size, early_diff, mod_depth, mod_freq, low, mid, high, low_cutoff, high_cutoff) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#rejpverb'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.jpverb"
+        },
+        {
+            "annotation": "reverbs.lib",
+            "contents": "re.greyhole",
+            "details": "<code>_,_ : greyhole(dt, damp, size, early_diff, feedback, mod_depth, mod_freq) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/reverbs/#regreyhole'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "re.greyhole"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.cross",
+            "details": "<code>cross(N)</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rocross'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.cross"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.crossnn",
+            "details": "<code>(si.bus(2*N)) : crossnn(N) : (si.bus(2*N))</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rocrossnn'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.crossnn"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.crossn1",
+            "details": "<code>(si.bus(N),_) : crossn1(N) : (_,si.bus(N))</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rocrossn1'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.crossn1"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.cross1n",
+            "details": "<code>(_,si.bus(N)) : crossn1(N) : (si.bus(N),_)</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rocross1n'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.cross1n"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.crossNM",
+            "details": "<code>(si.bus(N),si.bus(M)) : crossNM(N,M) : (si.bus(M),si.bus(N))</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rocrossnm'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.crossNM"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.interleave",
+            "details": "<code>si.bus(R*C) : interleave(R,C) : si.bus(R*C)</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rointerleave'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.interleave"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.butterfly",
+            "details": "<code>si.bus(N) : butterfly(N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#robutterfly'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.butterfly"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.hadamard",
+            "details": "<code>si.bus(N) : hadamard(N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rohadamard'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.hadamard"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.recursivize",
+            "details": "<code>_,_ : recursivize(p,q) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#rorecursivize'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.recursivize"
+        },
+        {
+            "annotation": "routes.lib",
+            "contents": "ro.bubbleSort",
+            "details": "<code>si.bus(N) : bubbleSort(N) : si.bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/routes/#robubblesort'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ro.bubbleSort"
+        },
+        {
+            "annotation": "spats.lib",
+            "contents": "sp.panner",
+            "details": "<code>_ : panner(g) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/spats/#sppanner'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sp.panner"
+        },
+        {
+            "annotation": "spats.lib",
+            "contents": "sp.spat",
+            "details": "<code>_ : spat(n,r,d) : _,_,...</code> - <a href='https://faustlibraries.grame.fr/libs/spats/#spspat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sp.spat"
+        },
+        {
+            "annotation": "spats.lib",
+            "contents": "sp.stereoize",
+            "details": "<code>_,_ : stereoize(p) : _,_</code> - <a href='https://faustlibraries.grame.fr/libs/spats/#spstereoize'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sp.stereoize"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.bus",
+            "details": "<code>bus(N)</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sibus'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.bus"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.block",
+            "details": "<code>_,_,... : block(N) : _,...</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#siblock'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.block"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.interpolate",
+            "details": "<code>_,_ : interpolate(i) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#siinterpolate'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.interpolate"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.smoo",
+            "details": "<code>hslider(...) : smoo;</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sismoo'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.smoo"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.polySmooth",
+            "details": "<code>hslider(...) : si.polySmooth(g,s,d) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sipolysmooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.polySmooth"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.smoothAndH",
+            "details": "<code>hslider(...) : smoothAndH(g,s) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sismoothandh'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.smoothAndH"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.bsmooth",
+            "details": "<code>hslider(...) : bsmooth : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sibsmooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.bsmooth"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.dot",
+            "details": "<code>_,_,_,_,_,_ : dot(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sidot'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.dot"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.smooth",
+            "details": "<code>_ : si.smooth(ba.tau2pole(tau)) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sismooth'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.smooth"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.cbus",
+            "details": "<code>cbus(n)</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sicbus'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.cbus"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.cmul",
+            "details": "<code>(r1,i1) : cmul(r2,i2) : (_,_)</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sicmul'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.cmul"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.cconj",
+            "details": "<code>(r1,i1) : cconj : (_,_)</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sicconj'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.cconj"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.lag_ud",
+            "details": "<code>_ : lag_ud(up, dn) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#silag_ud'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.lag_ud"
+        },
+        {
+            "annotation": "signals.lib",
+            "contents": "si.rev",
+            "details": "<code>_ : rev(N) : _</code> - <a href='https://faustlibraries.grame.fr/libs/signals/#sirev'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "si.rev"
+        },
+        {
+            "annotation": "soundfiles.lib",
+            "contents": "so.loop",
+            "details": "<code>loop(sf, part) : si.bus(outputs(sf))</code> - <a href='https://faustlibraries.grame.fr/libs/soundfiles/#soloop'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "so.loop"
+        },
+        {
+            "annotation": "soundfiles.lib",
+            "contents": "so.loop_speed",
+            "details": "<code>loop_speed(sf, part, speed) : si.bus(outputs(sf))</code> - <a href='https://faustlibraries.grame.fr/libs/soundfiles/#soloop_speed'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "so.loop_speed"
+        },
+        {
+            "annotation": "soundfiles.lib",
+            "contents": "so.loop_speed_level",
+            "details": "<code>loop_speed_level(sf, part, speed, level) : si.bus(outputs(sf))</code> - <a href='https://faustlibraries.grame.fr/libs/soundfiles/#soloop_speed_level'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "so.loop_speed_level"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.popFilterPerc",
+            "details": "<code>popFilterDrum(freq,q,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#sypopfilterperc'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.popFilterPerc"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.dubDub",
+            "details": "<code>dubDub(freq,ctFreq,q,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#sydubdub'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.dubDub"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.sawTrombone",
+            "details": "<code>sawTrombone(att,freq,gain,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#sysawtrombone'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.sawTrombone"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.combString",
+            "details": "<code>combString(freq,res,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#sycombstring'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.combString"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.additiveDrum",
+            "details": "<code>additiveDrum(freq,freqRatio,gain,harmDec,att,rel,gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#syadditivedrum'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.additiveDrum"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.fm",
+            "details": "<code>freqs = (300,400,...);</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#syfm'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.fm"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.kick",
+            "details": "<code>kick(pitch, click, attack, decay, drive, gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#sykick'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.kick"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.clap",
+            "details": "<code>clap(tone, attack, decay, gate) : _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#syclap'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.clap"
+        },
+        {
+            "annotation": "synths.lib",
+            "contents": "sy.hat",
+            "details": "<code>hat(pitch, tone, attack, decay, gate): _</code> - <a href='https://faustlibraries.grame.fr/libs/synths/#syhat'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "sy.hat"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.moog_vcf",
+            "details": "<code>_ : moog_vcf(res,fr) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vemoog_vcf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.moog_vcf"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.moog_vcf_2b[n]",
+            "details": "<code>_ : moog_vcf_2b(res,fr) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vemoog_vcf_2b[n]'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.moog_vcf_2b[n]"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.moogLadder",
+            "details": "<code>_ : moogLadder(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vemoogladder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.moogLadder"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.moogHalfLadder",
+            "details": "<code>_ : moogHalfLadder(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vemooghalfladder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.moogHalfLadder"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.diodeLadder",
+            "details": "<code>_ : diodeLadder(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vediodeladder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.diodeLadder"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.korg35LPF",
+            "details": "<code>_ : korg35LPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vekorg35lpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.korg35LPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.korg35HPF",
+            "details": "<code>_ : korg35HPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vekorg35hpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.korg35HPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.oberheim",
+            "details": "<code>_ : oberheim(normFreq,Q) : _,_,_,_</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#veoberheim'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.oberheim"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.oberheimBSF",
+            "details": "<code>_ : oberheimBSF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#veoberheimbsf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.oberheimBSF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.oberheimBPF",
+            "details": "<code>_ : oberheimBPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#veoberheimbpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.oberheimBPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.oberheimHPF",
+            "details": "<code>_ : oberheimHPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#veoberheimhpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.oberheimHPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.oberheimLPF",
+            "details": "<code>_ : oberheimLPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#veoberheimlpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.oberheimLPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.sallenKeyOnePoleHPF",
+            "details": "<code>_ : sallenKeyOnePoleHPF(normFreq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vesallenkeyonepolehpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.sallenKeyOnePoleHPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.sallenKey2ndOrder",
+            "details": "<code>_ : sallenKey2ndOrder(normFreq,Q) : _,_,_</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vesallenkey2ndorder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.sallenKey2ndOrder"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.sallenKey2ndOrderLPF",
+            "details": "<code>_ : sallenKey2ndOrderLPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vesallenkey2ndorderlpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.sallenKey2ndOrderLPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.sallenKey2ndOrderBPF",
+            "details": "<code>_ : sallenKey2ndOrderBPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vesallenkey2ndorderbpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.sallenKey2ndOrderBPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.sallenKey2ndOrderHPF",
+            "details": "<code>_ : sallenKey2ndOrderHPF(normFreq,Q) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vesallenkey2ndorderhpf'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.sallenKey2ndOrderHPF"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.wah4",
+            "details": "<code>_ : wah4(fr) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vewah4'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.wah4"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.autowah",
+            "details": "<code>_ : autowah(level) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#veautowah'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.autowah"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.crybaby",
+            "details": "<code>_ : crybaby(wah) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vecrybaby'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.crybaby"
+        },
+        {
+            "annotation": "vaeffects.lib",
+            "contents": "ve.vocoder",
+            "details": "<code>_ : vocoder(nBands,att,rel,BWRatio,source,excitation) : _</code> - <a href='https://faustlibraries.grame.fr/libs/vaeffects/#vevocoder'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "ve.vocoder"
+        },
+        {
+            "annotation": "version.lib",
+            "contents": "vl.version",
+            "details": "<code>version : _,_,_</code> - <a href='https://faustlibraries.grame.fr/libs/version/#vlversion'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "vl.version"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.lowpass2",
+            "details": "<code>_ : lowpass2(f0, Q, dtune) : _</code> - <a href='https://faustlibraries.grame.fr/libs/webaudio/#walowpass2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.lowpass2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.highpass2",
+            "details": "<code>_ : highpass2(f0, Q, dtune) : _</code> - <a href='https://faustlibraries.grame.fr/libs/webaudio/#wahighpass2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.highpass2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.bandpass2",
+            "details": "<code>_ : bandpass2(f0, Q, dtune) : _</code> - <a href='https://faustlibraries.grame.fr/libs/webaudio/#wabandpass2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.bandpass2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.notch2",
+            "details": "<code>_ : notch2(f0, Q, dtune) : _</code> - <a href='https://faustlibraries.grame.fr/libs/webaudio/#wanotch2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.notch2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.allpass2",
+            "details": "<code>_ : allpass2(f0, Q, dtune) : _</code> - <a href='https://faustlibraries.grame.fr/libs/webaudio/#waallpass2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.allpass2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.peaking2",
+            "details": "<code>_ : peaking2(f0, gain, Q, dtune) : _</code> - <a href='https://faustlibraries.grame.fr/libs/webaudio/#wapeaking2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.peaking2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.lowshelf2",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/webaudio/#walowshelf2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.lowshelf2"
+        },
+        {
+            "annotation": "webaudio.lib",
+            "contents": "wa.highshelf2",
+            "details": "<a href='https://faustlibraries.grame.fr/libs/webaudio/#wahighshelf2'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wa.highshelf2"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.resistor",
+            "details": "<code>r1(i) = resistor(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdresistor'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.resistor"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.resistor_Vout",
+            "details": "<code>rout(i) = resistor_Vout(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdresistor_vout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.resistor_Vout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.resistor_Iout",
+            "details": "<code>rout(i) = resistor_Iout(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdresistor_iout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.resistor_Iout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_voltage",
+            "details": "<code>v1(i) = u_Voltage(i, ein);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_voltage'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_voltage"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_current",
+            "details": "<code>i1(i) = u_current(i, jin);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_current'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_current"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.resVoltage",
+            "details": "<code>v1(i) = resVoltage(i, R, ein);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdresvoltage'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.resVoltage"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.resVoltage_Vout",
+            "details": "<code>vout(i) = resVoltage_Vout(i, R, ein);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdresvoltage_vout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.resVoltage_Vout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_resVoltage",
+            "details": "<code>v1(i) = u_resVoltage(i, R, ein);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_resvoltage'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_resVoltage"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.resCurrent",
+            "details": "<code>i1(i) = resCurrent(i, R, jin);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdrescurrent'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.resCurrent"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_resCurrent",
+            "details": "<code>i1(i) = u_resCurrent(i, R, jin);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_rescurrent'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_resCurrent"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_switch",
+            "details": "<code>s1(i) = u_resCurrent(i, lambda);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_switch'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_switch"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.capacitor",
+            "details": "<code>c1(i) = capacitor(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdcapacitor'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.capacitor"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.capacitor_Vout",
+            "details": "<code>cout(i) = capacitor_Vout(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdcapacitor_vout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.capacitor_Vout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.inductor",
+            "details": "<code>l1(i) = inductor(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdinductor'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.inductor"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.inductor_Vout",
+            "details": "<code>lout(i) = inductor_Vout(i, R);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdinductor_vout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.inductor_Vout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_idealDiode",
+            "details": "<code>buildtree( u_idealDiode : B );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_idealdiode'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_idealDiode"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_chua",
+            "details": "<code>chua1(i) = u_chua(i, G1, G2, V0);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_chua'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_chua"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.lambert",
+            "details": "<code>lambert(n, itr) : _</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdlambert'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.lambert"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_diodePair",
+            "details": "<code>d1(i) = u_diodePair(i, Is, Vt);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_diodepair'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_diodePair"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_diodeSingle",
+            "details": "<code>d1(i) = u_diodeSingle(i, Is, Vt);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_diodesingle'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_diodeSingle"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_diodeAntiparallel",
+            "details": "<code>d1(i) = u_diodeAntiparallel(i, Is, Vt);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_diodeantiparallel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_diodeAntiparallel"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_parallel2Port",
+            "details": "<code>buildtree( u_parallel2Port : (A, B) );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_parallel2port'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_parallel2Port"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.parallel2Port",
+            "details": "<code>buildtree( A : parallel2Port : B );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdparallel2port'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.parallel2Port"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_series2Port",
+            "details": "<code>buildtree( u_series2Port : (A, B) );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_series2port'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_series2Port"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.series2Port",
+            "details": "<code>buildtree( A : series2Port : B );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdseries2port'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.series2Port"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.parallelCurrent",
+            "details": "<code>i1(i) = parallelCurrent(i, jin);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdparallelcurrent'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.parallelCurrent"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.seriesVoltage",
+            "details": "<code>v1(i) = seriesVoltage(i, vin)</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdseriesvoltage'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.seriesVoltage"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_transformer",
+            "details": "<code>t1(i) = u_transformer(i, tr);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_transformer'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_transformer"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.transformer",
+            "details": "<code>t1(i) = transformer(i, tr);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdtransformer'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.transformer"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_transformerActive",
+            "details": "<code>t1(i) = u_transformerActive(i, gamma1, gamma2);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_transformeractive'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_transformerActive"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.transformerActive",
+            "details": "<code>t1(i) = transformerActive(i, gamma1, gamma2);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdtransformeractive'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.transformerActive"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.parallel",
+            "details": "<code>buildtree( A : parallel : (B, C) );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdparallel'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.parallel"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.series",
+            "details": "<code>\n</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdseries'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.series"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_sixportPassive",
+            "details": "<code>\n</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_sixportpassive'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_sixportPassive"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.genericNode",
+            "details": "<code>n1(i) = genericNode(i, scatter, upRes);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdgenericnode'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.genericNode"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.genericNode_Vout",
+            "details": "<code>n1(i) = genericNode_Vout(i, scatter, upRes);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdgenericnode_vout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.genericNode_Vout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.genericNode_Iout",
+            "details": "<code>n1(i) = genericNode_Iout(i, scatter, upRes);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdgenericnode_iout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.genericNode_Iout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.u_genericNode",
+            "details": "<code>n1(i) = u_genericNode(i, scatter);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdu_genericnode'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.u_genericNode"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.builddown",
+            "details": "<code>builddown(A : B)~buildup(A : B);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdbuilddown'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.builddown"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.buildup",
+            "details": "<code>builddown(A : B)~buildup(A : B);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdbuildup'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.buildup"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.getres",
+            "details": "<code>getres(A : B)~getres(A : B);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdgetres'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.getres"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.parres",
+            "details": "<code>parres((A , B))~parres((A , B));</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdparres'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.parres"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.buildout",
+            "details": "<code>buildout( A : B );</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdbuildout'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.buildout"
+        },
+        {
+            "annotation": "wdmodels.lib",
+            "contents": "wd.buildtree",
+            "details": "<code>buildtree(A : B);</code> - <a href='https://faustlibraries.grame.fr/libs/wdmodels/#wdbuildtree'>Docs</a>",
+            "kind": "ambiguous",
+            "trigger": "wd.buildtree"
+        }
+    ],
+    "scope": "source.faust"
+}

--- a/syntax-highlighting/sublime-text/Faust/hbargraph.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/hbargraph.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>hbargraph</tabTrigger>
+    <content><![CDATA[hbargraph("${1:title}",${2:min},${3:max})$0]]></content>
+    <description>hbargraph</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/hslider.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/hslider.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>hslider</tabTrigger>
+    <content><![CDATA[hslider("${1:title}",${2:default},${3:min},${4:max},${5:step})$0]]></content>
+    <description>hslider</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/import.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/import.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>import</tabTrigger>
+    <content><![CDATA[import("${1:name}.lib");$0]]></content>
+    <description>import</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/library.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/library.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>library</tabTrigger>
+    <content><![CDATA[library("${1:name}.lib")$0]]></content>
+    <description>library</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/process.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/process.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>process</tabTrigger>
+    <content><![CDATA[process = ${1:expression};$0]]></content>
+    <description>process</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/stdfaust_lib.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/stdfaust_lib.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>stdfaust.lib</tabTrigger>
+    <content><![CDATA[import("stdfaust.lib");$0]]></content>
+    <description>import stdfaust.lib</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/vbargraph.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/vbargraph.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>vbargraph</tabTrigger>
+    <content><![CDATA[vbargraph("${1:title}",${2:min},${3:max})$0]]></content>
+    <description>vbargraph</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/vslider.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/vslider.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <scope>source.faust</scope>
+    <tabTrigger>vslider</tabTrigger>
+    <content><![CDATA[vslider("${1:title}",${2:default},${3:min},${4:max},${5:step})$0]]></content>
+    <description>vslider</description>
+</snippet>

--- a/syntax-highlighting/sublime-text/Faust/with.sublime-snippet
+++ b/syntax-highlighting/sublime-text/Faust/with.sublime-snippet
@@ -1,0 +1,10 @@
+<snippet>
+    <scope>source.faust</scope>
+    <description>with</description>
+    <tabTrigger>with</tabTrigger>
+    <content><![CDATA[
+    	with {
+    		${1:name} = ${2:definition};$0
+    	}
+    ]]></content>
+</snippet>

--- a/tools/faust2appls/faust2sublimecompletions
+++ b/tools/faust2appls/faust2sublimecompletions
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+
+# ---------------------- faust2sublimecompletions -----------------------
+# Usage: `faust2sublimecompletions *.lib > faust.sublime-completions`
+#
+# Creates a ST4 completions file for each function in a library
+# Assumes the same format than faust2md.
+# This has been adapted from the faust2atomsnippets script, adding link to doc and Usage information by doing more parsing of the std lib
+#
+# The generated file has the following structure:
+#   {
+#   "scope": "source.faust",
+#    "completions": [
+#       {
+#            "annotation": "oscillators.lib",
+#            "contents": "os.osc",
+#            "details": "<code>osc(freq) : _</code> - <a href='https://faustlibraries.grame.fr/libs/oscillators/#ososc'>Docs</a>",
+#            "kind": "ambiguous",
+#            "trigger": "os.osc"
+#       },
+#       ...
+#   ]}
+#
+# The format of a title is :
+#       //############# Title Name #################
+#       //  markdown text....
+#       //  markdown text....
+#       //##########################################
+#
+# The format of a section is :
+#       //============== Section Name ==============
+#       //  markdown text....
+#       //  markdown text....
+#       //==========================================
+#
+# The format of a comment is :
+#       //-------------- foo(x,y) ------------------
+#       //  markdown text....
+#       //  markdown text....
+#       //------------------------------------------
+# everything else is considered faust code.
+# The translation is the following:
+#   ## foo(x,y)
+#       markdown text....
+#       markdown text....
+# --------------------------------------------------------
+
+import sys
+import re
+import getopt
+import os
+import json
+
+# Outdent a comment line by n characters in
+# order to remove the prefix "//   "
+def outdent(line, n):
+    if len(line) <= n:
+        return "\n"
+    else:
+        return line[n:]
+
+# Match the 2-characters prefix of a library.
+# We want to extract "no" from "...prefix is `no`..."
+def matchPrefixName(line):
+    return re.search(r'^.*prefix is .(..).*', line)
+
+# Match the first line of a title
+# of type "//#### Title ####
+# at least 3 * are needed
+def matchBeginTitle(line):
+    return re.search(r'^\s*//#{3,}\s*([^#]+)#{3,}', line)
+
+# Match the last line of a title
+# of type "//#######"
+# or a blank line
+def matchEndTitle(line):
+    return re.search(r'^\s*((//#{3,})|(\s*))$', line)
+
+
+# Match the first line of a section
+# of type "//==== Section ===="
+# at least 3 = are needed
+def matchBeginSection(line):
+    return re.search(r'^\s*//={3,}\s*([^=]+)={3,}', line)
+
+# Match the last line of a section
+# of type "//======="
+# or a blank line
+def matchEndSection(line):
+    return re.search(r'^\s*((//={3,})|(\s*))$', line)
+
+# Match the first line of a comment
+# of type "//--- foo(x,y) ----"
+# at least 3 - are needed
+def matchBeginComment(line):
+    return re.search(r'^\s*//-{3,}\s*`([^-`]+)`-{3,}', line)
+
+def matchBeginUsage(line):
+    return ("####" in line) & ("Usage" in line)
+
+# Match the last line of a comment
+# of type "//-----------------"
+# or a blank line
+def matchEndComment(line):
+    return re.search(r'^\s*((//-{3,})|(\s*))$', line)
+
+# Compute the indentation of a line,
+# that is the position of the first word character
+# after "//   "
+def indentation(line):
+    matchComment = re.search(r'(^\s*//\s*\w)', line)
+    if matchComment:
+        return len(matchComment.group(1))-1
+    else:
+        return 0
+
+# Indicates if a line is a comment
+def isComment(line):
+    matchComment = re.search(r'^\s*//', line)
+    if matchComment:
+        return 1
+    else:
+        return 0
+
+#
+# THE PROGRAM STARTS HERE
+#
+tabsize = 4             # tabsize used for expanding tabs
+mode = 0             # 0: in code; 1: in md-comment
+idt = 0             # indentation retained to outdent comment lines
+libprefix = "xx"  #
+
+# Analyze command line arguments
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "st:cf")
+    if not args:
+        raise getopt.error("At least one file argument required")
+except getopt.error as e:
+    print(e.msg)
+    print("usage: %s [-s][-t tabsize] file ..." % (sys.argv[0],))
+    sys.exit(1)
+for optname, optvalue in opts:
+    if optname == '-t':
+        tabsize = int(optvalue)
+
+# Process all the files and print the documentation on the standard output
+
+inUsage = 0
+trigger = ""
+usage = ""
+
+completions = []
+
+for file in args:
+    with open(file) as f:
+        lines = f.readlines()
+        for num, text in enumerate(lines):
+            line = text.expandtabs(tabsize)
+            matchPrefix = matchPrefixName(line)
+            if matchPrefix:
+                libprefix = matchPrefix.group(1)
+            if isComment(line) == 0:
+                if mode == 1:
+                    # we are closing a md-comment
+                    mode = 0
+            else:
+                if mode == 0:     # we are in code
+                    matchComment = matchBeginComment(line)
+                    matchSection = matchBeginSection(line)
+                    matchTitle = matchBeginTitle(line)
+                    if matchComment:
+                        trigger = ""
+                        usage =  ""
+                        foo = matchComment.group(1)
+                        trigger = foo[1:4]+foo[5:]
+                    if matchComment or matchSection or matchTitle:
+                        mode = 1  # we just started a md-comment
+                        idt = 0  # we have to measure the indentation
+                else:
+                    # we are in a md-comment
+                    matchUsage = matchBeginUsage(line)
+                    if matchUsage:
+                        inUsage = 1
+                    if line.startswith("//") and "```" in line and inUsage:
+                        usage = lines[num+1][2:]
+                        if usage.startswith(' '):
+                            usage = usage[1:-1]
+                        inUsage = 0
+                    if idt == 0:
+                        # we have to measure the indentation
+                        idt = indentation(line)
+                    # check end of md-comment
+                    matchComment = matchEndComment(line)
+                    matchSection = matchEndSection(line)
+                    matchTitle = matchEndTitle(line)
+                    if matchComment or matchSection or matchTitle:
+                        if matchComment:
+                            libfile = os.path.basename(file)
+                            libname = libfile.split('.')[0]
+                            link = "<a href='https://faustlibraries.grame.fr/libs/{0}/#{1}'>Docs</a>".format(libname.lower(), ''.join(trigger.split('.')).lower())
+                            completion = {
+                                "trigger": trigger,
+                                "contents": trigger,
+                                "annotation": libfile,
+                                "kind": "ambiguous",
+                                "details": "<code>" + usage + "</code> - " + link if usage != "" else link
+                            }
+                            completions.append(completion)
+                        # end of md-comment switch back to mode O
+                        mode = 0
+
+final = {
+    "scope": "source.faust",
+    "completions": completions
+}
+print(json.dumps(final, sort_keys=True, indent=4))


### PR DESCRIPTION
This PR proposes to add Sublime Text 4 automatic completions for the standard library and snippets taken from the atom snippets.

I'd like to have that tested a little bit before requesting the merge, this PR can be used for this. Is anyone using Sublime Text 4? @nuchi, maybe?

I wanted to bring as much as possible of the ease of use of faustide to my favorite editor. It resulted in doing more intensive parsing of the `.lib` files in order to extract Usage information, as well as a direct link to the docs:
![faust-completion](https://user-images.githubusercontent.com/2551484/144896443-a80cd33e-3ad6-4fd4-8166-602d57fe39c6.png)

I don't know about other code editors but Sublime Text is not very generous with the size of the area provided for completion: it has to be a single line and I couldn't figure how to force it to span according to the length of the content.
Some functions from the library have long usage lines and the worst case that I haven't covered is when the Usage has multiple lines and the first line is not the one demonstrating the usage. Only the first line of the Usage section is kept.

The more complex parsing allowed to spot some typos in the libraries, thanks to @sletz for promptly correcting all of these!

That is to say, this may have let a few incorrect names, links or usage information through, I cannot expect the automated script to catch every case, feel free to report any that you may find.