### PR TITLE
Fix accidental clashing intermediate JAX variables

### DIFF
--- a/compiler/generator/jax/jax_code_container.cpp
+++ b/compiler/generator/jax/jax_code_container.cpp
@@ -242,6 +242,8 @@ void JAXCodeContainer::produceClass()
     tab(n + 1, *fOut);
     *fOut << "def build_interface(self, state, x, T: int):";
     tab(n + 2, *fOut);
+    *fOut << "ui_path = []";
+    tab(n + 2, *fOut);
     gGlobal->gJAXVisitor->Tab(n + 2);
     generateUserInterface(gGlobal->gJAXVisitor);
     tab(n + 2, *fOut);

--- a/tests/impulse-tests/archs/impulsejax.py
+++ b/tests/impulse-tests/archs/impulsejax.py
@@ -16,6 +16,7 @@
 
 import json
 import re
+from typing import List
 
 import numpy as np
 import librosa
@@ -40,7 +41,7 @@ def remainder(x, y):
 			audio = np.expand_dims(audio, 0)
 		return audio, sr
 	
-	def add_soundfile(self, state, x, label: str, url: str, key: str):
+	def add_soundfile(self, state, zone: str, ui_path: List[str], label: str, url: str, x):
 		# todo: better parsing
 		filepaths = url[2:-2].split("';'")
 		fLength, fOffset, fSR, offset = [], [], [], 0
@@ -58,40 +59,45 @@ def remainder(x, y):
 			offset += y.shape[1]
 		if label.startswith('param:'):
 			label = label[6:]  # remove param:
-			fBuffers = self.param(key+"_"+label, (lambda key, shape: fBuffers), None)
+			label = "/".join(ui_path+[label])
+			fBuffers = self.param("_"+label, (lambda key, shape: fBuffers), None)
+		else:
+			label = "/".join(ui_path+[label])
 		self.sow('intermediates', label, fBuffers)
-		state[key] = {'fLength': fLength, 'fOffset': fOffset, 'fBuffers': fBuffers, 'fSR': fSR}
-		return state
+		state[zone] = {'fLength': fLength, 'fOffset': fOffset, 'fBuffers': fBuffers, 'fSR': fSR}
 	
-	def add_nentry(self, zone: str, label: str, init: float, a_min: float, a_max: float, step_size: float, scale_mode='linear'):
+	def add_nentry(self, state, zone: str, ui_path: List[str], label: str, init: float, a_min: float, a_max: float, step_size: float, scale_mode='linear'):
+		label = "/".join(ui_path+[label])
 		num_steps = int(jnp.round((a_max-a_min)/step_size))+1
 		init_unit = int(jnp.round(init-a_min)/step_size)
 		param = jnp.ones((num_steps,))
 		param = param.at[init_unit].set(2)
 		param = nn.softmax(param)
-		param = self.param(zone+"_"+label, (lambda key, shape: param), None)
+		param = self.param("_"+label, (lambda key, shape: param), None)
 		param = jnp.argmax(param, axis=-1)*step_size+a_min
 		self.sow('intermediates', label, param)
-		return param
+		state[zone] = param
 	
-	def add_button(self, zone: str, label: str):
-		param = self.param(zone+ "_"+label, nn.initializers.constant(0.), ())
+	def add_button(self, state, zone: str, ui_path: List[str], label: str):
+		label = "/".join(ui_path+[label])
+		param = self.param(zone+ ";"+label, nn.initializers.constant(0.), ())
 		param = jnp.where(param>0., 1., 0.)
 		self.sow('intermediates', label, param)
-		return param
+		state[zone] = param
 	
-	def add_slider(self, zone: str, label: str, init: float, a_min: float, a_max: float, scale_mode='linear'):
+	def add_slider(self, state, zone: str, ui_path: List[str], label: str, init: float, a_min: float, a_max: float, scale_mode='linear'):
+		label = "/".join(ui_path+[label])
 		init, a_min, a_max = float(init), float(a_min), float(a_max)
 		if scale_mode == 'linear':
 			init = jnp.interp(init, jnp.array([a_min, a_max]), jnp.array([-1.,1.]))
-			param = self.param(zone+"_"+label, nn.initializers.constant(init), ())
+			param = self.param("_"+label, nn.initializers.constant(init), ())
 			param = jnp.clip(param, -1., 1.)
 			param = jnp.interp(param, jnp.array([-1., 1.]), jnp.array([a_min, a_max]))
 		elif scale_mode == 'exp':
 			init = jnp.interp(init, jnp.array([a_min, a_max]), jnp.array([1., jnp.e]))
 			init = jnp.log(init)
 			init = jnp.interp(init, jnp.array([0., 1.]), jnp.array([-1.,1.]))
-			param = self.param(zone+"_"+label, nn.initializers.constant(init), ())
+			param = self.param("_"+label, nn.initializers.constant(init), ())
 			param = jnp.clip(param, -1., 1.)
 			param = jnp.interp(param, jnp.array([-1., 1.]), jnp.array([0., 1.]))
 			param = jnp.interp(jnp.exp(param), jnp.array([1., jnp.e]), jnp.array([a_min, a_max]))
@@ -99,14 +105,14 @@ def remainder(x, y):
 			init = jnp.interp(init, jnp.array([a_min, a_max]), jnp.array([-4., 0.]))
 			init = jnp.power(10., init)
 			init = jnp.interp(init, jnp.array([10.**-4., 1.]), jnp.array([-1.,1.]))
-			param = self.param(zone+"_"+label, nn.initializers.constant(init), ())
+			param = self.param("_"+label, nn.initializers.constant(init), ())
 			param = jnp.clip(param, -1., 1.)
 			param = jnp.interp(param, jnp.array([-1., 1.]), jnp.array([10.**-4., 1.]))
 			param = jnp.interp(jnp.log10(param), jnp.array([-4., 0.]), jnp.array([a_min, a_max]))
 		else:
 			raise ValueError(f"Unknown scale '{scale_mode}'.")
 		self.sow('intermediates', label, param)
-		return param
+		state[zone] = param
 		
 	@nn.compact
 	def __call__(self, x, T: int) -> jnp.array:


### PR DESCRIPTION
There's a problem with the current code at this line:
https://github.com/grame-cncm/faust/blob/3af02793c9b6c2244f6e9d38082819b511936d80/architecture/jax/minimal.py#L111

The label isn't unique so multiple things try to write to the same intermediate variable. I'm talking about the intermediate variables `mod_vars` [here](https://github.com/grame-cncm/faust/blob/3af02793c9b6c2244f6e9d38082819b511936d80/architecture/jax/minimal.py#L157).

Consider this Faust code:
```faust
import("stdfaust.lib");

// Define the number of sections
N = 3;

// Define the parameters for each section.
gains = 0, 0, 0;
freqs = 500, 5000, 10000;
bandwidths = 100, 5000, 5000;

section(i) = hgroup("Section %i",
    fi.peak_eq(
        vslider("Gain", gains : ba.selector(i, N), -80., 12., .001),
        vslider("Freq",  freqs : ba.selector(i, N), 20., 20000., .001),
        vslider("Bandwidth", bandwidths : ba.selector(i, N), 20., 5000., .001)
    )
);

// Define a final volume slider.
volume = _*(vslider("Volume[unit:dB]", 0., -12., 12., .001) : ba.db2linear);

// Sequence all the sections.
process = hgroup("Equalizer", seq(i, N, section(i)) : volume);
```

Previously the intermediate variables would have been
```python
FrozenDict({
    Bandwidth: (DeviceArray(100., dtype=float32),),
    Freq: (DeviceArray(499.99973, dtype=float32),),
    Gain: (DeviceArray(-40., dtype=float32),),
    Volume: (DeviceArray(0., dtype=float32),),
})
```
This is wrong because it's undercounting the true number of parameters used.

The code has worked so far because what matters for the output audio is this line:

https://github.com/grame-cncm/faust/blob/3af02793c9b6c2244f6e9d38082819b511936d80/architecture/jax/minimal.py#L90

The names there end up being unique due to the use of `zone` in the generated name. So we need to do something similar for the intermediate values. What has worked in my test is to use `OpenboxInst` and `CloseboxInst` to keep track of the full path. Then the call to `self.sow('intermediates', label, param)` will actually have a unique label based on the accumulated OpenboxInst instructions.

So now the intermediate variables look like

```python
FrozenDict({
    Equalizer/Section 0/Bandwidth: (DeviceArray(100., dtype=float32),),
    Equalizer/Section 0/Freq: (DeviceArray(499.99973, dtype=float32),),
    Equalizer/Section 0/Gain: (DeviceArray(-40., dtype=float32),),
    Equalizer/Section 1/Bandwidth: (DeviceArray(5000., dtype=float32),),
    Equalizer/Section 1/Freq: (DeviceArray(5000., dtype=float32),),
    Equalizer/Section 1/Gain: (DeviceArray(3.0000021, dtype=float32),),
    Equalizer/Section 2/Bandwidth: (DeviceArray(5000., dtype=float32),),
    Equalizer/Section 2/Freq: (DeviceArray(10000., dtype=float32),),
    Equalizer/Section 2/Gain: (DeviceArray(-19.999998, dtype=float32),),
    Equalizer/Volume: (DeviceArray(0., dtype=float32),),
})
```

I also made the add_* UI functions not need to return anything. Now they modify the state dictionary that's passed as an argument.