### PR TITLE
[ffunction] Allow the user of llvm-dsp.h to declare preexisting known foreign functions

### DIFF
--- a/architecture/faust/dsp/llvm-dsp.h
+++ b/architecture/faust/dsp/llvm-dsp.h
@@ -508,6 +508,12 @@ DEPRECATED(llvm_dsp* createDSPInstance(llvm_dsp_factory* factory));
  */ 
 DEPRECATED(void deleteDSPInstance(llvm_dsp* dsp));
 
+/**
+ * Register a custom foreign function that will be exported by the host binary running the DSP code
+ *
+ * @param function_name - the function name to make available.
+ */
+LIBFAUST_API void registerCustomForeignFunction(const std::string& fuction_name);
 /*!
  @}
  */

--- a/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -90,6 +90,7 @@ extern "C" LIBFAUST_API void printPtr(void* val)
 int llvm_dsp_factory_aux::gInstance = 0;
 
 dsp_factory_table<SDsp_factory> llvm_dsp_factory_aux::gLLVMFactoryTable;
+std::set<std::string> llvm_dsp_factory_aux::gCustomForeignFunctions;
 
 uint64_t llvm_dsp_factory_aux::loadOptimize(const string& function)
 {
@@ -877,3 +878,9 @@ LIBFAUST_API void deleteCDSPInstance(llvm_dsp* dsp)
 #ifdef __cplusplus
 }
 #endif
+
+LIBFAUST_API void registerCustomForeignFunction(const std::string& name)
+{
+    LOCK_API
+    llvm_dsp_factory_aux::gCustomForeignFunctions.insert(name);
+}

--- a/compiler/generator/llvm/llvm_dsp_aux.hh
+++ b/compiler/generator/llvm/llvm_dsp_aux.hh
@@ -23,6 +23,7 @@
 #define LLVM_DSP_AUX_H
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -245,6 +246,7 @@ class llvm_dsp_factory_aux : public dsp_factory_imp {
     static int gInstance;
 
     static dsp_factory_table<SDsp_factory> gLLVMFactoryTable;
+    static std::set<std::string>           gCustomForeignFunctions; // Map of custom foreign functions
 };
 
 // Public C++ interface


### PR DESCRIPTION
Tested in ossia with the Guitarix and STK ffunctions, I haven't encountered issues