### PR TITLE
Initial work for LLVM 15, also refactor the LLVM version macros

### DIFF
--- a/compiler/generator/interpreter/fbc_llvm_compiler.hh
+++ b/compiler/generator/interpreter/fbc_llvm_compiler.hh
@@ -865,7 +865,7 @@ class FBCLLVMCompiler : public FBCExecuteFun<REAL> {
         fLLVMInputs   = LLVMGetParam(execute, 2);
         fLLVMOutputs  = LLVMGetParam(execute, 3);
 
-#if defined(LLVM_50) || defined(LLVM_60)
+#if (LLVM_VERSION_MAJOR == 5) || (LLVM_VERSION_MAJOR == 6)
         LLVMSetValueName(fLLVMIntHeap, "int_heap");
         LLVMSetValueName(fLLVMRealHeap, "real_heap");
         LLVMSetValueName(fLLVMInputs, "inputs");

--- a/compiler/generator/llvm/clang_code_container.cpp
+++ b/compiler/generator/llvm/clang_code_container.cpp
@@ -40,17 +40,16 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <llvm/Bitcode/ReaderWriter.h>
-#if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || \
-    defined(LLVM_39) || defined(LLVM_40)
+#if (LLVM_VERSION_MAJOR >= 4) || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 4)
 #include <llvm/IR/Module.h>
 #else
 #include <llvm/Module.h>
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if (LLVM_VERSION_MAJOR >= 4) || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 5)
 #include <llvm/Support/FileSystem.h>
 #define sysfs_binary_flag sys::fs::F_None
-#elif defined(LLVM_34)
+#elif (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 4)
 #define sysfs_binary_flag sys::fs::F_Binary
 #else
 #define sysfs_binary_flag raw_fd_ostream::F_Binary
@@ -111,8 +110,7 @@ LLVMResult* ClangCodeContainer::produceModule(Tree signals, const string& filena
     fCompiler->compileMultiSignal(signals);
     fContainer->produceClass();
 
-#if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || \
-    defined(LLVM_39) || defined(LLVM_40)
+#if (LLVM_VERSION_MAJOR >= 4) || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 4)
     // Compile it with 'clang'
     IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts   = new DiagnosticOptions();
     TextDiagnosticPrinter*                DiagClient = new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);

--- a/compiler/generator/llvm/llvm_code_container.cpp
+++ b/compiler/generator/llvm/llvm_code_container.cpp
@@ -75,8 +75,7 @@ void LLVMCodeContainer::init(const string& name, int numInputs, int numOutputs, 
     
     // Set "-fast-math"
     FastMathFlags FMF;
-#if defined(LLVM_80) || defined(LLVM_90) || defined(LLVM_100) || \
-    defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130) || defined(LLVM_140)
+#if LLVM_VERSION_MAJOR >= 8
     FMF.setFast();  // has replaced the following function
 #else
     FMF.setUnsafeAlgebra();

--- a/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -116,7 +116,7 @@ void llvm_dsp_factory_aux::startLLVMLibrary()
 {
     if (llvm_dsp_factory_aux::gInstance++ == 0) {
         // Install the LLVM error handler
-    #if defined(__APPLE__) && defined(LLVM_130)
+    #if defined(__APPLE__) && LLVM_VERSION_MAJOR == 13
         #warning Crash on OSX so deactivated in this case
     #else
         LLVMInstallFatalErrorHandler(llvm_dsp_factory_aux::LLVMFatalErrorHandler);
@@ -128,7 +128,7 @@ void llvm_dsp_factory_aux::stopLLVMLibrary()
 {
     if (--llvm_dsp_factory_aux::gInstance == 0) {
         // Remove the LLVM error handler
-    #if defined(__APPLE__) && (defined(LLVM_110) || defined(LLVM_120) || defined(LLVM_130))
+    #if defined(__APPLE__) && (LLVM_VERSION_MAJOR >= 11 && LLVM_VERSION_MAJOR <= 13)
         #warning Crash on OSX so deactivated in this case
     #else
         LLVMResetFatalErrorHandler();


### PR DESCRIPTION
Hi,
I tried building against LLVM 15 but it currently fails... 

I marked the places which changed and that I could not fix, pretty much only IRBuilder, but my LLVM-fu is not high enough to understand what a correct fix would be..

I also replaced the LLVM_XX macros by LLVM_VERSION_MAJOR checks (which have been there since llvm 3.1, from what I could see the earliest macros in the code refer to 3.4)