### PR TITLE
Rust: Use wrapping add, sub and mul operations

### DIFF
--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -441,7 +441,7 @@ class RustInstVisitor : public TextInstVisitor {
             Typed::VarType type = TypingVisitor::getType(inst->fInst1);
             if (isInt32Type(type)) {
                 *fOut << "i32::";
-            } else if (isInt32Type(type)) {
+            } else if (isInt64Type(type)) {
                 *fOut << "i64::";
             } else {
                 faustassert(false);


### PR DESCRIPTION
The Rust operators `+`, `-` and `*` for integer don't allow overflow, they panic in debug mode, but Faust allow overflow and expect it to wrap. This PR replaces their usage with the wrapping equivalent operations.

Sample difference:

```rs
let mut iTemp8: i32 = iTemp7 + 1;
```
becomes:

```rs
let mut iTemp8: i32 = i32::wrapping_add(iTemp7, 1);
```

An alternative implementation would be to use the Wrapping types (`Wrapping<i32>`) that have overloaded operators. However this was much more intrusive and had side effects such as `get_sample_rate` returning a Wrapping.

Fixes #432

This PR does not change the behaviour of programs built in release mode, since they are built with assertion disabled.
