### PR TITLE
fix parallel build of Make.llvm.static

### DIFF
--- a/build/Make.llvm.static
+++ b/build/Make.llvm.static
@@ -19,10 +19,10 @@ MAKEFILE := $(lastword $(MAKEFILE_LIST))
 
 .PHONY: $(OUTPUT)
 
-all: $(FOLDERS) $(OUTPUT)
+all: $(OUTPUT)
 	$(MAKE) -f $(MAKEFILE) syslibs
 
-$(OUTPUT):
+$(OUTPUT): $(FOLDERS)
 	@-[ -f $@ ] && rm -f $@ 
 	$(AR) -csr $(OUTPUT) $(TMP)/*/*.o 
 	rm -rf $(TMP)


### PR DESCRIPTION
I noticed when updating Homebrew formula to 2.40.0 (https://github.com/Homebrew/homebrew-core/pull/98755) where parallel build is default behavior.

Repeated builds would produce different total size, e.g.
```
🍺  /usr/local/Cellar/faust/2.40.0: 1,469 files, 247.2MB, built in 2 minutes 49 seconds
```
```
🍺  /usr/local/Cellar/faust/2.40.0: 1,469 files, 250.6MB, built in 2 minutes 54 seconds
```

Running deparallelized showed 264.3MB:
```
🍺  /usr/local/Cellar/faust/2.40.0: 1,469 files, 264.3MB, built in 12 minutes 10 seconds
```

---

I believe the issue is that the `$(FOLDERS)` and  `$(OUTPUT)` are allowed to run in parallel, so the number of LLVM libraries extracted is non-deterministic by the time `libfaustwithllvm.a` is created.

To avoid this, the `$(OUTPUT)` should depend on `$(FOLDERS)`