### PR TITLE
Restart / reinit oboe when stream is disconnected

### DIFF
--- a/architecture/api/DspFaust.cpp
+++ b/architecture/api/DspFaust.cpp
@@ -170,6 +170,8 @@ DspFaust::DspFaust(bool auto_connect)
 #elif JUCE_DRIVER
     // JUCE audio device has its own sample rate and buffer size
     driver = new juceaudio();
+#elif ANDROID_DRIVER
+    driver = new oboeaudio(-1);
 #else
     printf("You are not setting 'sample_rate' and 'buffer_size', but the audio driver needs it !\n");
     throw std::bad_alloc();


### PR DESCRIPTION
As discussed in #691, when a disconnection event occurs processing in oboe stops. This PR attempts to re-init oboe again in that case. From testing on a couple of devices this seems to work as intended.

I've also added the `ANDROID_DRIVER` to the default constructor since that allows to init `DspFaust` without any sample rate and buffer size, both of which are not passed on to the oboe driver anyway currently. This saves some setup in the consuming Android app too.
