### PR TITLE
Work around Safari bug for wasm support

### DIFF
--- a/architecture/webaudio/webaudio-workletnode-emcc-poly-standalone-wrapper.js
+++ b/architecture/webaudio/webaudio-workletnode-emcc-poly-standalone-wrapper.js
@@ -481,7 +481,7 @@ class mydspPoly {
 
             let json_object = JSON.parse(json);
 
-            let options = { wasm_module: wasm_module.module, json: json, wasm_effect_module: ((wasm_effect_module) ? wasm_effect_module.module : null), json_effect: json_effect, soundfiles: soundfiles, json_all: json_all, polyphony: this.polyphony };
+            let options = { wasm_buffer: wasm_buffer, json: json, wasm_effect_module: ((wasm_effect_module) ? wasm_effect_module.module : null), json_effect: json_effect, soundfiles: soundfiles, json_all: json_all, polyphony: this.polyphony };
 
             let re = /JSON_STR/g;
             let mydspPolyProcessorString1 = mydspPolyProcessorString.replace(re, json_all);
@@ -738,7 +738,8 @@ let mydspPolyProcessorString = `
                                                         AudioWorkletGlobalScope.faust_module.FS.close(stream);
                                                         });
             
-            this.wasm_instance = new WebAssembly.Instance(options.processorOptions.wasm_module, importObject);
+            const wasmModule = new WebAssembly.Module(options.processorOptions.wasm_buffer);
+            this.wasm_instance = new WebAssembly.Instance(wasmModule, importObject);
             AudioWorkletGlobalScope.faust_module.faust.wasm_instance.push(this.wasm_instance);
             this.factory = AudioWorkletGlobalScope.faust_module.wasm_dsp_factory.createWasmDSPFactory(0, options.processorOptions.json);
             

--- a/architecture/webaudio/webaudio-workletnode-emcc-standalone-wrapper.js
+++ b/architecture/webaudio/webaudio-workletnode-emcc-standalone-wrapper.js
@@ -405,7 +405,6 @@ class mydsp {
             let real_url = (this.baseURL === "") ? "mydsp.wasm" : (this.baseURL + "/mydsp.wasm");
             const wasm_file = await fetch(real_url);
             const wasm_buffer = await wasm_file.arrayBuffer();
-            const wasm_module = await WebAssembly.compile(wasm_buffer);
             const json = faust_module.wasm_dsp_factory.extractJSON(wasm_buffer);
 
             // Load soundfiles
@@ -414,7 +413,7 @@ class mydsp {
             return new Promise((resolve, reject) => {
 
                 let json_object = JSON.parse(json);
-                let options = { wasm_module: wasm_module, json: json, soundfiles: soundfiles };
+                let options = { wasm_buffer: wasm_buffer, json: json, soundfiles: soundfiles };
 
                 let re = /JSON_STR/g;
                 let mydspProcessorString1 = mydspProcessorString.replace(re, json);
@@ -663,7 +662,8 @@ let mydspProcessorString = `
                                                         AudioWorkletGlobalScope.faust_module.FS.close(stream);
                                                         });
             
-            this.wasm_instance = new WebAssembly.Instance(options.processorOptions.wasm_module, importObject);
+            const wasmModule = new WebAssembly.Module(options.processorOptions.wasm_buffer);
+            this.wasm_instance = new WebAssembly.Instance(wasmModule, importObject);
             AudioWorkletGlobalScope.faust_module.faust.wasm_instance.push(this.wasm_instance);
             this.json_object = JSON.parse(options.processorOptions.json);
             this.factory = AudioWorkletGlobalScope.faust_module.wasm_dsp_factory.createWasmDSPFactory(0, options.processorOptions.json);

--- a/architecture/webaudio/webaudio-workletnode-standalone-wrapper.js
+++ b/architecture/webaudio/webaudio-workletnode-standalone-wrapper.js
@@ -448,7 +448,7 @@ class mydsp {
             let HEAPU8 = new Uint8Array(dspInstance.exports.memory.buffer);
             let json = this.heap2Str(HEAPU8);
             let json_object = JSON.parse(json);
-            let options = { wasm_module: dspModule, json: json };
+            let options = { wasm_buffer: dspBuffer, json: json };
 
             if (this.fWorkletProcessors.indexOf(name) === -1) {
                 try {
@@ -673,7 +673,8 @@ let mydspProcessorString = `
                     }
             };
             
-            this.mydsp_instance = new WebAssembly.Instance(options.processorOptions.wasm_module, importObject);
+            const wasmModule = new WebAssembly.Module(options.processorOptions.wasm_buffer);
+            this.mydsp_instance = new WebAssembly.Instance(wasmModule, importObject);
             this.json_object = JSON.parse(options.processorOptions.json);
          
             this.output_handler = function(path, value) { this.port.postMessage({ path: path, value: value }); };

--- a/architecture/webaudio/webaudio-workletprocessor-standalone-wrapper.js
+++ b/architecture/webaudio/webaudio-workletprocessor-standalone-wrapper.js
@@ -156,7 +156,8 @@ class mydspProcessor extends AudioWorkletProcessor {
             }
         };
 
-        this.mydsp_instance = new WebAssembly.Instance(options.processorOptions.wasm_module, importObject);
+        const wasmModule = new WebAssembly.Module(options.processorOptions.wasm_buffer);
+        this.mydsp_instance = new WebAssembly.Instance(wasmModule, importObject);
         this.json_object = JSON.parse(options.processorOptions.json);
 
         this.output_handler = function (path, value) { this.port.postMessage({ path: path, value: value }); };


### PR DESCRIPTION
Fixes https://github.com/grame-cncm/faust/issues/640

I've tested with `faust2wasm -worklet`, the result works across Firefox/Chromium/Safari on macOS. I haven't tested the other code paths but they should work just as well. I also haven't regenerated the web audio examples.

The Safari bug means that wasm modules can't be posted to the AudioWorketProcessor — the workaround is to post the buffer and compile in the processor.