### PR TITLE
fix: faust2sc.py missing "include" part of header path in guess

### DIFF
--- a/tools/faust2appls/faust2sc.py
+++ b/tools/faust2appls/faust2sc.py
@@ -125,9 +125,9 @@ def faustoptflags():
 # Return the header paths if they exists.
 def get_header_paths(headerpath):
     folders = [
-        path.join(headerpath, "plugin_interface"),
-        path.join(headerpath, "server"),
-        path.join(headerpath, "common")
+        path.join(headerpath, "include", "plugin_interface"),
+        path.join(headerpath, "include", "server"),
+        path.join(headerpath, "include",  "common")
     ]
 
     if all(path.exists(folder) for folder in folders):


### PR DESCRIPTION
The guessing mechanism was missing the "include" part of the headerpath guess which is the subfolder the folders it is looking for exists in in the supercollider repo