### PR TITLE
Rust: Allocate arrays on the heap

### DIFF
--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -60,9 +60,9 @@ struct RustInitFieldsVisitor : public DispatchVisitor {
 
         if (array_type) {
             if (isIntPtrType(type)) {
-                *fOut << "[0;" << array_type->fSize << "]";
+                *fOut << "vec![0;" << array_type->fSize << "]";
             } else if (isRealPtrType(type)) {
-                *fOut << "[0.0;" << array_type->fSize << "]";
+                *fOut << "vec![0.0;" << array_type->fSize << "]";
             }
         } else {
             if (isIntType(type)) {

--- a/compiler/generator/type_manager.hh
+++ b/compiler/generator/type_manager.hh
@@ -232,9 +232,13 @@ class RustStringTypeManager : public StringTypeManager {
             string ty_str = named_typed->fName + generateType(named_typed->fType);
             return name + ((ty_str != "") ? (": " + ty_str) : "");
         } else if (array_typed) {
+            // Allocate arrays on the heap with std::vec::Vec
+            // Until the rust feature box_syntax is stabilized, this is necessary
+            // to avoid data to be allocated first on the stack, then moved to the heap.
+            // See: https://github.com/rust-lang/rust/issues/53827
             return (array_typed->fSize == 0)
                        ? name + ": " + fPtrRef + generateType(array_typed->fType)
-                       : name + ": [" + generateType(array_typed->fType) + ";" + std::to_string(array_typed->fSize) + "]";
+                       : name + ": std::vec::Vec<" + generateType(array_typed->fType) + ">";
         } else {
             faustassert(false);
             return "";


### PR DESCRIPTION
Even though the code wraps the allocation of the DSP in a `Box<>`, the defined behaviour of rust is that the memory is first allocated in the stack, then moved in the heap. In Release build, this is often optimized out, hiding this issue, but this makes Faust generated rust code very prone to stack overflow in Debug. This is generally considered an issue in Rust, see: https://github.com/rust-lang/rust/issues/53827

It looks like a rust unstable feature (`box` syntax) would allow to allocate directly on the heap with relying on optimization, but this has not been stabilized. In the meantime, using `Vec` seems to be the general advise for this problem, so this PR replaces the arrays with vectors.
