### PR TITLE
Daisy Pod support & for some bugfix.

### DIFF
--- a/architecture/daisy/ex_faust.cpp
+++ b/architecture/daisy/ex_faust.cpp
@@ -36,6 +36,8 @@
 
 #ifdef PATCH
 #include "daisy_patch.h"
+#elif defined POD
+#include "daisy_pod.h"
 #else
 #include "daisy_seed.h"
 #endif
@@ -79,6 +81,8 @@ using namespace std;
 
 #ifdef PATCH
 static daisy::DaisyPatch hw;
+#elif defined POD
+static daisy::DaisyPod hw; 
 #else
 static daisy::DaisySeed hw;
 #endif
@@ -103,7 +107,7 @@ static void AudioCallback(daisy::AudioHandle::InputBuffer in, daisy::AudioHandle
 int main(void)
 {
     // initialize seed hardware and daisysp modules
-#ifndef PATCH
+#if (!defined PATCH) | (!defined POD)
     hw.Configure();
 #endif
     hw.Init();
@@ -126,19 +130,19 @@ int main(void)
     DSP->init(MY_SAMPLE_RATE);
     
     // setup controllers
-#ifdef PATCH
+#if (defined PATCH) | (defined POD)
     control_UI = new DaisyControlUI(&hw.seed, MY_SAMPLE_RATE/MY_BUFFER_SIZE);
-#else
-    control_UI = new DaisyControlUI(&hw, MY_SAMPLE_RATE/MY_BUFFER_SIZE);
-#endif
     DSP->buildUserInterface(control_UI);
-    
+    hw.StartAdc();
+#else
+    //initialize UI for seed
+    control_UI = new DaisyControlUI(&hw, MY_SAMPLE_RATE/MY_BUFFER_SIZE);
+    DSP->buildUserInterface(control_UI);
     // start ADC
     hw.adc.Start();
-    
+#endif
     // define and start callback
     hw.StartAudio(AudioCallback);
-    
 #ifdef MIDICTRL
     daisy_midi midi_handler;
     MidiUI midi_interface(&midi_handler);

--- a/architecture/daisy/ex_faust.cpp
+++ b/architecture/daisy/ex_faust.cpp
@@ -97,7 +97,7 @@ static void AudioCallback(daisy::AudioHandle::InputBuffer in, daisy::AudioHandle
     control_UI->update();
     
     // DSP processing
-    DSP->compute(count, static_cast<float**>(in), out);
+    DSP->compute(count, const_cast<float**>(in), out);
 }
 
 int main(void)

--- a/tools/faust2appls/faust2daisy
+++ b/tools/faust2appls/faust2daisy
@@ -24,6 +24,7 @@ NVOICES=0
 MIDI=false
 POLY=""
 PATCH=false
+POD=false
 SR=44100
 BS=16
 SOURCE=false
@@ -33,7 +34,8 @@ echoHelp ()
     echo "faust2daisy [-patch] [-midi] [-nvoices <num>] [-sr <num>] [-bs <num>] [-source] [Faust options (-vec -vs 8...)] <file.dsp>"
     echo "Compiles Faust programs to Daisy boards"
     option
-    option -patch "to compile for 4 ins/outs Patch"
+    option -patch "to compile for 4 ins/outs Patch(knob[1,2,3,4])"
+    option -pod "to compile for 2 ins/outs Pod (knob[1,3])"
     options -midi
     option "-nvoices <num>"
     option "-sr <num>"
@@ -64,6 +66,8 @@ do
     #patch
     elif [ $p = "-patch" ]; then
         PATCH=true
+    elif [ $p = "-pod" ]; then
+        POD=true
     # -sr
     elif [ $p = "-sr" ]; then
         shift
@@ -112,6 +116,10 @@ for p in $FILE; do
     # for PATCH support
     if [ $PATCH == true ]; then
         echo "#define PATCH" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+    fi
+    # for POD support
+    if [ $POD == true ]; then
+        echo "#define POD" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
     fi
 
     # for MIDI


### PR DESCRIPTION
This PR fixes some compilation errors of faust2daisy on my environment and adds basic support for Daisy Pod based on a current implementation for a Patch.
The version of my libdaisy is a current master branch.

-  `static_cast` added on this commit needed to be`const_cast` in the latest libdaisy. https://github.com/grame-cncm/faust/commit/a0e58b5a4aecc9c1d3d6382140aa82a14ba21f98#diff-db20fb08bb6609ca9435273eefd9ec4f826a0116d40cd83049c507415dc417abR100
- `hw.adc.Start();` for seed needs to be `hw.StartAdc();` for Patch and Pod.
- The pin assignments of Knobs are different for each platform. 
  - Pod: `15 21`
  - Patch: `15 16 21 18`
  - Petal :`16 19 17 20 18 21`
Pod users can use only `knob:1` and `knob:3` to use the common pin mappings to Patch.
It would be better to define correct pin assignments in the preprocessor, but I added a description of knob mappings in the help of `faust2daisy` for now.

Maybe I can add Encoder support and Petal platform support in the future.