### PR TITLE
Add more `OCPP_BUILD` checks to fix undefined `old_comp` in `compiler/libcode.cpp`.

### DIFF
--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -1936,9 +1936,13 @@ static void generateCode(Tree signals, int numInputs, int numOutputs, bool gener
 
     if (new_comp) {
         generateCodeAux1(dst);
-    } else if (old_comp) {
+    }
+#ifdef OCPP_BUILD
+    else if (old_comp) {
         generateCodeAux2(dst);
-    } else {
+    }
+#endif
+    else {
         faustassert(false);
     }
     
@@ -1987,9 +1991,13 @@ static void generateOutputFiles()
     if (gGlobal->gPrintXMLSwitch) {
         if (new_comp) {
             printXML(new_comp->getDescription(), container->inputs(), container->outputs());
-        } else if (old_comp) {
+        }
+#ifdef OCPP_BUILD
+        else if (old_comp) {
             printXML(old_comp->getDescription(), old_comp->getClass()->inputs(), old_comp->getClass()->outputs());
-        } else {
+        }
+#endif
+        else {
             faustassert(false);
         }
     }
@@ -2010,9 +2018,13 @@ static void generateOutputFiles()
         ofstream dotfile(subst("$0.dot", gGlobal->makeDrawPath()).c_str());
         if (new_comp) {
             container->printGraphDotFormat(dotfile);
-        } else if (old_comp) {
+        }
+#ifdef OCPP_BUILD
+        else if (old_comp) {
             old_comp->getClass()->printGraphDotFormat(dotfile);
-        } else {
+        }
+#endif
+        else {
             faustassert(false);
         }
     }


### PR DESCRIPTION
@sletz Wasn't able to build after updating to latest commit on `master-dev`. Looks like just a few missing spots from [recent refactoring](https://github.com/grame-cncm/faust/commit/37a8d272bb837266df718593facd9636e630b97a). First commit so please let me know if anything else is expected for PRs!