### PR TITLE
Fix missing `std::` namespace qualifiers in `global.cpp`

### DIFF
--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -103,6 +103,10 @@
 #include "template_code_container.hh"
 #endif
 
+using std::list;
+using std::vector;
+using std::string;
+
 // Globals for lex/yack parser
 extern FILE*       yyin;
 extern const char* yyfilename;
@@ -655,7 +659,7 @@ string global::printFloat()
     }
 }
 
-void global::printCompilationOptions(stringstream& dst, bool backend)
+void global::printCompilationOptions(std::stringstream& dst, bool backend)
 {
     if (gArchFile != "") dst << "-a " << gArchFile << " ";
     if (backend) {
@@ -702,7 +706,7 @@ void global::printCompilationOptions(stringstream& dst, bool backend)
 
 string global::printCompilationOptions1()
 {
-    stringstream dst;
+    std::stringstream dst;
     printCompilationOptions(dst, true);
     string res = dst.str();
     return res.substr(0, res.size() - 1);


### PR DESCRIPTION
Likely missed in https://github.com/grame-cncm/faust/commit/fd39eb6375914db8746d9fa9c0410c6e3601abff
