### PR TITLE
Fix some unused var compiler warnings

### DIFF
--- a/architecture/faust/dsp/dsp.h
+++ b/architecture/faust/dsp/dsp.h
@@ -49,7 +49,7 @@ struct FAUST_API dsp_memory_manager {
      * Inform the Memory Manager with the number of expected memory zones.
      * @param count - the number of expected memory zones
      */
-    virtual void begin(size_t count) {}
+    virtual void begin(size_t /*count*/) {}
     
     /**
      * Give the Memory Manager information on a given memory zone.
@@ -57,8 +57,8 @@ struct FAUST_API dsp_memory_manager {
      * @param reads - the number of Read access to the zone used to compute one frame
      * @param writes - the number of Write access to the zone used to compute one frame
      */
-    virtual void info(size_t size, size_t reads, size_t writes) {}
-    
+    virtual void info(size_t /*size*/, size_t /*reads*/, size_t /*writes*/) {}
+
     /**
      * Inform the Memory Manager that all memory zones have been described,
      * to possibly start a 'compute the best allocation strategy' step.

--- a/architecture/faust/dsp/libfaust-box.h
+++ b/architecture/faust/dsp/libfaust-box.h
@@ -87,7 +87,7 @@ struct LIBFAUST_API dsp_factory_base {
     
     virtual ~dsp_factory_base() {}
     
-    virtual void write(std::ostream* out, bool binary = false, bool compact = false) {}
+    virtual void write(std::ostream* /*out*/, bool /*binary*/ = false, bool /*compact*/ = false) {}
 };
 
 /**

--- a/architecture/faust/dsp/libfaust-signal.h
+++ b/architecture/faust/dsp/libfaust-signal.h
@@ -87,7 +87,7 @@ struct LIBFAUST_API dsp_factory_base {
     
     virtual ~dsp_factory_base() {}
     
-    virtual void write(std::ostream* out, bool binary = false, bool compact = false) {}
+    virtual void write(std::ostream* /*out*/, bool /*binary*/ = false, bool /*compact*/ = false) {}
 };
 
 /**

--- a/architecture/faust/gui/UI.h
+++ b/architecture/faust/gui/UI.h
@@ -72,8 +72,8 @@ struct FAUST_API UIReal {
     
     // -- metadata declarations
     
-    virtual void declare(REAL* zone, const char* key, const char* val) {}
-    
+    virtual void declare(REAL* /*zone*/, const char* /*key*/, const char* /*val*/) {}
+
     // To be used by LLVM client
     virtual int sizeOfFAUSTFLOAT() { return sizeof(FAUSTFLOAT); }
 };


### PR DESCRIPTION
Fixing a few unused var warnings I get in these public-facing files.