### PR TITLE
Correct minimum frequency in elecGuitar.dsp

### DIFF
--- a/examples/smartKeyboard/elecGuitar.dsp
+++ b/examples/smartKeyboard/elecGuitar.dsp
@@ -58,7 +58,7 @@ t = button("gate");
 
 // mapping params
 gate = t+s : min(1);
-freq = f*bend : max(60); // min freq is 60 Hz
+freq = f*bend : max(50); // min freq is 50 Hz
 
 stringLength = freq : pm.f2l;
 pluckPosition = 0.8;


### PR DESCRIPTION
Previously users were able to select frequencies down to 50 Hz, but all frequencies on the range [50 Hz, 60 Hz] were equivalent to selecting 60 Hz. This commit corrects the minimum frequency value to reflect the frequencies provided to the user through the user interface

Tested in Faust IDE