### PR TITLE
Update faust2caqt for QT6

### DIFF
--- a/tools/faust2appls/faust2caqt
+++ b/tools/faust2appls/faust2caqt
@@ -134,8 +134,8 @@ if [[ $(uname) == Darwin ]]; then
     if [ $SYS_VERSION -ge 13 ]
 	then
 	    SPEC="-spec macx-clang"
-	    CLANGOPT="QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9"  
-	    CXXFLAGS="$CXXFLAGS -mmacosx-version-min=10.9"
+	    CLANGOPT="QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15"  
+	    CXXFLAGS="$CXXFLAGS -mmacosx-version-min=10.15"
 	else
 	    SPEC="-spec macx-g++"
 	    CLANGOPT=""


### PR DESCRIPTION
Without this change faust2caqt fails due to the usage of std::filesystem in QT6, with errors such as:

```/opt/homebrew/lib/QtCore.framework/Headers/qfileinfo.h:120:14: error: '~path' is unavailable: introduced in macOS 10.15
    { return QtPrivate::toFilesystemPath(absoluteFilePath()); }```

if supporting macOS < 10.15 is important, then this might not be the best fix