### PR TITLE
Support LLVM 15 by disabling opaque pointers

### DIFF
--- a/compiler/generator/llvm/llvm_code_container.cpp
+++ b/compiler/generator/llvm/llvm_code_container.cpp
@@ -52,6 +52,9 @@ CodeContainer* LLVMCodeContainer::createScalarContainer(const string& name, int 
 LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numOutputs)
 {
     LLVMContext* context = new LLVMContext();
+#if LLVM_VERSION_MAJOR == 15
+     context->setOpaquePointers(false);
+#endif
     Module* module = new Module(gGlobal->printCompilationOptions1() + ", v" + string(FAUSTVERSION), *context);
     
     init(name, numInputs, numOutputs, module, context);

--- a/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -152,6 +152,9 @@ llvm_dsp_factory_aux::llvm_dsp_factory_aux(const string& sha_key, const string& 
 
     // Creates module and context
     fContext = new LLVMContext();
+#if LLVM_VERSION_MAJOR == 15
+    fContext->setOpaquePointers(false);
+#endif
     fModule  = new Module(string(LLVM_BACKEND_NAME) + ", v" + string(FAUSTVERSION), *fContext);
     fDecoder = nullptr;
 }
@@ -179,7 +182,6 @@ llvm_dsp_factory_aux::~llvm_dsp_factory_aux()
     if (fJIT) {
         fJIT->runStaticConstructorsDestructors(true);
         // fModule is kept and deleted by fJIT
-        delete fJIT;
     }
     delete fContext;
     delete fDecoder;
@@ -909,4 +911,3 @@ LIBFAUST_API void registerCForeignFunction(const char* name)
 #ifdef __cplusplus
 }
 #endif
-

--- a/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
@@ -384,6 +384,9 @@ static llvm_dsp_factory* readDSPFactoryFromBitcodeAux(MEMORY_BUFFER buffer, cons
     } else {
         try {
             LLVMContext* context = new LLVMContext();
+#if LLVM_VERSION_MAJOR == 15
+            context->setOpaquePointers(false);
+#endif
             Module*      module  = ParseBitcodeFile(buffer, *context, error_msg);
             if (!module) return nullptr;
             llvm_dynamic_dsp_factory_aux* factory_aux
@@ -491,6 +494,9 @@ static llvm_dsp_factory* readDSPFactoryFromIRAux(MEMORY_BUFFER buffer, const str
             }
             setlocale(LC_ALL, "C");
             LLVMContext* context = new LLVMContext();
+#if LLVM_VERSION_MAJOR == 15
+            context->setOpaquePointers(false);
+#endif
             SMDiagnostic err;
             // parseIR takes ownership of the given buffer, so don't delete it
             Module* module = parseIR(buffer, err, *context).release();

--- a/compiler/generator/llvm/llvm_instructions.hh
+++ b/compiler/generator/llvm/llvm_instructions.hh
@@ -58,9 +58,6 @@ using namespace llvm;
 #define MakeIdx(beg, end) llvm::ArrayRef<LLVMValue>(beg, end)
 #define MakeArgs(args) llvm::ArrayRef<lLLVMValue>(args)
 #if LLVM_VERSION_MAJOR >= 14
-    #if LLVM_VERSION_MAJOR == 15
-    #error LLVM 15 not yet supported
-    #endif
 #define GetType(ptr) ptr->getType()->getScalarType()->getPointerElementType()
 #define MakeStructGEP(v1, v2) fBuilder->CreateStructGEP(GetType(v1), v1, v2);
 #define MyCreateLoad(var, is_volatile) fBuilder->CreateLoad(GetType(var), var, is_volatile)


### PR DESCRIPTION
This is a temporary approach until we [migrate to opaque pointers](https://llvm.org/docs/OpaquePointers.html#migration-instructions), and works for me on clang 15.0.5. The only issue I ran into was a new mutex error on shutdown when destructing `ExecutionEngine`: `recursive_mutex lock failed: Invalid argument`.

I don't have sources for llvm in my debug environment (just headers) but I would assume it's in [this line](https://github.com/llvm/llvm-project/blob/main/llvm/lib/ExecutionEngine/ExecutionEngine.cpp#L228). I can't find any info about this API being updated in 15, and couldn't find a resolution. Simply not explicitly deleting the `ExecutionEngine` instance works for me without apparent issues, but it's clearly not good to just remove the delete. I don't see any relevant differences between LLVM's JIT example for [15.0.5](https://github.com/llvm/llvm-project/blob/llvmorg-15.0.5/llvm/examples/HowToUseJIT/HowToUseJIT.cpp) compared with say [14.0.0](https://github.com/llvm/llvm-project/blob/llvmorg-14.0.0/llvm/examples/HowToUseJIT/HowToUseJIT.cpp). They both expect the caller to explicitly `delete`. So something else is going on here.

Anyway, I thought I'd get the ball rolling, and hoped someone with more LLVM/Faust experience could help, especially someone who's building LLVM locally already and can step into it.