### PR TITLE
CSharp fixes for IsInfinity, removal of GetInputRate() and GetOutputRate()

### DIFF
--- a/architecture/CSharpFaustBase.cs
+++ b/architecture/CSharpFaustBase.cs
@@ -167,8 +167,6 @@ public interface IFaustDSP
 
     int GetNumInputs();
     int GetNumOutputs();
-    int GetInputRate(int channel);
-    int GetOutputRate(int channel);
     void ClassInit(int sample_rate);
     void InstanceConstants(int sample_rate);
     void InstanceResetUserInterface();
@@ -197,6 +195,16 @@ public class dsp
     public static float FModF(float val1, float val2)
     {
         return val1 % val2;
+    }
+
+    public static bool IsInfinity(double d)
+    {
+        return double.IsNegativeInfinity(d) || double.IsPositiveInfinity(d);
+    }
+
+    public static bool IsInfinityF(float d)
+    {
+        return float.IsNegativeInfinity(d) || float.IsPositiveInfinity(d);
     }
 }
 

--- a/compiler/generator/csharp/csharp_code_container.cpp
+++ b/compiler/generator/csharp/csharp_code_container.cpp
@@ -161,14 +161,7 @@ void CSharpCodeContainer::produceClass()
     // Libraries
     printLibrary(*fOut);
     tab(n, *fOut);
-    
-    if (gGlobal->gFloatSize == 1) {
-        *fOut << "public static bool IsInfinity(float d) { return Float.IsNegativeInfinity(float d) || Float.IsPositiveInfinity(float d); }";
-    } else if (gGlobal->gFloatSize == 2) {
-        *fOut << "public static bool IsInfinity(double d) { return Double.IsNegativeInfinity(double d) || Double.IsPositiveInfinity(double d); }";
-    }
-    tab(n, *fOut);
-    
+        
     tab(n, *fOut);
     *fOut << "public class " << fKlassName << " : " << fSuperKlassName << ", " << "IFaustDSP";
     tab(n, *fOut);

--- a/compiler/generator/csharp/csharp_instructions.hh
+++ b/compiler/generator/csharp/csharp_instructions.hh
@@ -95,7 +95,7 @@ class CSharpInstVisitor : public TextInstVisitor {
     
         gMathLibTable["isnanf"]     = "(float)Math.IsNan";
         // Manually implemented
-        gMathLibTable["isinff"]     = "IsInfinity";
+        gMathLibTable["isinff"]     = "IsInfinityF";
         gMathLibTable["copysignf"]  = "(float)Math.CopySign";
 
         // Double version


### PR DESCRIPTION
Added IsInfinity and IsInfinityF to C# base class and removed from codegen. Removed GetInputRate() and GetOutputRate() from IFaustDSP interface.

Fixes issues #686 and #687