### PR TITLE
Improve dplug.d architecture file

### DIFF
--- a/architecture/dplug.d
+++ b/architecture/dplug.d
@@ -36,6 +36,7 @@
 
 import dplug.core.vec;
 import dplug.client;
+import core.stdc.stdlib : strtol;
 
 alias FAUSTFLOAT = float;
 
@@ -101,34 +102,44 @@ nothrow:
         _faustParams = makeVec!FaustParam();
     }
 
+    override void declare(FAUSTFLOAT* id, string key, string value)
+    {
+        if(value == "")
+        {
+            nextParamId = cast(int)strtol(key.ptr, null, 0);
+        }
+    }
+
     override void addButton(string label, FAUSTFLOAT* val)
     {
-        _faustParams.pushBack(FaustParam(label, val, 0, 0, 0, 0, true));
+        _faustParams.pushBack(FaustParam(label, val, 0, 0, 0, 0, true, nextParamId));
     }
     
     override void addCheckButton(string label, FAUSTFLOAT* val)
     {
-        _faustParams.pushBack(FaustParam(label, val, 0, 0, 0, 0, true));
+        _faustParams.pushBack(FaustParam(label, val, 0, 0, 0, 0, true, nextParamId));
     }
     
     override void addVerticalSlider(string label, FAUSTFLOAT* val, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
     {
-        _faustParams.pushBack(FaustParam(label, val, init, min, max, step));
+        _faustParams.pushBack(FaustParam(label, val, init, min, max, step, false, nextParamId));
     }
 
     override void addHorizontalSlider(string label, FAUSTFLOAT* val, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
     {
-        _faustParams.pushBack(FaustParam(label, val, init, min, max, step));
+        _faustParams.pushBack(FaustParam(label, val, init, min, max, step, false, nextParamId));
     }
 
     override void addNumEntry(string label, FAUSTFLOAT* val, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
     {
-        _faustParams.pushBack(FaustParam(label, val, init, min, max, step));
+        _faustParams.pushBack(FaustParam(label, val, init, min, max, step, false, nextParamId));
     }
 
     FaustParam[] readParams()
     {
-        return _faustParams.releaseData();
+        /* return _faustParams.releaseData(); */
+        /* Vec!FaustParam _sortedList = makeVec!FaustParam(); */
+        return sortParams(_faustParams.releaseData());
     }
 
     FaustParam readParam(int index)
@@ -143,6 +154,30 @@ nothrow:
 
 private:
 	Vec!FaustParam _faustParams;
+    int nextParamId = 0;
+
+    // simple bubble sort
+    FaustParam[] sortParams(FaustParam[] params)
+    {
+        bool success = true;
+        do
+        {
+            success = true;
+            for(int i = 0; i < params.length - 1; ++i)
+            {
+                auto left = params[i];
+                auto right = params[i + 1];
+                if (right.ParamId < left.ParamId)
+                {
+                    params[i] = right;
+                    params[i + 1] = left;
+                    success = false;
+                }
+            }
+        }
+        while(!success);
+        return params;
+    }
 }
 
 struct FaustParam
@@ -154,6 +189,7 @@ struct FaustParam
 	FAUSTFLOAT max;
 	FAUSTFLOAT step;
     bool isButton = false;
+    int ParamId;
 }
 
 version(unittest){}

--- a/architecture/dplug.d
+++ b/architecture/dplug.d
@@ -108,31 +108,40 @@ nothrow:
         {
             nextParamId = cast(int)strtol(key.ptr, null, 0);
         }
+        else if (key == "unit")
+        {
+            nextParamUnit = value;
+        }
     }
 
     override void addButton(string label, FAUSTFLOAT* val)
     {
-        _faustParams.pushBack(FaustParam(label, val, 0, 0, 0, 0, true, nextParamId));
+        _faustParams.pushBack(FaustParam(label, nextParamUnit, val, 0, 0, 0, 0, true, nextParamId));
+        resetNextParamMeta();
     }
     
     override void addCheckButton(string label, FAUSTFLOAT* val)
     {
-        _faustParams.pushBack(FaustParam(label, val, 0, 0, 0, 0, true, nextParamId));
+        _faustParams.pushBack(FaustParam(label, nextParamUnit, val, 0, 0, 0, 0, true, nextParamId));
+        resetNextParamMeta();
     }
     
     override void addVerticalSlider(string label, FAUSTFLOAT* val, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
     {
-        _faustParams.pushBack(FaustParam(label, val, init, min, max, step, false, nextParamId));
+        _faustParams.pushBack(FaustParam(label, nextParamUnit, val, init, min, max, step, false, nextParamId));
+        resetNextParamMeta();
     }
 
     override void addHorizontalSlider(string label, FAUSTFLOAT* val, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
     {
-        _faustParams.pushBack(FaustParam(label, val, init, min, max, step, false, nextParamId));
+        _faustParams.pushBack(FaustParam(label, nextParamUnit, val, init, min, max, step, false, nextParamId));
+        resetNextParamMeta();
     }
 
     override void addNumEntry(string label, FAUSTFLOAT* val, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
     {
-        _faustParams.pushBack(FaustParam(label, val, init, min, max, step, false, nextParamId));
+        _faustParams.pushBack(FaustParam(label, nextParamUnit, val, init, min, max, step, false, nextParamId));
+        resetNextParamMeta();
     }
 
     FaustParam[] readParams()
@@ -154,7 +163,14 @@ nothrow:
 
 private:
 	Vec!FaustParam _faustParams;
-    int nextParamId = 0;
+    int nextParamId = -1;
+    string nextParamUnit = "";
+
+    void resetNextParamMeta()
+    {
+        nextParamId = -1;
+        nextParamUnit = "";
+    }
 
     // simple bubble sort
     FaustParam[] sortParams(FaustParam[] params)
@@ -183,6 +199,7 @@ private:
 struct FaustParam
 {
 	string label;
+    string unit;
 	FAUSTFLOAT* val;
 	FAUSTFLOAT initial;
 	FAUSTFLOAT min;
@@ -242,11 +259,11 @@ nothrow:
                 params ~= mallocNew!BoolParameter(faustParamIndexStart++, param.label, cast(bool)(*param.val));
             }
             else if (param.step == 1.0f) {
-                params ~= mallocNew!IntegerParameter(faustParamIndexStart++, param.label, param.label, cast(int)param.min, cast(int)param.max, cast(int)param.initial);
+                params ~= mallocNew!IntegerParameter(faustParamIndexStart++, param.label, param.unit, cast(int)param.min, cast(int)param.max, cast(int)param.initial);
             }
             else
             {
-                params ~= mallocNew!LinearFloatParameter(faustParamIndexStart++, param.label, param.label, param.min, param.max, param.initial);
+                params ~= mallocNew!LinearFloatParameter(faustParamIndexStart++, param.label, param.unit, param.min, param.max, param.initial);
             }
         }
 


### PR DESCRIPTION
This adds the following to the dplug.d architecture file

- Sorts the parameters based on their order metadata
- Makes use of the `unit` metadata
- Checks if `step == 1.0` when creating parameters to determine integer or float parameters.
- Allows the user to add `faustoverride` to their versions in `dub.json` to override the plugin entrypoints and use the output code in an existing project.