### PR TITLE
Instead of throwing on syntax error in `DSPToBoxes`, set the provided error message

### DIFF
--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -2130,9 +2130,14 @@ LIBFAUST_API Tree DSPToBoxes(const std::string& dsp_content, int* inputs, int* o
     }
     initDocumentNames();
     initFaustFloat();
-    
-    parseSourceFiles();
-    
+
+    try{
+        parseSourceFiles();
+    } catch (faustexception& e) {
+        error_msg = e.what();
+        return nullptr;
+    }
+
     /****************************************************************
      3 - evaluate 'process' definition
      *****************************************************************/


### PR DESCRIPTION
As a first step to prep for some explorations building Boxes using a visual node editor, I am replacing my `createDSPFactoryFromString` step with a `DSPToBoxes` -> `createDSPFactoryFromBoxes` chain. Currently, I can rely on `createDSPFactoryFromString` to set the provided error message string with any syntax errors, and return a `nullptr`. However, `DSPToBoxes` seems to assume the provided code has no syntax errors.

I see other places where `parseSourceFiles` is called without a try-catch block, so maybe this is an intentional part of the contract at this stage, and the user is expected to handle thrown errors?

Also, since `createDSPFactoryFromString` take a `string name_app` arg, it's able to use this in the error message, eg.

```
Faust error:
FlowGrid : 1 : ERROR : syntax error
```

whereas since `DSPToBoxes` uses a dummy filename,

```cpp
gGlobal->gInputFiles.push_back("dummy");
```

a syntax error (with this PR) results in:

```
Faust error:
dummy : 1 : ERROR : syntax error
```

Maybe we could provide an optional `app_name` arg, or a delegate method signature with `app_name` as the first arg? If that sounds good, I can add that to this PR.

Thanks!