### PR TITLE
Trill sensors support for faust2bela

### DIFF
--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -34,10 +34,29 @@
  that work under terms of your choice, so long as this FAUST
  architecture section is not modified.
  
- evolution : Trill Sensors support (Pascal Faivre-Cubizolles)
+
  
  ************************************************************************
- ************************************************************************/
+ ************************************************************************/ 
+ 
+ /************************************************************************
+    Evolution (2022): Trill Sensors support 
+	
+	type supported : 
+		BAR : Position, Pressure, Touched. Multitouch not supported
+		SQUARE : Position X & Y, Pressure, Touched. Multitouch not supported
+	usage : addin Meta data in UI widget of the Faust Code
+		TRILL:BAR_POS_n
+		TRILL:BAR_LVL_n
+		TRILL:BAR_TOUCH_n
+		TRILL:SQUARE_XPOS_n
+		TRILL:SQUARE_YPOS_n
+		TRILL:SQUARE_LVL_n
+		TRILL:SQUARE_TOUCH_n
+	where n is the sensors index. index suported are 0 to 7 for each type of sensor
+	2 array (TrillBarAdress and TrillSquareAdress) allow to route the i2c addresses of the sensors
+	
+ ************************************************************************/ 
 
 #ifndef __FaustBela_H__
 #define __FaustBela_H__
@@ -125,7 +144,7 @@ const char* const pinNamesStrings[] =
     "ANALOG_OUT_6",
     "ANALOG_OUT_7",
     "ANALOG_OUT_8",
-	"BAR_POS_0",
+	"BAR_POS_0", //Trill sensors
     "BAR_LVL_0",
 	"BAR_TOUCH_0",
 	"BAR_POS_1",
@@ -379,6 +398,13 @@ class BelaWidget
 		}
 			
 };
+
+/**************************************************************************************
+ 
+ BelaWidget : object used by BelaUI to ensures the connection between a Trill sensors values
+ and a Faust widget
+ 
+ ***************************************************************************************/
 
 
 class TrillWidget : public BelaWidget

--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -41,21 +41,21 @@
  
  /************************************************************************
     Evolution (2022): Trill Sensors support 
-	
-	type of sensors supported : 
-		BAR : Position, Pressure, Touched. (Multitouch not supported)
-		SQUARE : Position X & Y, Pressure, Touched. (Multitouch not supported)
-	usage : addin Meta data in UI widget of the Faust Code
-		TRILL:BAR_POS_n
-		TRILL:BAR_LVL_n
-		TRILL:BAR_TOUCH_n
-		TRILL:SQUARE_XPOS_n
-		TRILL:SQUARE_YPOS_n
-		TRILL:SQUARE_LVL_n
-		TRILL:SQUARE_TOUCH_n
-	where n is the sensors index. index suported are 0 to 7 for each type of sensor
-	2 array (TrillBarAdress and TrillSquareAdress) allow to route the i2c addresses of the sensors
-	
+    
+    type of sensors supported : 
+        BAR : Position, Pressure, Touched. (Multitouch not supported)
+        SQUARE : Position X & Y, Pressure, Touched. (Multitouch not supported)
+    usage : addin Meta data in UI widget of the Faust Code
+        TRILL:BAR_POS_n
+        TRILL:BAR_LVL_n
+        TRILL:BAR_TOUCH_n
+        TRILL:SQUARE_XPOS_n
+        TRILL:SQUARE_YPOS_n
+        TRILL:SQUARE_LVL_n
+        TRILL:SQUARE_TOUCH_n
+    where n is the sensors index. index suported are 0 to 7 for each type of sensor
+    2 array (TrillBarAdress and TrillSquareAdress) allow to route the i2c addresses of the sensors
+    
  ************************************************************************/ 
 
 #ifndef __FaustBela_H__
@@ -144,62 +144,62 @@ const char* const pinNamesStrings[] =
     "ANALOG_OUT_6",
     "ANALOG_OUT_7",
     "ANALOG_OUT_8",
-	"BAR_POS_0", //Trill sensors
+    "BAR_POS_0", //Trill sensors
     "BAR_LVL_0",
-	"BAR_TOUCH_0",
-	"BAR_POS_1",
+    "BAR_TOUCH_0",
+    "BAR_POS_1",
     "BAR_LVL_1",
-	"BAR_TOUCH_1",
-	"BAR_POS_2",
+    "BAR_TOUCH_1",
+    "BAR_POS_2",
     "BAR_LVL_2",
-	"BAR_TOUCH_2",
-	"BAR_POS_3",
+    "BAR_TOUCH_2",
+    "BAR_POS_3",
     "BAR_LVL_3",
-	"BAR_TOUCH_3",
-	"BAR_POS_4",
+    "BAR_TOUCH_3",
+    "BAR_POS_4",
     "BAR_LVL_4",
-	"BAR_TOUCH_4",
-	"BAR_POS_5",
+    "BAR_TOUCH_4",
+    "BAR_POS_5",
     "BAR_LVL_5",
-	"BAR_TOUCH_5",
-	"BAR_POS_6",
+    "BAR_TOUCH_5",
+    "BAR_POS_6",
     "BAR_LVL_6",
-	"BAR_TOUCH_6",
-	"BAR_POS_7",
+    "BAR_TOUCH_6",
+    "BAR_POS_7",
     "BAR_LVL_7",
-	"BAR_TOUCH_7",
-	"SQUARE_XPOS_0",
-	"SQUARE_YPOS_0",
-	"SQUARE_LVL_0",
-	"SQUARE_TOUCH_0",
-	"SQUARE_XPOS_1",
-	"SQUARE_YPOS_1",
-	"SQUARE_LVL_1",
-	"SQUARE_TOUCH_1",
-	"SQUARE_XPOS_2",
-	"SQUARE_YPOS_2",	
-	"SQUARE_LVL_2",
-	"SQUARE_TOUCH_2",
-	"SQUARE_XPOS_3",
-	"SQUARE_YPOS_3",
-	"SQUARE_LVL_3",
-	"SQUARE_TOUCH_3",
-	"SQUARE_XPOS_4",
-	"SQUARE_YPOS_4",	
-	"SQUARE_LVL_4",
-	"SQUARE_TOUCH_4",
-	"SQUARE_XPOS_5",
-	"SQUARE_YPOS_5",
-	"SQUARE_LVL_5",
-	"SQUARE_TOUCH_5",
-	"SQUARE_XPOS_6",
-	"SQUARE_YPOS_6",	
-	"SQUARE_LVL_6",
-	"SQUARE_TOUCH_6",
-	"SQUARE_XPOS_7",
-	"SQUARE_YPOS_7",
-	"SQUARE_LVL_7",
-	"SQUARE_TOUCH_7"
+    "BAR_TOUCH_7",
+    "SQUARE_XPOS_0",
+    "SQUARE_YPOS_0",
+    "SQUARE_LVL_0",
+    "SQUARE_TOUCH_0",
+    "SQUARE_XPOS_1",
+    "SQUARE_YPOS_1",
+    "SQUARE_LVL_1",
+    "SQUARE_TOUCH_1",
+    "SQUARE_XPOS_2",
+    "SQUARE_YPOS_2",    
+    "SQUARE_LVL_2",
+    "SQUARE_TOUCH_2",
+    "SQUARE_XPOS_3",
+    "SQUARE_YPOS_3",
+    "SQUARE_LVL_3",
+    "SQUARE_TOUCH_3",
+    "SQUARE_XPOS_4",
+    "SQUARE_YPOS_4",    
+    "SQUARE_LVL_4",
+    "SQUARE_TOUCH_4",
+    "SQUARE_XPOS_5",
+    "SQUARE_YPOS_5",
+    "SQUARE_LVL_5",
+    "SQUARE_TOUCH_5",
+    "SQUARE_XPOS_6",
+    "SQUARE_YPOS_6",    
+    "SQUARE_LVL_6",
+    "SQUARE_TOUCH_6",
+    "SQUARE_XPOS_7",
+    "SQUARE_YPOS_7",
+    "SQUARE_LVL_7",
+    "SQUARE_TOUCH_7"
 };
 
 enum EInOutPin
@@ -239,62 +239,62 @@ enum EInOutPin
     kANALOG_OUT_6,
     kANALOG_OUT_7,
     kANALOG_OUT_8,
-	kBAR_POS_0,
+    kBAR_POS_0,
     kBAR_LVL_0,
-	kBAR_TOUCH_0,
-	kBAR_POS_1,
+    kBAR_TOUCH_0,
+    kBAR_POS_1,
     kBAR_LVL_1,
-	kBAR_TOUCH_1,
-	kBAR_POS_2,
+    kBAR_TOUCH_1,
+    kBAR_POS_2,
     kBAR_LVL_2,
-	kBAR_TOUCH_2,
-	kBAR_POS_3,
+    kBAR_TOUCH_2,
+    kBAR_POS_3,
     kBAR_LVL_3,
-	kBAR_TOUCH_3,
-	kBAR_POS_4,
+    kBAR_TOUCH_3,
+    kBAR_POS_4,
     kBAR_LVL_4,
-	kBAR_TOUCH_4,
-	kBAR_POS_5,
+    kBAR_TOUCH_4,
+    kBAR_POS_5,
     kBAR_LVL_5,
-	kBAR_TOUCH_5,
-	kBAR_POS_6,
+    kBAR_TOUCH_5,
+    kBAR_POS_6,
     kBAR_LVL_6,
-	kBAR_TOUCH_6,
-	kBAR_POS_7,
+    kBAR_TOUCH_6,
+    kBAR_POS_7,
     kBAR_LVL_7,
-	kBAR_TOUCH_7,
-	kSQUARE_XPOS_0,
-	kSQUARE_YPOS_0,
-	kSQUARE_LVL_0,
-	kSQUARE_TOUCH_0,
-	kSQUARE_XPOS_1,
-	kSQUARE_YPOS_1,
-	kSQUARE_LVL_1,
-	kSQUARE_TOUCH_1,
-	kSQUARE_XPOS_2,
-	kSQUARE_YPOS_2,
-	kSQUARE_LVL_2,	
-	kSQUARE_TOUCH_2,
-	kSQUARE_XPOS_3,
-	kSQUARE_YPOS_3,
-	kSQUARE_LVL_3,
-	kSQUARE_TOUCH_3,
-	kSQUARE_XPOS_4,
-	kSQUARE_YPOS_4,
-	kSQUARE_LVL_4,	
-	kSQUARE_TOUCH_4,
-	kSQUARE_XPOS_5,
-	kSQUARE_YPOS_5,
-	kSQUARE_LVL_5,
-	kSQUARE_TOUCH_5,
-	kSQUARE_XPOS_6,
-	kSQUARE_YPOS_6,
-	kSQUARE_LVL_6,	
-	kSQUARE_TOUCH_6,
-	kSQUARE_XPOS_7,
-	kSQUARE_YPOS_7,
-	kSQUARE_LVL_7,
-	kSQUARE_TOUCH_7,
+    kBAR_TOUCH_7,
+    kSQUARE_XPOS_0,
+    kSQUARE_YPOS_0,
+    kSQUARE_LVL_0,
+    kSQUARE_TOUCH_0,
+    kSQUARE_XPOS_1,
+    kSQUARE_YPOS_1,
+    kSQUARE_LVL_1,
+    kSQUARE_TOUCH_1,
+    kSQUARE_XPOS_2,
+    kSQUARE_YPOS_2,
+    kSQUARE_LVL_2,    
+    kSQUARE_TOUCH_2,
+    kSQUARE_XPOS_3,
+    kSQUARE_YPOS_3,
+    kSQUARE_LVL_3,
+    kSQUARE_TOUCH_3,
+    kSQUARE_XPOS_4,
+    kSQUARE_YPOS_4,
+    kSQUARE_LVL_4,    
+    kSQUARE_TOUCH_4,
+    kSQUARE_XPOS_5,
+    kSQUARE_YPOS_5,
+    kSQUARE_LVL_5,
+    kSQUARE_TOUCH_5,
+    kSQUARE_XPOS_6,
+    kSQUARE_YPOS_6,
+    kSQUARE_LVL_6,    
+    kSQUARE_TOUCH_6,
+    kSQUARE_XPOS_7,
+    kSQUARE_YPOS_7,
+    kSQUARE_LVL_7,
+    kSQUARE_TOUCH_7,
     kNumInputPins
 };
 
@@ -392,11 +392,11 @@ class BelaWidget
                     break;
             };
         }
-		
-		virtual EInOutPin getBelaPin() {
-			return  fBelaPin;
-		}
-			
+        
+        virtual EInOutPin getBelaPin() {
+            return  fBelaPin;
+        }
+            
 };
 
 /**************************************************************************************
@@ -409,149 +409,149 @@ class BelaWidget
 
 class TrillWidget : public BelaWidget
 {
-	protected:
-	   
-		Trill* sensor;
-		Trill::Device type;
-	public:
-	 
-	TrillWidget() 
-	{ 
-		BelaWidget(); 
-		sensor=NULL;
-		type=Trill::NONE;
-	}
+    protected:
+       
+        Trill* sensor;
+        Trill::Device type;
+    public:
+     
+    TrillWidget() 
+    { 
+        BelaWidget(); 
+        sensor=NULL;
+        type=Trill::NONE;
+    }
 
-	TrillWidget(const TrillWidget& w) 
-	{ 
-		BelaWidget((BelaWidget) w); 
-		sensor=NULL;
-		type=Trill::NONE;
-	}
+    TrillWidget(const TrillWidget& w) 
+    { 
+        BelaWidget((BelaWidget) w); 
+        sensor=NULL;
+        type=Trill::NONE;
+    }
 
-	TrillWidget(EInOutPin pin, FAUSTFLOAT* z, const char* l, FAUSTFLOAT lo, FAUSTFLOAT hi)
-	{  
-		fBelaPin=pin;
+    TrillWidget(EInOutPin pin, FAUSTFLOAT* z, const char* l, FAUSTFLOAT lo, FAUSTFLOAT hi)
+    {  
+        fBelaPin=pin;
         fZone=z;  // zone
         fLabel=l; // label
         fMin=lo;    // minimal value
         fRange=hi;
-		sensor=NULL;
-		if(strstr(pinNamesStrings[fBelaPin],"BAR"))
-			type=Trill::BAR;
-		else if(strstr(pinNamesStrings[fBelaPin],"SQUARE"))
-			type=Trill::SQUARE;
-		else 
-			type=Trill::NONE;
-	}
-	
-	void setSensor(Trill* nSensor)
-	{
-		if(nSensor)
-			sensor=nSensor;
-	}
+        sensor=NULL;
+        if(strstr(pinNamesStrings[fBelaPin],"BAR"))
+            type=Trill::BAR;
+        else if(strstr(pinNamesStrings[fBelaPin],"SQUARE"))
+            type=Trill::SQUARE;
+        else 
+            type=Trill::NONE;
+    }
+    
+    void setSensor(Trill* nSensor)
+    {
+        if(nSensor)
+            sensor=nSensor;
+    }
 
-	virtual void update(BelaContext* context)
-	{
-		float val=0;
-		switch(fBelaPin) {
+    virtual void update(BelaContext* context)
+    {
+        float val=0;
+        switch(fBelaPin) {
                 case kBAR_POS_0:
-				case kBAR_POS_1:
-				case kBAR_POS_2:
-				case kBAR_POS_3:
-				case kBAR_POS_4:
-				case kBAR_POS_5:
-				case kBAR_POS_6:
-				case kBAR_POS_7:
-					if(sensor && sensor->getNumTouches()>0)
-						val=sensor->compoundTouchLocation();
-					*fZone = fMin + fRange * val;
-					break;
-				
-				case kBAR_LVL_0:
-				case kBAR_LVL_1:
-				case kBAR_LVL_2:
-				case kBAR_LVL_3:
-				case kBAR_LVL_4:
-				case kBAR_LVL_5:
-				case kBAR_LVL_6:
-				case kBAR_LVL_7:
-					if(sensor && sensor->getNumTouches()>0)
-						val=sensor->compoundTouchSize();
-					*fZone = fMin + fRange * val;
-					break;
-					
-				case kBAR_TOUCH_0:
-				case kBAR_TOUCH_1:
-				case kBAR_TOUCH_2:
-				case kBAR_TOUCH_3:
-				case kBAR_TOUCH_4:
-				case kBAR_TOUCH_5:
-				case kBAR_TOUCH_6:
-				case kBAR_TOUCH_7:
-					if(sensor)
-						val=sensor->getNumTouches();
-					*fZone = max(fRange,val);
-					break;
-					
-				case kSQUARE_XPOS_0:
-				case kSQUARE_XPOS_1:
-				case kSQUARE_XPOS_2:
-				case kSQUARE_XPOS_3:
-				case kSQUARE_XPOS_4:
-				case kSQUARE_XPOS_5:
-				case kSQUARE_XPOS_6:
-				case kSQUARE_XPOS_7:
-					if(sensor && sensor->getNumTouches()>0)
-						val=sensor->compoundTouchHorizontalLocation();
-					*fZone = fMin + fRange * val;	
-					break;
-				
-				case kSQUARE_YPOS_0:
-				case kSQUARE_YPOS_1:
-				case kSQUARE_YPOS_2:
-				case kSQUARE_YPOS_3:
-				case kSQUARE_YPOS_4:
-				case kSQUARE_YPOS_5:
-				case kSQUARE_YPOS_6:
-				case kSQUARE_YPOS_7:
-					if(sensor && sensor->getNumTouches()>0)
-						val=sensor->compoundTouchLocation();
-					*fZone = fMin + fRange * val;
-					break;
-				
-				case kSQUARE_LVL_0:
-				case kSQUARE_LVL_1:
-				case kSQUARE_LVL_2:
-				case kSQUARE_LVL_3:
-				case kSQUARE_LVL_4:
-				case kSQUARE_LVL_5:
-				case kSQUARE_LVL_6:
-				case kSQUARE_LVL_7:
-					if(sensor && sensor->getNumTouches()>0)
-						val=sensor->compoundTouchSize();
-					*fZone = fMin + fRange * val;
-					break;
-				
-				case kSQUARE_TOUCH_0:
-				case kSQUARE_TOUCH_1:
-				case kSQUARE_TOUCH_2:
-				case kSQUARE_TOUCH_3:
-				case kSQUARE_TOUCH_4:
-				case kSQUARE_TOUCH_5:
-				case kSQUARE_TOUCH_6:
-				case kSQUARE_TOUCH_7:
-					if(sensor)
-						val=sensor->getNumTouches();
-					*fZone = max(fRange,val);
-					break;
-					
-				default:
+                case kBAR_POS_1:
+                case kBAR_POS_2:
+                case kBAR_POS_3:
+                case kBAR_POS_4:
+                case kBAR_POS_5:
+                case kBAR_POS_6:
+                case kBAR_POS_7:
+                    if(sensor && sensor->getNumTouches()>0)
+                        val=sensor->compoundTouchLocation();
+                    *fZone = fMin + fRange * val;
+                    break;
+                
+                case kBAR_LVL_0:
+                case kBAR_LVL_1:
+                case kBAR_LVL_2:
+                case kBAR_LVL_3:
+                case kBAR_LVL_4:
+                case kBAR_LVL_5:
+                case kBAR_LVL_6:
+                case kBAR_LVL_7:
+                    if(sensor && sensor->getNumTouches()>0)
+                        val=sensor->compoundTouchSize();
+                    *fZone = fMin + fRange * val;
+                    break;
+                    
+                case kBAR_TOUCH_0:
+                case kBAR_TOUCH_1:
+                case kBAR_TOUCH_2:
+                case kBAR_TOUCH_3:
+                case kBAR_TOUCH_4:
+                case kBAR_TOUCH_5:
+                case kBAR_TOUCH_6:
+                case kBAR_TOUCH_7:
+                    if(sensor)
+                        val=sensor->getNumTouches();
+                    *fZone = max(fRange,val);
+                    break;
+                    
+                case kSQUARE_XPOS_0:
+                case kSQUARE_XPOS_1:
+                case kSQUARE_XPOS_2:
+                case kSQUARE_XPOS_3:
+                case kSQUARE_XPOS_4:
+                case kSQUARE_XPOS_5:
+                case kSQUARE_XPOS_6:
+                case kSQUARE_XPOS_7:
+                    if(sensor && sensor->getNumTouches()>0)
+                        val=sensor->compoundTouchHorizontalLocation();
+                    *fZone = fMin + fRange * val;    
+                    break;
+                
+                case kSQUARE_YPOS_0:
+                case kSQUARE_YPOS_1:
+                case kSQUARE_YPOS_2:
+                case kSQUARE_YPOS_3:
+                case kSQUARE_YPOS_4:
+                case kSQUARE_YPOS_5:
+                case kSQUARE_YPOS_6:
+                case kSQUARE_YPOS_7:
+                    if(sensor && sensor->getNumTouches()>0)
+                        val=sensor->compoundTouchLocation();
+                    *fZone = fMin + fRange * val;
+                    break;
+                
+                case kSQUARE_LVL_0:
+                case kSQUARE_LVL_1:
+                case kSQUARE_LVL_2:
+                case kSQUARE_LVL_3:
+                case kSQUARE_LVL_4:
+                case kSQUARE_LVL_5:
+                case kSQUARE_LVL_6:
+                case kSQUARE_LVL_7:
+                    if(sensor && sensor->getNumTouches()>0)
+                        val=sensor->compoundTouchSize();
+                    *fZone = fMin + fRange * val;
+                    break;
+                
+                case kSQUARE_TOUCH_0:
+                case kSQUARE_TOUCH_1:
+                case kSQUARE_TOUCH_2:
+                case kSQUARE_TOUCH_3:
+                case kSQUARE_TOUCH_4:
+                case kSQUARE_TOUCH_5:
+                case kSQUARE_TOUCH_6:
+                case kSQUARE_TOUCH_7:
+                    if(sensor)
+                        val=sensor->getNumTouches();
+                    *fZone = max(fRange,val);
+                    break;
+                    
+                default:
                     break;
             };
-	}
-	
-	Trill::Device getType() { return type;}
+    }
+    
+    Trill::Device getType() { return type;}
 
 };
 
@@ -581,11 +581,11 @@ class BelaUI : public GenericUI
         int fIndex;                           // number of BelaWidgets collected so far
         EInOutPin fBelaPin;                   // current pin id
         BelaWidget fTable[MAXBELAWIDGETS];    // kind of static list of BelaWidgets
-		
-		int fTrillIndex;
-		EInOutPin fTrillPin;
-		TrillWidget fTrillTable[MAXTRILLWIDGETS];
-		
+        
+        int fTrillIndex;
+        EInOutPin fTrillPin;
+        TrillWidget fTrillTable[MAXTRILLWIDGETS];
+        
         
         // check if the widget is linked to a Bela parameter and, if so, add the corresponding BelaWidget
         void addBelaWidget(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi)
@@ -596,7 +596,7 @@ class BelaUI : public GenericUI
             }
             fBelaPin = kNoPin;
         }
-		void addTrillWidget(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi)
+        void addTrillWidget(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi)
         {
             if (fTrillPin != kNoPin && (fTrillIndex < MAXTRILLWIDGETS)) {
                 fTrillTable[fTrillIndex] = TrillWidget(fTrillPin, zone, label, lo, hi);
@@ -610,8 +610,8 @@ class BelaUI : public GenericUI
         BelaUI()
         : fIndex(0)
         , fBelaPin(kNoPin)
-		, fTrillIndex(0)
-		, fTrillPin(kNoPin)
+        , fTrillIndex(0)
+        , fTrillPin(kNoPin)
         {}
         
         virtual ~BelaUI() {}
@@ -622,42 +622,42 @@ class BelaUI : public GenericUI
             for (int i = 0; i < fIndex; i++) {
                 fTable[i].update(context);
             }
-			for (int i = 0; i < fTrillIndex; i++) {
+            for (int i = 0; i < fTrillIndex; i++) {
                 fTrillTable[i].update(context);
             }
         }
         
         // -- active widgets
         virtual void addButton(const char* label, FAUSTFLOAT* zone) {
-			if(fBelaPin!=kNoPin)
-				addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
-			else
-				addTrillWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
-		}
+            if(fBelaPin!=kNoPin)
+                addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
+            else
+                addTrillWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
+        }
         virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) {
-			if(fBelaPin!=kNoPin)
-				addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
-			else
-				addTrillWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1));  
-		}
+            if(fBelaPin!=kNoPin)
+                addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
+            else
+                addTrillWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1));  
+        }
         virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
-			if(fBelaPin!=kNoPin)
-				addBelaWidget(label, zone, lo, hi); 
-			else
-				addTrillWidget(label, zone, lo, hi); 
-		}
+            if(fBelaPin!=kNoPin)
+                addBelaWidget(label, zone, lo, hi); 
+            else
+                addTrillWidget(label, zone, lo, hi); 
+        }
         virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
-			if(fBelaPin!=kNoPin)
-				addBelaWidget(label, zone, lo, hi); 
-			else
-				addTrillWidget(label, zone, lo, hi); 
-		}
+            if(fBelaPin!=kNoPin)
+                addBelaWidget(label, zone, lo, hi); 
+            else
+                addTrillWidget(label, zone, lo, hi); 
+        }
         virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
-			if(fBelaPin!=kNoPin)
-				addBelaWidget(label, zone, lo, hi); 
-			else
-				addTrillWidget(label, zone, lo, hi); 
-		}
+            if(fBelaPin!=kNoPin)
+                addBelaWidget(label, zone, lo, hi); 
+            else
+                addTrillWidget(label, zone, lo, hi); 
+        }
         
         // -- passive widgets
         virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) { addBelaWidget(label, zone, lo, hi); }
@@ -667,15 +667,15 @@ class BelaUI : public GenericUI
         virtual void declare(FAUSTFLOAT* z, const char* k, const char* id)
         {
             if (strcasecmp(k,"BELA") == 0) {
-				
+                
                 for (int i = 0; i < kNumInputPins; i++) {
                     if (strcasecmp(id, pinNamesStrings[i]) == 0) {
                         fBelaPin = (EInOutPin)i;
                     }
                 }
             }
-			else if (strcasecmp(k,"TRILL") == 0) {
-				
+            else if (strcasecmp(k,"TRILL") == 0) {
+                
                 for (int i = 0; i < kNumInputPins; i++) {
                     if (strcasecmp(id, pinNamesStrings[i]) == 0) {
                         fTrillPin = (EInOutPin)i;
@@ -683,34 +683,34 @@ class BelaUI : public GenericUI
                 }
             }
         }
-		
-		void setTrill(Trill::Device device,Trill* sensor,int idx)
-		{
-			EInOutPin CurTrill;
-			switch(device) {
+        
+        void setTrill(Trill::Device device,Trill* sensor,int idx)
+        {
+            EInOutPin CurTrill;
+            switch(device) {
                 case Trill::BAR:
-					CurTrill=(EInOutPin) (kBAR_POS_0+idx*3);
-					for(int i=0;i<fTrillIndex;i++)
-					{
-						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2)) && fTrillTable[i].getType()==device)
-							fTrillTable[i].setSensor(sensor);
-					}
-					break;
-				
-				case Trill::SQUARE:
-					CurTrill=(EInOutPin) (kSQUARE_XPOS_0+idx*4);
-					for(int i=0;i<fTrillIndex;i++)
-					{
-						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2) || fTrillTable[i].getBelaPin()==(CurTrill+3)) && fTrillTable[i].getType()==device)
-							fTrillTable[i].setSensor(sensor);
-					}
-					break;
-					
-				default:
-					break;
-			};
-			
-		}
+                    CurTrill=(EInOutPin) (kBAR_POS_0+idx*3);
+                    for(int i=0;i<fTrillIndex;i++)
+                    {
+                        if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2)) && fTrillTable[i].getType()==device)
+                            fTrillTable[i].setSensor(sensor);
+                    }
+                    break;
+                
+                case Trill::SQUARE:
+                    CurTrill=(EInOutPin) (kSQUARE_XPOS_0+idx*4);
+                    for(int i=0;i<fTrillIndex;i++)
+                    {
+                        if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2) || fTrillTable[i].getBelaPin()==(CurTrill+3)) && fTrillTable[i].getType()==device)
+                            fTrillTable[i].setSensor(sensor);
+                    }
+                    break;
+                    
+                default:
+                    break;
+            };
+            
+        }
     
 };
 
@@ -780,38 +780,38 @@ const uint8_t TrillSquareAdress[] = {0x28,0x29,0x2A,0x2B,0x2C,0x2D,0x2E,0x2F};
 
 //return the sensor index corresponding to the i2c address in input
 int trillAdress2index(uint8_t i2cadress) {
-	int cnt=sizeof(TrillBarAdress);
-	for(int i=0;i<cnt;i++)
-	{
-		if(TrillBarAdress[i]==i2cadress)
-				return i;
-	}
-	cnt=sizeof(TrillSquareAdress);
-	for(int i=0;i<cnt;i++)
-	{
-		if(TrillSquareAdress[i]==i2cadress)
-				return i;
-	}
-	return -1;
+    int cnt=sizeof(TrillBarAdress);
+    for(int i=0;i<cnt;i++)
+    {
+        if(TrillBarAdress[i]==i2cadress)
+                return i;
+    }
+    cnt=sizeof(TrillSquareAdress);
+    for(int i=0;i<cnt;i++)
+    {
+        if(TrillSquareAdress[i]==i2cadress)
+                return i;
+    }
+    return -1;
 }
 
 std::vector<Trill*> gTouchSensors;
 
 
 void trillLoop(void*) {
-	// This is the auxilary task function which will read our Trill sensors
-	// loop
-	while(!Bela_stopRequested())
-	{
-		//read all Trill sensors
-		for(unsigned int n = 0; n < gTouchSensors.size(); ++n)
-		{
-			Trill* t = gTouchSensors[n];
-			t->readI2C();
-		}
-		// Put the process to sleep when finished*/
-		usleep(12000);
-	}
+    // This is the auxilary task function which will read our Trill sensors
+    // loop
+    while(!Bela_stopRequested())
+    {
+        //read all Trill sensors
+        for(unsigned int n = 0; n < gTouchSensors.size(); ++n)
+        {
+            Trill* t = gTouchSensors[n];
+            t->readI2C();
+        }
+        // Put the process to sleep when finished*/
+        usleep(12000);
+    }
 }
 
 //*******************************************************************************
@@ -916,26 +916,26 @@ bool setup(BelaContext* context, void* userData)
     gDSP->buildUserInterface(&gSoundInterface);
 #endif
     
-	
-	//Trill sensors initilization
-	unsigned int i2cBus = 1;
-	for(uint8_t addr = 0x20; addr <= 0x50; ++addr)
-	{
-		Trill::Device device = Trill::probe(i2cBus, addr);
-		if(Trill::NONE != device && Trill::CRAFT != device)
-		{
-			Trill* newsensor=new Trill(i2cBus, device, addr);
-			gTouchSensors.push_back(newsensor);
-			//gTouchSensors.back()->printDetails();
-			int trillidx=trillAdress2index(addr);
-			gControlUI.setTrill(device,newsensor,trillidx);
-		}
-	}
-	
-	
-	Bela_runAuxiliaryTask(trillLoop);
-	
-	
+    
+    //Trill sensors initilization
+    unsigned int i2cBus = 1;
+    for(uint8_t addr = 0x20; addr <= 0x50; ++addr)
+    {
+        Trill::Device device = Trill::probe(i2cBus, addr);
+        if(Trill::NONE != device && Trill::CRAFT != device)
+        {
+            Trill* newsensor=new Trill(i2cBus, device, addr);
+            gTouchSensors.push_back(newsensor);
+            //gTouchSensors.back()->printDetails();
+            int trillidx=trillAdress2index(addr);
+            gControlUI.setTrill(device,newsensor,trillidx);
+        }
+    }
+    
+    
+    Bela_runAuxiliaryTask(trillLoop);
+    
+    
     return true;
 }
 
@@ -961,8 +961,8 @@ void cleanup(BelaContext* context, void* userData)
     delete gMidiInterface;
 #endif
 
-	for(auto t : gTouchSensors)
-		delete t;
+    for(auto t : gTouchSensors)
+        delete t;
 }
 
 /******************** END bela.cpp ****************/

--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -42,9 +42,9 @@
  /************************************************************************
     Evolution (2022): Trill Sensors support 
 	
-	type supported : 
-		BAR : Position, Pressure, Touched. Multitouch not supported
-		SQUARE : Position X & Y, Pressure, Touched. Multitouch not supported
+	type of sensors supported : 
+		BAR : Position, Pressure, Touched. (Multitouch not supported)
+		SQUARE : Position X & Y, Pressure, Touched. (Multitouch not supported)
 	usage : addin Meta data in UI widget of the Faust Code
 		TRILL:BAR_POS_n
 		TRILL:BAR_LVL_n
@@ -569,7 +569,9 @@ class TrillWidget : public BelaWidget
 // To be modified: We can have 8 inputs, 8 outputs, and 16 digital In or Out.
 #define MAXBELAWIDGETS 16
 
-#define MAXTRILLWIDGETS 16
+//Max number of trill sensors parameters mapped 
+// max of 8 BAR sensors with 3 parameters (Position,Pressure,Touch) et 8 SQUARE sensors with 4 parameters (Position X, Position Y, Pressure, Touch)
+#define MAXTRILLWIDGETS 56
 
 class BelaUI : public GenericUI
 {
@@ -775,6 +777,8 @@ dsp* gDSP = NULL;
 //trill adress routing
 const uint8_t TrillBarAdress[] = {0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27};
 const uint8_t TrillSquareAdress[] = {0x28,0x29,0x2A,0x2B,0x2C,0x2D,0x2E,0x2F};
+
+//return the sensor index corresponding to the i2c address in input
 int trillAdress2index(uint8_t i2cadress) {
 	int cnt=sizeof(TrillBarAdress);
 	for(int i=0;i<cnt;i++)
@@ -790,6 +794,7 @@ int trillAdress2index(uint8_t i2cadress) {
 	}
 	return -1;
 }
+
 std::vector<Trill*> gTouchSensors;
 
 

--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -127,44 +127,60 @@ const char* const pinNamesStrings[] =
     "ANALOG_OUT_8",
 	"BAR_POS_0",
     "BAR_LVL_0",
+	"BAR_TOUCH_0",
 	"BAR_POS_1",
     "BAR_LVL_1",
+	"BAR_TOUCH_1",
 	"BAR_POS_2",
     "BAR_LVL_2",
+	"BAR_TOUCH_2",
 	"BAR_POS_3",
     "BAR_LVL_3",
+	"BAR_TOUCH_3",
 	"BAR_POS_4",
     "BAR_LVL_4",
+	"BAR_TOUCH_4",
 	"BAR_POS_5",
     "BAR_LVL_5",
+	"BAR_TOUCH_5",
 	"BAR_POS_6",
     "BAR_LVL_6",
+	"BAR_TOUCH_6",
 	"BAR_POS_7",
     "BAR_LVL_7",
+	"BAR_TOUCH_7",
 	"SQUARE_XPOS_0",
 	"SQUARE_YPOS_0",
 	"SQUARE_LVL_0",
+	"SQUARE_TOUCH_0",
 	"SQUARE_XPOS_1",
 	"SQUARE_YPOS_1",
 	"SQUARE_LVL_1",
+	"SQUARE_TOUCH_1",
 	"SQUARE_XPOS_2",
 	"SQUARE_YPOS_2",	
 	"SQUARE_LVL_2",
+	"SQUARE_TOUCH_2",
 	"SQUARE_XPOS_3",
 	"SQUARE_YPOS_3",
 	"SQUARE_LVL_3",
+	"SQUARE_TOUCH_3",
 	"SQUARE_XPOS_4",
 	"SQUARE_YPOS_4",	
 	"SQUARE_LVL_4",
+	"SQUARE_TOUCH_4",
 	"SQUARE_XPOS_5",
 	"SQUARE_YPOS_5",
 	"SQUARE_LVL_5",
+	"SQUARE_TOUCH_5",
 	"SQUARE_XPOS_6",
 	"SQUARE_YPOS_6",	
 	"SQUARE_LVL_6",
+	"SQUARE_TOUCH_6",
 	"SQUARE_XPOS_7",
 	"SQUARE_YPOS_7",
-	"SQUARE_LVL_7"
+	"SQUARE_LVL_7",
+	"SQUARE_TOUCH_7"
 };
 
 enum EInOutPin
@@ -206,44 +222,60 @@ enum EInOutPin
     kANALOG_OUT_8,
 	kBAR_POS_0,
     kBAR_LVL_0,
+	kBAR_TOUCH_0,
 	kBAR_POS_1,
     kBAR_LVL_1,
+	kBAR_TOUCH_1,
 	kBAR_POS_2,
     kBAR_LVL_2,
+	kBAR_TOUCH_2,
 	kBAR_POS_3,
     kBAR_LVL_3,
+	kBAR_TOUCH_3,
 	kBAR_POS_4,
     kBAR_LVL_4,
+	kBAR_TOUCH_4,
 	kBAR_POS_5,
     kBAR_LVL_5,
+	kBAR_TOUCH_5,
 	kBAR_POS_6,
     kBAR_LVL_6,
+	kBAR_TOUCH_6,
 	kBAR_POS_7,
     kBAR_LVL_7,
+	kBAR_TOUCH_7,
 	kSQUARE_XPOS_0,
 	kSQUARE_YPOS_0,
 	kSQUARE_LVL_0,
+	kSQUARE_TOUCH_0,
 	kSQUARE_XPOS_1,
 	kSQUARE_YPOS_1,
 	kSQUARE_LVL_1,
+	kSQUARE_TOUCH_1,
 	kSQUARE_XPOS_2,
 	kSQUARE_YPOS_2,
 	kSQUARE_LVL_2,	
+	kSQUARE_TOUCH_2,
 	kSQUARE_XPOS_3,
 	kSQUARE_YPOS_3,
 	kSQUARE_LVL_3,
+	kSQUARE_TOUCH_3,
 	kSQUARE_XPOS_4,
 	kSQUARE_YPOS_4,
 	kSQUARE_LVL_4,	
+	kSQUARE_TOUCH_4,
 	kSQUARE_XPOS_5,
 	kSQUARE_YPOS_5,
 	kSQUARE_LVL_5,
+	kSQUARE_TOUCH_5,
 	kSQUARE_XPOS_6,
 	kSQUARE_YPOS_6,
 	kSQUARE_LVL_6,	
+	kSQUARE_TOUCH_6,
 	kSQUARE_XPOS_7,
 	kSQUARE_YPOS_7,
 	kSQUARE_LVL_7,
+	kSQUARE_TOUCH_7,
     kNumInputPins
 };
 
@@ -395,6 +427,7 @@ class TrillWidget : public BelaWidget
 
 	virtual void update(BelaContext* context)
 	{
+		float val=0;
 		switch(fBelaPin) {
                 case kBAR_POS_0:
 				case kBAR_POS_1:
@@ -404,14 +437,9 @@ class TrillWidget : public BelaWidget
 				case kBAR_POS_5:
 				case kBAR_POS_6:
 				case kBAR_POS_7:
-				//case kBAR_POS_8:
-					if(sensor)
-					{
-						float val=0;
-						if(sensor && sensor->getNumTouches()>0)
-							val=sensor->compoundTouchLocation();
-						*fZone = fMin + fRange * val;
-					}
+					if(sensor && sensor->getNumTouches()>0)
+						val=sensor->compoundTouchLocation();
+					*fZone = fMin + fRange * val;
 					break;
 				
 				case kBAR_LVL_0:
@@ -422,14 +450,22 @@ class TrillWidget : public BelaWidget
 				case kBAR_LVL_5:
 				case kBAR_LVL_6:
 				case kBAR_LVL_7:
-				//case kBAR_LVL_8:
+					if(sensor && sensor->getNumTouches()>0)
+						val=sensor->compoundTouchSize();
+					*fZone = fMin + fRange * val;
+					break;
+					
+				case kBAR_TOUCH_0:
+				case kBAR_TOUCH_1:
+				case kBAR_TOUCH_2:
+				case kBAR_TOUCH_3:
+				case kBAR_TOUCH_4:
+				case kBAR_TOUCH_5:
+				case kBAR_TOUCH_6:
+				case kBAR_TOUCH_7:
 					if(sensor)
-					{
-						float val=0;
-						if(sensor && sensor->getNumTouches()>0)
-							val=sensor->compoundTouchSize();
-						*fZone = fMin + fRange * val;
-					}
+						val=sensor->getNumTouches();
+					*fZone = max(fRange,val);
 					break;
 					
 				case kSQUARE_XPOS_0:
@@ -440,14 +476,9 @@ class TrillWidget : public BelaWidget
 				case kSQUARE_XPOS_5:
 				case kSQUARE_XPOS_6:
 				case kSQUARE_XPOS_7:
-				//case kSQUARE_XPOS_8:
-					if(sensor)
-					{
-						float val=0;
-						if(sensor)
-							val=sensor->compoundTouchHorizontalLocation();
-						*fZone = fMin + fRange * val;
-					}	
+					if(sensor && sensor->getNumTouches()>0)
+						val=sensor->compoundTouchHorizontalLocation();
+					*fZone = fMin + fRange * val;	
 					break;
 				
 				case kSQUARE_YPOS_0:
@@ -458,14 +489,9 @@ class TrillWidget : public BelaWidget
 				case kSQUARE_YPOS_5:
 				case kSQUARE_YPOS_6:
 				case kSQUARE_YPOS_7:
-				//case kSQUARE_YPOS_8:
-					if(sensor)
-					{
-						float val=0;
-						if(sensor)
-							val=sensor->compoundTouchLocation();
-						*fZone = fMin + fRange * val;
-					}	
+					if(sensor && sensor->getNumTouches()>0)
+						val=sensor->compoundTouchLocation();
+					*fZone = fMin + fRange * val;
 					break;
 				
 				case kSQUARE_LVL_0:
@@ -476,17 +502,24 @@ class TrillWidget : public BelaWidget
 				case kSQUARE_LVL_5:
 				case kSQUARE_LVL_6:
 				case kSQUARE_LVL_7:
-				//case kSQUARE_LVL_8:
-					if(sensor)
-					{
-						float val=0;
-						if(sensor)
-							val=sensor->compoundTouchSize();
-						*fZone = fMin + fRange * val;
-					}
+					if(sensor && sensor->getNumTouches()>0)
+						val=sensor->compoundTouchSize();
+					*fZone = fMin + fRange * val;
 					break;
 				
-				
+				case kSQUARE_TOUCH_0:
+				case kSQUARE_TOUCH_1:
+				case kSQUARE_TOUCH_2:
+				case kSQUARE_TOUCH_3:
+				case kSQUARE_TOUCH_4:
+				case kSQUARE_TOUCH_5:
+				case kSQUARE_TOUCH_6:
+				case kSQUARE_TOUCH_7:
+					if(sensor)
+						val=sensor->getNumTouches();
+					*fZone = max(fRange,val);
+					break;
+					
 				default:
                     break;
             };
@@ -628,19 +661,19 @@ class BelaUI : public GenericUI
 			EInOutPin CurTrill;
 			switch(device) {
                 case Trill::BAR:
-					CurTrill=(EInOutPin) (kBAR_POS_0+idx*2);
+					CurTrill=(EInOutPin) (kBAR_POS_0+idx*3);
 					for(int i=0;i<fTrillIndex;i++)
 					{
-						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1)) && fTrillTable[i].getType()==device)
+						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2)) && fTrillTable[i].getType()==device)
 							fTrillTable[i].setSensor(sensor);
 					}
 					break;
 				
 				case Trill::SQUARE:
-					CurTrill=(EInOutPin) (kSQUARE_XPOS_0+idx*3);
+					CurTrill=(EInOutPin) (kSQUARE_XPOS_0+idx*4);
 					for(int i=0;i<fTrillIndex;i++)
 					{
-						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2)) && fTrillTable[i].getType()==device)
+						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2) || fTrillTable[i].getBelaPin()==(CurTrill+3)) && fTrillTable[i].getType()==device)
 							fTrillTable[i].setSensor(sensor);
 					}
 					break;

--- a/architecture/bela.cpp
+++ b/architecture/bela.cpp
@@ -34,6 +34,8 @@
  that work under terms of your choice, so long as this FAUST
  architecture section is not modified.
  
+ evolution : Trill Sensors support (Pascal Faivre-Cubizolles)
+ 
  ************************************************************************
  ************************************************************************/
 
@@ -48,6 +50,8 @@
 #include <cstdlib>
 #include <Bela.h>
 #include <Utilities.h>
+
+#include <libraries/Trill/Trill.h>
 
 using namespace std;
 
@@ -120,7 +124,47 @@ const char* const pinNamesStrings[] =
     "ANALOG_OUT_5",
     "ANALOG_OUT_6",
     "ANALOG_OUT_7",
-    "ANALOG_OUT_8"
+    "ANALOG_OUT_8",
+	"BAR_POS_0",
+    "BAR_LVL_0",
+	"BAR_POS_1",
+    "BAR_LVL_1",
+	"BAR_POS_2",
+    "BAR_LVL_2",
+	"BAR_POS_3",
+    "BAR_LVL_3",
+	"BAR_POS_4",
+    "BAR_LVL_4",
+	"BAR_POS_5",
+    "BAR_LVL_5",
+	"BAR_POS_6",
+    "BAR_LVL_6",
+	"BAR_POS_7",
+    "BAR_LVL_7",
+	"SQUARE_XPOS_0",
+	"SQUARE_YPOS_0",
+	"SQUARE_LVL_0",
+	"SQUARE_XPOS_1",
+	"SQUARE_YPOS_1",
+	"SQUARE_LVL_1",
+	"SQUARE_XPOS_2",
+	"SQUARE_YPOS_2",	
+	"SQUARE_LVL_2",
+	"SQUARE_XPOS_3",
+	"SQUARE_YPOS_3",
+	"SQUARE_LVL_3",
+	"SQUARE_XPOS_4",
+	"SQUARE_YPOS_4",	
+	"SQUARE_LVL_4",
+	"SQUARE_XPOS_5",
+	"SQUARE_YPOS_5",
+	"SQUARE_LVL_5",
+	"SQUARE_XPOS_6",
+	"SQUARE_YPOS_6",	
+	"SQUARE_LVL_6",
+	"SQUARE_XPOS_7",
+	"SQUARE_YPOS_7",
+	"SQUARE_LVL_7"
 };
 
 enum EInOutPin
@@ -160,8 +204,50 @@ enum EInOutPin
     kANALOG_OUT_6,
     kANALOG_OUT_7,
     kANALOG_OUT_8,
+	kBAR_POS_0,
+    kBAR_LVL_0,
+	kBAR_POS_1,
+    kBAR_LVL_1,
+	kBAR_POS_2,
+    kBAR_LVL_2,
+	kBAR_POS_3,
+    kBAR_LVL_3,
+	kBAR_POS_4,
+    kBAR_LVL_4,
+	kBAR_POS_5,
+    kBAR_LVL_5,
+	kBAR_POS_6,
+    kBAR_LVL_6,
+	kBAR_POS_7,
+    kBAR_LVL_7,
+	kSQUARE_XPOS_0,
+	kSQUARE_YPOS_0,
+	kSQUARE_LVL_0,
+	kSQUARE_XPOS_1,
+	kSQUARE_YPOS_1,
+	kSQUARE_LVL_1,
+	kSQUARE_XPOS_2,
+	kSQUARE_YPOS_2,
+	kSQUARE_LVL_2,	
+	kSQUARE_XPOS_3,
+	kSQUARE_YPOS_3,
+	kSQUARE_LVL_3,
+	kSQUARE_XPOS_4,
+	kSQUARE_YPOS_4,
+	kSQUARE_LVL_4,	
+	kSQUARE_XPOS_5,
+	kSQUARE_YPOS_5,
+	kSQUARE_LVL_5,
+	kSQUARE_XPOS_6,
+	kSQUARE_YPOS_6,
+	kSQUARE_LVL_6,	
+	kSQUARE_XPOS_7,
+	kSQUARE_YPOS_7,
+	kSQUARE_LVL_7,
     kNumInputPins
 };
+
+
 
 /**************************************************************************************
  
@@ -207,7 +293,7 @@ class BelaWidget
         ,fRange(hi-lo)
         {}
         
-        void update(BelaContext* context)
+        virtual void update(BelaContext* context)
         {
             switch(fBelaPin) {
                 case kANALOG_0:
@@ -255,7 +341,159 @@ class BelaWidget
                     break;
             };
         }
-    
+		
+		virtual EInOutPin getBelaPin() {
+			return  fBelaPin;
+		}
+			
+};
+
+
+class TrillWidget : public BelaWidget
+{
+	protected:
+	   
+		Trill* sensor;
+		Trill::Device type;
+	public:
+	 
+	TrillWidget() 
+	{ 
+		BelaWidget(); 
+		sensor=NULL;
+		type=Trill::NONE;
+	}
+
+	TrillWidget(const TrillWidget& w) 
+	{ 
+		BelaWidget((BelaWidget) w); 
+		sensor=NULL;
+		type=Trill::NONE;
+	}
+
+	TrillWidget(EInOutPin pin, FAUSTFLOAT* z, const char* l, FAUSTFLOAT lo, FAUSTFLOAT hi)
+	{  
+		fBelaPin=pin;
+        fZone=z;  // zone
+        fLabel=l; // label
+        fMin=lo;    // minimal value
+        fRange=hi;
+		sensor=NULL;
+		if(strstr(pinNamesStrings[fBelaPin],"BAR"))
+			type=Trill::BAR;
+		else if(strstr(pinNamesStrings[fBelaPin],"SQUARE"))
+			type=Trill::SQUARE;
+		else 
+			type=Trill::NONE;
+	}
+	
+	void setSensor(Trill* nSensor)
+	{
+		if(nSensor)
+			sensor=nSensor;
+	}
+
+	virtual void update(BelaContext* context)
+	{
+		switch(fBelaPin) {
+                case kBAR_POS_0:
+				case kBAR_POS_1:
+				case kBAR_POS_2:
+				case kBAR_POS_3:
+				case kBAR_POS_4:
+				case kBAR_POS_5:
+				case kBAR_POS_6:
+				case kBAR_POS_7:
+				//case kBAR_POS_8:
+					if(sensor)
+					{
+						float val=0;
+						if(sensor && sensor->getNumTouches()>0)
+							val=sensor->compoundTouchLocation();
+						*fZone = fMin + fRange * val;
+					}
+					break;
+				
+				case kBAR_LVL_0:
+				case kBAR_LVL_1:
+				case kBAR_LVL_2:
+				case kBAR_LVL_3:
+				case kBAR_LVL_4:
+				case kBAR_LVL_5:
+				case kBAR_LVL_6:
+				case kBAR_LVL_7:
+				//case kBAR_LVL_8:
+					if(sensor)
+					{
+						float val=0;
+						if(sensor && sensor->getNumTouches()>0)
+							val=sensor->compoundTouchSize();
+						*fZone = fMin + fRange * val;
+					}
+					break;
+					
+				case kSQUARE_XPOS_0:
+				case kSQUARE_XPOS_1:
+				case kSQUARE_XPOS_2:
+				case kSQUARE_XPOS_3:
+				case kSQUARE_XPOS_4:
+				case kSQUARE_XPOS_5:
+				case kSQUARE_XPOS_6:
+				case kSQUARE_XPOS_7:
+				//case kSQUARE_XPOS_8:
+					if(sensor)
+					{
+						float val=0;
+						if(sensor)
+							val=sensor->compoundTouchHorizontalLocation();
+						*fZone = fMin + fRange * val;
+					}	
+					break;
+				
+				case kSQUARE_YPOS_0:
+				case kSQUARE_YPOS_1:
+				case kSQUARE_YPOS_2:
+				case kSQUARE_YPOS_3:
+				case kSQUARE_YPOS_4:
+				case kSQUARE_YPOS_5:
+				case kSQUARE_YPOS_6:
+				case kSQUARE_YPOS_7:
+				//case kSQUARE_YPOS_8:
+					if(sensor)
+					{
+						float val=0;
+						if(sensor)
+							val=sensor->compoundTouchLocation();
+						*fZone = fMin + fRange * val;
+					}	
+					break;
+				
+				case kSQUARE_LVL_0:
+				case kSQUARE_LVL_1:
+				case kSQUARE_LVL_2:
+				case kSQUARE_LVL_3:
+				case kSQUARE_LVL_4:
+				case kSQUARE_LVL_5:
+				case kSQUARE_LVL_6:
+				case kSQUARE_LVL_7:
+				//case kSQUARE_LVL_8:
+					if(sensor)
+					{
+						float val=0;
+						if(sensor)
+							val=sensor->compoundTouchSize();
+						*fZone = fMin + fRange * val;
+					}
+					break;
+				
+				
+				default:
+                    break;
+            };
+	}
+	
+	Trill::Device getType() { return type;}
+
 };
 
 /**************************************************************************************
@@ -272,6 +510,8 @@ class BelaWidget
 // To be modified: We can have 8 inputs, 8 outputs, and 16 digital In or Out.
 #define MAXBELAWIDGETS 16
 
+#define MAXTRILLWIDGETS 16
+
 class BelaUI : public GenericUI
 {
     
@@ -280,6 +520,11 @@ class BelaUI : public GenericUI
         int fIndex;                           // number of BelaWidgets collected so far
         EInOutPin fBelaPin;                   // current pin id
         BelaWidget fTable[MAXBELAWIDGETS];    // kind of static list of BelaWidgets
+		
+		int fTrillIndex;
+		EInOutPin fTrillPin;
+		TrillWidget fTrillTable[MAXTRILLWIDGETS];
+		
         
         // check if the widget is linked to a Bela parameter and, if so, add the corresponding BelaWidget
         void addBelaWidget(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi)
@@ -290,12 +535,22 @@ class BelaUI : public GenericUI
             }
             fBelaPin = kNoPin;
         }
+		void addTrillWidget(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi)
+        {
+            if (fTrillPin != kNoPin && (fTrillIndex < MAXTRILLWIDGETS)) {
+                fTrillTable[fTrillIndex] = TrillWidget(fTrillPin, zone, label, lo, hi);
+                fTrillIndex++;
+            }
+            fTrillPin = kNoPin;
+        }
         
     public:
         
         BelaUI()
         : fIndex(0)
         , fBelaPin(kNoPin)
+		, fTrillIndex(0)
+		, fTrillPin(kNoPin)
         {}
         
         virtual ~BelaUI() {}
@@ -306,14 +561,42 @@ class BelaUI : public GenericUI
             for (int i = 0; i < fIndex; i++) {
                 fTable[i].update(context);
             }
+			for (int i = 0; i < fTrillIndex; i++) {
+                fTrillTable[i].update(context);
+            }
         }
         
         // -- active widgets
-        virtual void addButton(const char* label, FAUSTFLOAT* zone) { addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); }
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) { addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); }
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) { addBelaWidget(label, zone, lo, hi); }
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) { addBelaWidget(label, zone, lo, hi); }
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) { addBelaWidget(label, zone, lo, hi); }
+        virtual void addButton(const char* label, FAUSTFLOAT* zone) {
+			if(fBelaPin!=kNoPin)
+				addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
+			else
+				addTrillWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
+		}
+        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) {
+			if(fBelaPin!=kNoPin)
+				addBelaWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1)); 
+			else
+				addTrillWidget(label, zone, FAUSTFLOAT(0), FAUSTFLOAT(1));  
+		}
+        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
+			if(fBelaPin!=kNoPin)
+				addBelaWidget(label, zone, lo, hi); 
+			else
+				addTrillWidget(label, zone, lo, hi); 
+		}
+        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
+			if(fBelaPin!=kNoPin)
+				addBelaWidget(label, zone, lo, hi); 
+			else
+				addTrillWidget(label, zone, lo, hi); 
+		}
+        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
+			if(fBelaPin!=kNoPin)
+				addBelaWidget(label, zone, lo, hi); 
+			else
+				addTrillWidget(label, zone, lo, hi); 
+		}
         
         // -- passive widgets
         virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) { addBelaWidget(label, zone, lo, hi); }
@@ -323,13 +606,50 @@ class BelaUI : public GenericUI
         virtual void declare(FAUSTFLOAT* z, const char* k, const char* id)
         {
             if (strcasecmp(k,"BELA") == 0) {
+				
                 for (int i = 0; i < kNumInputPins; i++) {
                     if (strcasecmp(id, pinNamesStrings[i]) == 0) {
                         fBelaPin = (EInOutPin)i;
                     }
                 }
             }
+			else if (strcasecmp(k,"TRILL") == 0) {
+				
+                for (int i = 0; i < kNumInputPins; i++) {
+                    if (strcasecmp(id, pinNamesStrings[i]) == 0) {
+                        fTrillPin = (EInOutPin)i;
+                    }
+                }
+            }
         }
+		
+		void setTrill(Trill::Device device,Trill* sensor,int idx)
+		{
+			EInOutPin CurTrill;
+			switch(device) {
+                case Trill::BAR:
+					CurTrill=(EInOutPin) (kBAR_POS_0+idx*2);
+					for(int i=0;i<fTrillIndex;i++)
+					{
+						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1)) && fTrillTable[i].getType()==device)
+							fTrillTable[i].setSensor(sensor);
+					}
+					break;
+				
+				case Trill::SQUARE:
+					CurTrill=(EInOutPin) (kSQUARE_XPOS_0+idx*3);
+					for(int i=0;i<fTrillIndex;i++)
+					{
+						if((fTrillTable[i].getBelaPin()==CurTrill || fTrillTable[i].getBelaPin()==(CurTrill+1) || fTrillTable[i].getBelaPin()==(CurTrill+2)) && fTrillTable[i].getType()==device)
+							fTrillTable[i].setSensor(sensor);
+					}
+					break;
+					
+				default:
+					break;
+			};
+			
+		}
     
 };
 
@@ -388,6 +708,50 @@ FAUSTFLOAT** gOutputs = NULL;  // array of pointers to context->audioOut data
 
 BelaUI gControlUI;
 dsp* gDSP = NULL;
+
+
+//trill implémentation************************************************************
+
+
+//trill adress routing
+const uint8_t TrillBarAdress[] = {0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27};
+const uint8_t TrillSquareAdress[] = {0x28,0x29,0x2A,0x2B,0x2C,0x2D,0x2E,0x2F};
+int trillAdress2index(uint8_t i2cadress) {
+	int cnt=sizeof(TrillBarAdress);
+	for(int i=0;i<cnt;i++)
+	{
+		if(TrillBarAdress[i]==i2cadress)
+				return i;
+	}
+	cnt=sizeof(TrillSquareAdress);
+	for(int i=0;i<cnt;i++)
+	{
+		if(TrillSquareAdress[i]==i2cadress)
+				return i;
+	}
+	return -1;
+}
+std::vector<Trill*> gTouchSensors;
+
+
+void trillLoop(void*) {
+	// This is the auxilary task function which will read our Trill sensors
+	// loop
+	while(!Bela_stopRequested())
+	{
+		//read all Trill sensors
+		for(unsigned int n = 0; n < gTouchSensors.size(); ++n)
+		{
+			Trill* t = gTouchSensors[n];
+			t->readI2C();
+		}
+		// Put the process to sleep when finished*/
+		usleep(12000);
+	}
+}
+
+//*******************************************************************************
+
 
 void Bela_userSettings(BelaInitSettings* settings)
 {
@@ -488,6 +852,26 @@ bool setup(BelaContext* context, void* userData)
     gDSP->buildUserInterface(&gSoundInterface);
 #endif
     
+	
+	//Trill sensors initilization
+	unsigned int i2cBus = 1;
+	for(uint8_t addr = 0x20; addr <= 0x50; ++addr)
+	{
+		Trill::Device device = Trill::probe(i2cBus, addr);
+		if(Trill::NONE != device && Trill::CRAFT != device)
+		{
+			Trill* newsensor=new Trill(i2cBus, device, addr);
+			gTouchSensors.push_back(newsensor);
+			//gTouchSensors.back()->printDetails();
+			int trillidx=trillAdress2index(addr);
+			gControlUI.setTrill(device,newsensor,trillidx);
+		}
+	}
+	
+	
+	Bela_runAuxiliaryTask(trillLoop);
+	
+	
     return true;
 }
 
@@ -512,6 +896,9 @@ void cleanup(BelaContext* context, void* userData)
 #ifdef MIDICTRL
     delete gMidiInterface;
 #endif
+
+	for(auto t : gTouchSensors)
+		delete t;
 }
 
 /******************** END bela.cpp ****************/


### PR DESCRIPTION
**Modification of the architecture/bela.cpp for adding the support of [Trill sensors](https://learn.bela.io/products/trill/about-trill/).**

Currently only BAR and SQUARE sensor type are supported. A maximum 8 sensors per type at the same time.
The parameters that can be used are: 
- position (x and y for the SQUARE type), 
- pressure 
- touch (Multitouch not supported)
For using, the approach is the same as digital and analog pin of the Bela.
The Metadata in the Faust Widget are  : 
TRILL:BAR_POS_n
TRILL:BAR_LVL_n
TRILL:BAR_TOUCH_n
TRILL:SQUARE_XPOS_n
TRILL:SQUARE_YPOS_n
TRILL:SQUARE_LVL_n
TRILL:SQUARE_TOUCH_n
where n is the index of the Trill sensor used
2 array (TrillBarAdress and TrillSquareAdress) allow to route the i2c addresses of the sensors index.
