### PR TITLE
Bela: add -lmicrohttpd alongside -lHTTPFaust.

### DIFF
--- a/tools/faust2appls/faust2bela
+++ b/tools/faust2appls/faust2bela
@@ -136,7 +136,7 @@ fi
 
 if [[ "$GUIDEFS" == *GUI* ]]; then
     echo '#define HTTPDGUI' >> "$PROJECTDIR/tmp.txt"
-    BELA_LDLIBS="$BELA_LDLIBS -lHTTPDFaust"
+    BELA_LDLIBS="$BELA_LDLIBS -lHTTPDFaust -lmicrohttpd"
 fi
 
 if [[ "$SOUNDFILEDEFS" == *SOUNDFILE* ]]; then


### PR DESCRIPTION
this is needed if the linker uses the static version of libHTTPDFaust , at which point it won't know about its dependency on libmicrohttpd. I checked the other faust2appls and they are all doing it correctly already, the issue was only with faust2bela.