### PR TITLE
JAX backend patches 001

### DIFF
--- a/compiler/generator/jax/jax_code_container.hh
+++ b/compiler/generator/jax/jax_code_container.hh
@@ -63,8 +63,6 @@ class JAXCodeContainer : public virtual CodeContainer {
                                           std::ostream* dst = new std::stringstream());
 
     BlockInst* get_fComputeBlockInstructions() { return fComputeBlockInstructions; }
-
-    BlockInst* inlineSubcontainersFunCalls(BlockInst* block);
 };
 
 class JAXScalarCodeContainer : public JAXCodeContainer {

--- a/compiler/generator/jax/jax_instructions.hh
+++ b/compiler/generator/jax/jax_instructions.hh
@@ -287,7 +287,7 @@ class JAXInstVisitor : public TextInstVisitor {
         gPolyMathLibTable["log2f"]      = "jnp.log2";
         gPolyMathLibTable["log10f"]     = "jnp.log10";
         gPolyMathLibTable["powf"]       = "jnp.power";
-        gPolyMathLibTable["remainderf"] = "remainder";  // todo: we must rely on a custom remainder implementation in jax_code_container.cpp.
+        gPolyMathLibTable["remainderf"] = "remainder";  // todo: we currently rely on a custom remainder implementation in the architecture file.
         gPolyMathLibTable["rintf"]      = "jnp.rint";
         gPolyMathLibTable["roundf"]     = "jnp.round";
         gPolyMathLibTable["sinf"]       = "jnp.sin";
@@ -326,7 +326,7 @@ class JAXInstVisitor : public TextInstVisitor {
         gPolyMathLibTable["log2"]      = "jnp.log2";
         gPolyMathLibTable["log10"]     = "jnp.log10";
         gPolyMathLibTable["pow"]       = "jnp.power";
-        gPolyMathLibTable["remainder"] = "remainder"; // todo: we must rely on a custom remainder implementation in jax_code_container.cpp.
+        gPolyMathLibTable["remainder"] = "remainder"; // todo: we currently rely on a custom remainder implementation in the architecture file.
         gPolyMathLibTable["rint"]      = "jnp.rint";
         gPolyMathLibTable["round"]     = "jnp.round";
         gPolyMathLibTable["sin"]       = "jnp.sin";


### PR DESCRIPTION
* Remove re-implementation of inlineSubcontainersFunCalls because I had only changed it due to an earlier bug which is now fixed.
* Remove the definition of \_\_call\_\_ from `jax_code_container.cpp` because it's in architecture files

I tested impulse-tests on macOS.