### PR TITLE
Rust: Allocate on the heap with default-boxed

### DIFF
--- a/architecture/cpal.rs
+++ b/architecture/cpal.rs
@@ -106,7 +106,17 @@ pub trait UI<T> {
 fn main() -> Result<(), anyhow::Error> {
 
     // Allocation DSP on the heap
-    let mut dsp = Box::new(mydsp::new());
+    let mut dsp;
+    #[cfg(feature = "default-boxed")]
+    {
+        use default_boxed::DefaultBoxed;
+        dsp = mydsp::default_boxed();
+    }
+
+    #[cfg(not(feature = "default-boxed"))]
+    {
+        dsp = Box::new(mydsp::new());
+    }
 
     println!("get_num_inputs: {}", dsp.get_num_inputs());
     println!("get_num_outputs: {}", dsp.get_num_outputs());

--- a/architecture/jack.rs
+++ b/architecture/jack.rs
@@ -108,7 +108,17 @@ fn main() {
     let (client, _status) = j::Client::new("faust_rust", j::client_options::NO_START_SERVER).unwrap();
 
     // Allocation DSP on the heap
-    let mut dsp = Box::new(mydsp::new());
+    let mut dsp;
+    #[cfg(feature = "default-boxed")]
+    {
+        use default_boxed::DefaultBoxed;
+        dsp = mydsp::default_boxed();
+    }
+
+    #[cfg(not(feature = "default-boxed"))]
+    {
+        dsp = Box::new(mydsp::new());
+    }
 
     println!("Faust Rust code running with JACK: sample-rate = {} buffer-size = {}", client.sample_rate(), client.buffer_size());
 

--- a/architecture/minimal.rs
+++ b/architecture/minimal.rs
@@ -189,7 +189,18 @@ fn main() {
 
     println!("Faust Rust DSP");
 
-    let mut dsp = Box::new(mydsp::new());
+    // Allocation DSP on the heap
+    let mut dsp;
+    #[cfg(feature = "default-boxed")]
+    {
+        use default_boxed::DefaultBoxed;
+        dsp = mydsp::default_boxed();
+    }
+
+    #[cfg(not(feature = "default-boxed"))]
+    {
+        dsp = Box::new(mydsp::new());
+    }
 
     println!("get_num_inputs: {}", dsp.get_num_inputs());
     println!("get_num_outputs: {}", dsp.get_num_outputs());

--- a/architecture/portaudio.rs
+++ b/architecture/portaudio.rs
@@ -115,7 +115,17 @@ fn run() -> Result<(), pa::Error> {
     let pa = pa::PortAudio::new()?;
 
     // Allocation DSP on the heap
-    let mut dsp = Box::new(mydsp::new());
+    let mut dsp;
+    #[cfg(feature = "default-boxed")]
+    {
+        use default_boxed::DefaultBoxed;
+        dsp = mydsp::default_boxed();
+    }
+
+    #[cfg(not(feature = "default-boxed"))]
+    {
+        dsp = Box::new(mydsp::new());
+    }
 
     println!("Faust Rust code running with Portaudio: sample-rate = {} buffer-size = {}", SAMPLE_RATE, FRAMES_PER_BUFFER);
 

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -173,6 +173,9 @@ void RustCodeContainer::produceClass()
     fCodeProducer.Tab(n);
     generateGlobalDeclarations(&fCodeProducer);
 
+    tab(n, *fOut);
+    *fOut << "#[cfg_attr(feature = \"default-boxed\", derive(default_boxed::DefaultBoxed))]";
+    tab(n, *fOut);
     *fOut << "pub struct " << fKlassName << " {";
     tab(n + 1, *fOut);
 

--- a/tools/faust2appls/faust2cpalrust
+++ b/tools/faust2appls/faust2cpalrust
@@ -15,7 +15,7 @@ SRC="0"
 ARCHFILE=$FAUSTARCH/cpal.rs
 
 echoHelp() 
-s{
+{
     usage faust2cpalrust "[options] [Faust options] <file.dsp>"
     require CPAL
     echo "Compiles Faust programs to CPAL and Rust binary"
@@ -74,9 +74,19 @@ for p in $FILES; do
     faust -a $ARCHFILE -lang rust "$SRCDIR/$f" -o "$SRCDIR/$dspName/src/main.rs"
 
     # add dependencies
-    echo "anyhow = \"*\"" >> "$SRCDIR/$dspName/Cargo.toml"
-    echo "cpal = \"*\"" >> "$SRCDIR/$dspName/Cargo.toml"
-    echo "libm = \"*\"" >> "$SRCDIR/$dspName/Cargo.toml"
+    cat <<EOT >> "$SRCDIR/$dspName/Cargo.toml"
+anyhow = "*"
+cpal = "*"
+libm = "*"
+
+[dependencies.default-boxed]
+version = "0.2.0"
+optional = true
+
+[features]
+default = ["default-boxed"]
+default-boxed = ["dep:default-boxed"]
+EOT
 
     # build the project
     if [ $SRC = "0" ]; then

--- a/tools/faust2appls/faust2jackrust
+++ b/tools/faust2appls/faust2jackrust
@@ -72,8 +72,18 @@ for p in $FILES; do
     faust -a $ARCHFILE -lang rust $OPTIONS "$SRCDIR/$f" -o "$SRCDIR/$dspName/src/main.rs"
 
     # add dependencies
-    echo "jack = \"0.5.3\"" >> "$SRCDIR/$dspName/Cargo.toml"
-    echo "libm = \"*\"" >> "$SRCDIR/$dspName/Cargo.toml"
+    cat <<EOT >> "$SRCDIR/$dspName/Cargo.toml"
+jack = "0.5.3"
+libm = "*"
+
+[dependencies.default-boxed]
+version = "0.2.0"
+optional = true
+
+[features]
+default = ["default-boxed"]
+default-boxed = ["dep:default-boxed"]
+EOT
 
     # build the project
     if [ $SRC = "0" ]; then

--- a/tools/faust2appls/faust2portaudiorust
+++ b/tools/faust2appls/faust2portaudiorust
@@ -74,8 +74,18 @@ for p in $FILES; do
     faust -a $ARCHFILE -lang rust $OPTIONS "$SRCDIR/$f" -o "$SRCDIR/$dspName/src/main.rs"
 
     # add dependencies
-    echo "portaudio = \"*\"" >> "$SRCDIR/$dspName/Cargo.toml"
-    echo "libm = \"*\"" >> "$SRCDIR/$dspName/Cargo.toml"
+    cat <<EOT >> "$SRCDIR/$dspName/Cargo.toml"
+portaudio = "*"
+libm = "*"
+
+[dependencies.default-boxed]
+version = "0.2.0"
+optional = true
+
+[features]
+default = ["default-boxed"]
+default-boxed = ["dep:default-boxed"]
+EOT
 
     # build the project
     if [ $SRC = "0" ]; then


### PR DESCRIPTION
Add the ability to allocate directly on the heap with default-boxed.

Fixes #804

At the moment, there is no formal way to allocate an arbitrary struct on the heap in rust. The current approach taken by Faust is to allocate the dsp with `Box::new(Dsp::new())` which would be expected to first allocate on stack then move on heap, but this move is optimized away in release and it's allocated directly on the heap. However, when running in debug mode, the intermediary allocation is here making any echo or reverb very likely to stack overflow.

This PR adds a way to allocate the DSP on the heap with the help of the third-party crate [default-boxed](https://docs.rs/default-boxed/latest/default_boxed/).

The change in the generated code of Faust is very conservative: It's under conditional compilation with a feature, disabled by default. When the feature is enabled, it adds a new `default_boxed()` method. This change should not break any user, including in specific environment such as embedded/no-std.

```rs
#[cfg_attr(feature = "default-boxed", derive(default_boxed::DefaultBoxed))]
#[derive(Debug,Clone)]
pub struct mydsp {
	iVec0: [i32;2],
```

The architecture files are updated to take advantage of it. The feature is enabled by default in `Cargo.toml` so users of the `faust2XXX` scripts will benefit of it. They can still opt-out with `cargo build --no-default-features`.
