### PR TITLE
Make all compute input buffers const

### DIFF
--- a/architecture/c-jack-gtk.c
+++ b/architecture/c-jack-gtk.c
@@ -165,7 +165,7 @@ class Cdsp : public dsp {
             metadatamydsp(&glue);
         }
     
-        virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+        virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
         {
             computemydsp(fDSP, count, input, output);
         }

--- a/architecture/faust/dsp/cmajor-cpp-dsp.h
+++ b/architecture/faust/dsp/cmajor-cpp-dsp.h
@@ -196,7 +196,7 @@ class cmajor_cpp_dsp : public dsp {
         virtual void metadata(Meta* m)
         {}
     
-        void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             // Copy audio inputs
             if (fDSP.numAudioInputChannels > 0) {
@@ -221,7 +221,7 @@ class cmajor_cpp_dsp : public dsp {
             }
         }
     
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }

--- a/architecture/faust/dsp/cmajorpatch-dsp.h
+++ b/architecture/faust/dsp/cmajorpatch-dsp.h
@@ -135,9 +135,9 @@ class cmajorpatch_dsp : public dsp {
     
         virtual void metadata(Meta* m) {}
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
     
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
        
 };
 
@@ -365,7 +365,7 @@ void cmajorpatch_dsp::buildUserInterface(UI* ui_interface)
     ui_interface->closeBox();
 }
 
-void cmajorpatch_dsp::compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+void cmajorpatch_dsp::compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
 {
     fPerformer.setBlockSize(count);
     

--- a/architecture/faust/dsp/dsp-adapter.h
+++ b/architecture/faust/dsp/dsp-adapter.h
@@ -46,7 +46,7 @@ class dsp_adapter : public decorator_dsp {
         int fHWOutputs;
         int fBufferSize;
     
-        void adaptBuffers(FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void adaptBuffers(const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             for (int i = 0; i < fHWInputs; i++) {
                 fAdaptedInputs[i] = inputs[i];
@@ -95,13 +95,13 @@ class dsp_adapter : public decorator_dsp {
     
         virtual dsp_adapter* clone() { return new dsp_adapter(fDSP->clone(), fHWInputs, fHWOutputs, fBufferSize); }
     
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             adaptBuffers(inputs, outputs);
             fDSP->compute(date_usec, count, fAdaptedInputs, fAdaptedOutputs);
         }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             adaptBuffers(inputs, outputs);
             fDSP->compute(count, fAdaptedInputs, fAdaptedOutputs);
@@ -117,7 +117,7 @@ class dsp_sample_adapter : public decorator_dsp {
         REAL_INT** fAdaptedInputs;
         REAL_INT** fAdaptedOutputs;
     
-        void adaptInputBuffers(int count, FAUSTFLOAT** inputs)
+        void adaptInputBuffers(int count, const FAUSTFLOAT** inputs)
         {
             for (int chan = 0; chan < fDSP->getNumInputs(); chan++) {
                 for (int frame = 0; frame < count; frame++) {
@@ -165,7 +165,7 @@ class dsp_sample_adapter : public decorator_dsp {
     
         virtual dsp_sample_adapter* clone() { return new dsp_sample_adapter(fDSP->clone()); }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             assert(count <= 4096);
             adaptInputBuffers(count, inputs);
@@ -174,7 +174,7 @@ class dsp_sample_adapter : public decorator_dsp {
             adaptOutputsBuffers(count, outputs);
         }
     
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             assert(count <= 4096);
             adaptInputBuffers(count, inputs);
@@ -460,14 +460,14 @@ struct dsp_bus : public dsp {
     
     virtual void metadata(Meta* m) {}
     
-    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
     {
         for (int chan = 0; chan < fChannels; chan++) {
             memcpy(outputs[chan], inputs[chan], sizeof(FAUSTFLOAT) * count);
         }
     }
     
-    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
     {
         compute(count, inputs, outputs);
     }
@@ -524,7 +524,7 @@ class dsp_down_sampler : public sr_sampler<FILTER> {
     
         virtual dsp_down_sampler* clone() { return new dsp_down_sampler(decorator_dsp::clone()); }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             int real_count = count / this->getFactor();
             
@@ -565,7 +565,7 @@ class dsp_down_sampler : public sr_sampler<FILTER> {
             }
         }
     
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
 };
 
 // Up sample-rate adapter
@@ -594,7 +594,7 @@ class dsp_up_sampler : public sr_sampler<FILTER> {
     
         virtual dsp_up_sampler* clone() { return new dsp_up_sampler(decorator_dsp::clone()); }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             int real_count = count * this->getFactor();
             
@@ -637,7 +637,7 @@ class dsp_up_sampler : public sr_sampler<FILTER> {
             }
         }
     
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
 };
 
 // Create a UP/DS + Filter adapted DSP

--- a/architecture/faust/dsp/dsp-checker.h
+++ b/architecture/faust/dsp/dsp-checker.h
@@ -77,7 +77,7 @@ class dsp_me_checker : public decorator_dsp
     
         virtual ~dsp_me_checker() {}
     
-        void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             if (fRuntime) {
                 TRY_FPE
@@ -88,7 +88,7 @@ class dsp_me_checker : public decorator_dsp
                 getStats(count, outputs);
             }
         }
-        void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             if (fRuntime) {
                 TRY_FPE

--- a/architecture/faust/dsp/dsp-combiner.h
+++ b/architecture/faust/dsp/dsp-combiner.h
@@ -182,13 +182,13 @@ class dsp_sequencer : public dsp_binary_combiner {
             return new dsp_sequencer(fDSP1->clone(), fDSP2->clone(), fBufferSize, fLayout, fLabel);
         }
 
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             fDSP1->compute(count, inputs, fDSP1Outputs);
             fDSP2->compute(count, fDSP1Outputs, outputs);
         }
 
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
 
 };
 
@@ -232,7 +232,7 @@ class dsp_parallelizer : public dsp_binary_combiner {
             return new dsp_parallelizer(fDSP1->clone(), fDSP2->clone(), fBufferSize, fLayout, fLabel);
         }
 
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             fDSP1->compute(count, inputs, outputs);
 
@@ -247,7 +247,7 @@ class dsp_parallelizer : public dsp_binary_combiner {
             fDSP2->compute(count, fDSP2Inputs, fDSP2Outputs);
         }
 
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
 
 };
 
@@ -291,7 +291,7 @@ class dsp_splitter : public dsp_binary_combiner {
             return new dsp_splitter(fDSP1->clone(), fDSP2->clone(), fBufferSize, fLayout, fLabel);
         }
 
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             fDSP1->compute(count, inputs, fDSP1Outputs);
 
@@ -353,7 +353,7 @@ class dsp_merger : public dsp_binary_combiner {
             return new dsp_merger(fDSP1->clone(), fDSP2->clone(), fBufferSize, fLayout, fLabel);
         }
 
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             fDSP1->compute(count, fDSP1Inputs, fDSP1Outputs);
 
@@ -418,7 +418,7 @@ class dsp_recursiver : public dsp_binary_combiner {
             return new dsp_recursiver(fDSP1->clone(), fDSP2->clone(), fLayout, fLabel);
         }
 
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             for (int frame = 0; (frame < count); frame++) {
 
@@ -444,7 +444,7 @@ class dsp_recursiver : public dsp_binary_combiner {
             }
         }
 
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
 
 };
 
@@ -520,7 +520,7 @@ class dsp_crossfader: public dsp_binary_combiner {
             return new dsp_crossfader(fDSP1->clone(), fDSP2->clone(), fLayout, fLabel);
         }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             if (fCrossfade == FAUSTFLOAT(1)) {
                 fDSP1->compute(count, inputs, outputs);
@@ -541,7 +541,7 @@ class dsp_crossfader: public dsp_binary_combiner {
             }
         }
     
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
 };
 
 #ifndef __dsp_algebra_api__

--- a/architecture/faust/dsp/dsp-compute-adapter.h
+++ b/architecture/faust/dsp/dsp-compute-adapter.h
@@ -50,12 +50,12 @@ class dsp_compute_mix : public decorator_dsp {
         dsp_compute_mix(dsp* dsp) : decorator_dsp(dsp)
         {}
     
-        virtual void computeAdding(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void computeAdding(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             fDSP->compute(count, inputs, outputs);
         }
     
-        virtual void computeRemplacing(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void computeRemplacing(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             for (int chan = 0; chan < fDSP->getNumOutputs(); chan++) {
                 memset(outputs[chan], 0, sizeof(FAUSTFLOAT) * count);

--- a/architecture/faust/dsp/dsp-tools.h
+++ b/architecture/faust/dsp/dsp-tools.h
@@ -126,7 +126,7 @@ class Interleaver
             delete [] fOutput;
         }
         
-        FAUSTFLOAT** inputs() { return fInputs; }
+        const FAUSTFLOAT** inputs() { return fInputs; }
         
         FAUSTFLOAT* output() { return fOutput; }
         

--- a/architecture/faust/dsp/dsp.h
+++ b/architecture/faust/dsp/dsp.h
@@ -158,7 +158,7 @@ class FAUST_API dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
     
         /**
          * DSP instance computation: alternative method to be used by subclasses.
@@ -169,7 +169,7 @@ class FAUST_API dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
        
 };
 
@@ -200,8 +200,8 @@ class FAUST_API decorator_dsp : public dsp {
         virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
         virtual void metadata(Meta* m) { fDSP->metadata(m); }
         // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
     
 };
 

--- a/architecture/faust/dsp/faust-poly-engine.h
+++ b/architecture/faust/dsp/faust-poly-engine.h
@@ -303,7 +303,7 @@ class FaustPolyEngine {
             fFinalDSP->buildUserInterface(ui_interface);
         }
     
-        void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             fFinalDSP->compute(count, inputs, outputs);
         }

--- a/architecture/faust/dsp/interpreter-dsp-c.h
+++ b/architecture/faust/dsp/interpreter-dsp-c.h
@@ -257,7 +257,7 @@ extern "C"
     
     LIBFAUST_API void metadataCInterpreterDSPInstance(interpreter_dsp* dsp, MetaGlue* meta);
     
-    LIBFAUST_API void computeCInterpreterDSPInstance(interpreter_dsp* dsp, int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+    LIBFAUST_API void computeCInterpreterDSPInstance(interpreter_dsp* dsp, int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
     /**
      * Create a Faust DSP instance.

--- a/architecture/faust/dsp/interpreter-dsp.h
+++ b/architecture/faust/dsp/interpreter-dsp.h
@@ -86,7 +86,7 @@ class LIBFAUST_API interpreter_dsp : public dsp {
         
         void metadata(Meta* m);
         
-        void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+        void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
 };
 

--- a/architecture/faust/dsp/interpreter-machine-dsp.h
+++ b/architecture/faust/dsp/interpreter-machine-dsp.h
@@ -83,7 +83,7 @@ class LIBFAUST_API interpreter_dsp : public dsp {
         
         void metadata(Meta* m);
         
-        void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+        void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
 };
 

--- a/architecture/faust/dsp/llvm-dsp-adapter.h
+++ b/architecture/faust/dsp/llvm-dsp-adapter.h
@@ -50,7 +50,7 @@ extern "C"
     void instanceConstantsmydsp(comp_llvm_mydsp* dsp, int sample_rate);
     void instanceClearmydsp(comp_llvm_mydsp* dsp);
     void classInitmydsp(int sample_rate);
-    void computemydsp(comp_llvm_mydsp* dsp, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+    void computemydsp(comp_llvm_mydsp* dsp, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
     char* getJSONmydsp();
     
 #ifdef __cplusplus
@@ -141,12 +141,12 @@ class mydsp : public dsp {
             fDecoder->metadata(m);
         }
         
-        virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+        virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
         {
             computemydsp(fDSP, count, input, output);
         }
     
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }

--- a/architecture/faust/dsp/llvm-dsp-c.h
+++ b/architecture/faust/dsp/llvm-dsp-c.h
@@ -480,7 +480,7 @@ extern "C"
     
     LIBFAUST_API void metadataCDSPInstance(llvm_dsp* dsp, MetaGlue* meta);
     
-    LIBFAUST_API void computeCDSPInstance(llvm_dsp* dsp, int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+    LIBFAUST_API void computeCDSPInstance(llvm_dsp* dsp, int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
     /* Set custom memory manager to be used when creating instances */
     LIBFAUST_API void setCMemoryManager(llvm_dsp_factory* factory, MemoryManagerGlue* manager);

--- a/architecture/faust/dsp/llvm-dsp.h
+++ b/architecture/faust/dsp/llvm-dsp.h
@@ -86,7 +86,7 @@ class LIBFAUST_API llvm_dsp : public dsp {
         
         void metadata(Meta* m);
         
-        void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+        void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
     
 };
 

--- a/architecture/faust/dsp/llvm-machine-dsp.h
+++ b/architecture/faust/dsp/llvm-machine-dsp.h
@@ -78,7 +78,7 @@ class LIBFAUST_API llvm_dsp : public dsp {
         
         void metadata(Meta* m);
         
-        void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+        void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
     
 };
 

--- a/architecture/faust/dsp/one-sample-dsp.h
+++ b/architecture/faust/dsp/one-sample-dsp.h
@@ -113,7 +113,7 @@ class FAUST_API one_sample_dsp : public dsp {
         virtual void compute(FAUSTFLOAT* inputs, FAUSTFLOAT* outputs, int* iControl, FAUSTFLOAT* fControl) = 0;
     
         // The standard 'compute' expressed using the control/compute (one sample) model
-        virtual void compute(int count, FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
+        virtual void compute(int count, const FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
         {
             // Control
             control();
@@ -149,7 +149,7 @@ class FAUST_API one_sample_dsp : public dsp {
             }
         }
         
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }
@@ -309,7 +309,7 @@ class FAUST_API one_sample_dsp_real : public dsp {
                              int* iZone, REAL* fZone) = 0;
         
         // The standard 'compute' expressed using the control/compute (one sample) model
-        virtual void compute(int count, FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
+        virtual void compute(int count, const FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
         {
             assert(fInputs);
             
@@ -347,7 +347,7 @@ class FAUST_API one_sample_dsp_real : public dsp {
             }
         }
         
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }
@@ -423,7 +423,7 @@ class FAUST_API one_sample_dsp_real1 : public dsp {
         virtual void compute(FAUSTFLOAT* inputs, FAUSTFLOAT* outputs) = 0;
         
         // The standard 'compute' expressed using the control/compute (one sample) model
-        virtual void compute(int count, FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
+        virtual void compute(int count, const FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
         {
             // TODO : not RT safe
             if (!fInputs) {
@@ -465,7 +465,7 @@ class FAUST_API one_sample_dsp_real1 : public dsp {
             }
         }
         
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }

--- a/architecture/faust/dsp/poly-dsp.h
+++ b/architecture/faust/dsp/poly-dsp.h
@@ -193,9 +193,9 @@ struct dsp_voice : public MapUI, public decorator_dsp {
     virtual ~dsp_voice()
     {}
     
-    void computeSlice(int offset, int slice, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    void computeSlice(int offset, int slice, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
     {
-        FAUSTFLOAT** inputsSlice = static_cast<FAUSTFLOAT**>(alloca(sizeof(FAUSTFLOAT*) * getNumInputs()));
+        const FAUSTFLOAT** inputsSlice = static_cast<FAUSTFLOAT**>(alloca(sizeof(FAUSTFLOAT*) * getNumInputs()));
         for (int chan = 0; chan < getNumInputs(); chan++) {
             inputsSlice[chan] = &(inputs[chan][offset]);
         }
@@ -206,7 +206,7 @@ struct dsp_voice : public MapUI, public decorator_dsp {
         compute(slice, inputsSlice, outputsSlice);
     }
     
-    void computeLegato(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    void computeLegato(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
     {
         int slice = count/2;
         
@@ -795,7 +795,7 @@ class mydsp_poly : public dsp_voice_group, public dsp_poly {
             return new mydsp_poly(fDSP->clone(), int(fVoiceTable.size()), fVoiceControl, fGroupControl);
         }
 
-        void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             assert(count <= MIX_BUFFER_SIZE);
 
@@ -839,7 +839,7 @@ class mydsp_poly : public dsp_voice_group, public dsp_poly {
             copy(count, fOutBuffer, outputs);
         }
 
-        void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }

--- a/architecture/faust/dsp/proxy-dsp.h
+++ b/architecture/faust/dsp/proxy-dsp.h
@@ -99,8 +99,8 @@ class proxy_dsp : public dsp {
         virtual proxy_dsp* clone() { return new proxy_dsp(fDecoder->fJSON); }
         virtual void metadata(Meta* m) { fDecoder->metadata(m); }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {} 
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {} 
         
 };
 

--- a/architecture/faust/dsp/sound-player.h
+++ b/architecture/faust/dsp/sound-player.h
@@ -157,7 +157,7 @@ class sound_base_player : public dsp {
             m->declare("name", fFileName.c_str());
         }
         
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             if (fPlayButton == FAUSTFLOAT(1) && fMutex.try_lock()) {
                 

--- a/architecture/faust/dsp/timed-dsp.h
+++ b/architecture/faust/dsp/timed-dsp.h
@@ -141,7 +141,7 @@ class timed_dsp : public decorator_dsp {
         FAUSTFLOAT** fInputsSlice;
         FAUSTFLOAT** fOutputsSlice;
     
-        void computeSlice(int offset, int slice, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) 
+        void computeSlice(int offset, int slice, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) 
         {
             if (slice > 0) {
                 for (int chan = 0; chan < fDSP->getNumInputs(); chan++) {
@@ -183,7 +183,7 @@ class timed_dsp : public decorator_dsp {
             return it2;
         }
         
-        virtual void computeAux(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs, bool convert_ts)
+        virtual void computeAux(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs, bool convert_ts)
         {
             int slice, offset = 0;
             ztimedmap::iterator it;
@@ -246,12 +246,12 @@ class timed_dsp : public decorator_dsp {
         }
     
         // Default method take a timestamp at 'compute' call time
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(::GetCurrentTimeInUsec(), count, inputs, outputs);
         }    
         
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             if (date_usec == -1) {
                 // Timestamp is expressed in frames

--- a/architecture/faust/dsp/wasm-dsp-imp.h
+++ b/architecture/faust/dsp/wasm-dsp-imp.h
@@ -180,8 +180,8 @@ class LIFAUST_API wasm_dsp_imp : public dsp {
             fFactory->fDecoder->metadata(m);
         }
         // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
+        virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
 };
 
 #endif

--- a/architecture/faust/dsp/wasm-dsp.h
+++ b/architecture/faust/dsp/wasm-dsp.h
@@ -78,7 +78,7 @@ class LIFAUST_API wasm_dsp : public dsp {
 
         void metadata(Meta* m);
 
-        void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+        void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
 };
 

--- a/architecture/faust/gui/CInterface.h
+++ b/architecture/faust/gui/CInterface.h
@@ -115,7 +115,7 @@ typedef void (* instanceInitFun) (dsp_imp* dsp, int sample_rate);
 typedef void (* instanceConstantsFun) (dsp_imp* dsp, int sample_rate);
 typedef void (* instanceResetUserInterfaceFun) (dsp_imp* dsp);
 typedef void (* instanceClearFun) (dsp_imp* dsp);
-typedef void (* computeFun) (dsp_imp* dsp, int len, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+typedef void (* computeFun) (dsp_imp* dsp, int len, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
 typedef void (* metadataFun) (MetaGlue* meta);
     
 /***************************************

--- a/architecture/faust/vst/faust.h
+++ b/architecture/faust/vst/faust.h
@@ -48,7 +48,7 @@ class Faust : public AudioEffectX {
         // Destructor
         virtual ~Faust();
 
-        virtual void processReplacing (FAUSTFLOAT** inputs, FAUSTFLOAT** outputs, VstInt32 sampleFrames);
+        virtual void processReplacing (const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs, VstInt32 sampleFrames);
         virtual VstInt32 processEvents (VstEvents* events);
 
         virtual void setProgram (VstInt32 program);

--- a/architecture/iOS/ios-faust.h
+++ b/architecture/iOS/ios-faust.h
@@ -100,7 +100,7 @@ class mydsp : public dsp {
             return fSampleRate;
         }
         virtual void buildUserInterface(UI* interface) {}
-        virtual void compute (int count, FAUSTFLOAT** input, FAUSTFLOAT** output) {}
+        virtual void compute (int count, const FAUSTFLOAT** input, FAUSTFLOAT** output) {}
 };
 
 /***************************END USER SECTION ***************************/

--- a/architecture/minimal-effect.c
+++ b/architecture/minimal-effect.c
@@ -136,7 +136,7 @@ class Cdsp : public dsp {
             metadatamydsp(&glue);
         }
     
-        virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+        virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
         {
             computemydsp(fDSP, count, input, output);
         }

--- a/architecture/module.cpp
+++ b/architecture/module.cpp
@@ -85,7 +85,7 @@ extern "C" EXPORT void instanceConstants(dsp* self, int sample_rate) { self->ins
 extern "C" EXPORT void instanceResetUserInterface(dsp* self) { self->instanceResetUserInterface(); }
 extern "C" EXPORT dsp*  clone(dsp* self) { return self->clone(); }
 extern "C" EXPORT void metadata(dsp* self, Meta* m) { self->metadata(m); }
-extern "C" EXPORT void compute(dsp* self, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { self->compute(count, inputs, outputs); }
+extern "C" EXPORT void compute(dsp* self, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { self->compute(count, inputs, outputs); }
 
 /******************* END module.cpp ****************/
 

--- a/architecture/unsupported-arch/llvm-jack-gtk.cpp
+++ b/architecture/unsupported-arch/llvm-jack-gtk.cpp
@@ -144,7 +144,7 @@ class llvmdsp : public dsp {
         buildUserInterfacemydsp(fDsp, &glue);
  	}
 
-	virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+	virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
     {
         AVOIDDENORMALS;
 		computemydsp(fDsp, count, input, output);

--- a/architecture/vcvrack/template/src/FaustModule.cpp
+++ b/architecture/vcvrack/template/src/FaustModule.cpp
@@ -86,8 +86,8 @@ class rack_dsp {
         virtual void instanceClear() = 0;
         virtual rack_dsp* clone() = 0;
         virtual void metadata(Meta* m) = 0;
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
+        virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
     
 };
 
@@ -125,10 +125,10 @@ struct one_sample_dsp : public rack_dsp {
     
     virtual void compute(FAUSTFLOAT* inputs, FAUSTFLOAT* outputs, int* iControl, FAUSTFLOAT* fControl) = 0;
     
-    virtual void compute(int count, FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
+    virtual void compute(int count, const FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
     {}
     
-    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
     {
         compute(count, inputs, outputs);
     }

--- a/architecture/vst.cpp
+++ b/architecture/vst.cpp
@@ -616,7 +616,7 @@ void Faust::initProcess()
 }
 
 //----------------------------------------------------------------------------
-void Faust::processReplacing(FAUSTFLOAT** inputs, FAUSTFLOAT** outputs, VstInt32 sampleFrames)
+void Faust::processReplacing(const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs, VstInt32 sampleFrames)
 {
     AVOIDDENORMALS;
 #ifdef DEBUG
@@ -640,7 +640,7 @@ inline float midiToFreq(int note)
 }
 
 //----------------------------------------------------------------------------
-void Faust::synthProcessReplacing(FAUSTFLOAT** inputs, FAUSTFLOAT** outputs,
+void Faust::synthProcessReplacing(const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs,
                                   VstInt32 sampleFrames)
 {
     float* outptr[MAX_NOUTS] = {NULL,};
@@ -752,7 +752,7 @@ void Faust::synthProcessReplacing(FAUSTFLOAT** inputs, FAUSTFLOAT** outputs,
 }
 
 //----------------------------------------------------------------------------
-void Faust::compute(FAUSTFLOAT** inputs, FAUSTFLOAT** outputs,
+void Faust::compute(const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs,
                       VstInt32 sampleFrames)
 {
     const unsigned int output_buffer_size = sizeof(FAUSTFLOAT) * sampleFrames;

--- a/compiler/generator/interpreter/fbc_cpp_compiler.hh
+++ b/compiler/generator/interpreter/fbc_cpp_compiler.hh
@@ -933,7 +933,7 @@ class FBCCPPGenerator : public FBCInterpreter<T, 0> {
 
         tab(tabs + 1, out);
         tab(tabs + 1, out);
-        out << "virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)";
+        out << "virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)";
         {
             FBCCPPCompiler<T> compiler;
             compiler.AddBlock();

--- a/compiler/generator/interpreter/interpreter_dsp_aux.cpp
+++ b/compiler/generator/interpreter/interpreter_dsp_aux.cpp
@@ -277,7 +277,7 @@ LIBFAUST_API void interpreter_dsp::buildUserInterface(UIGlue* ui_glue)
     fDSP->buildUserInterface(&glue);
 }
 
-LIBFAUST_API void interpreter_dsp::compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+LIBFAUST_API void interpreter_dsp::compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
     fDSP->compute(count, input, output);
 }
@@ -428,7 +428,7 @@ LIBFAUST_API void buildUserInterfaceCInterpreterDSPInstance(interpreter_dsp* dsp
     }
 }
 
-LIBFAUST_API void computeCInterpreterDSPInstance(interpreter_dsp* dsp, int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+LIBFAUST_API void computeCInterpreterDSPInstance(interpreter_dsp* dsp, int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
     if (dsp) {
         dsp->compute(count, input, output);

--- a/compiler/generator/interpreter/interpreter_dsp_aux.hh
+++ b/compiler/generator/interpreter/interpreter_dsp_aux.hh
@@ -484,9 +484,9 @@ struct interpreter_dsp_base : public dsp {
     virtual void metadata(MetaGlue* meta) {}
 
     // Not implemented...
-    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
+    virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
 
-    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
+    virtual void compute(double date_usec, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {}
 };
 
 template <class REAL, int TRACE>
@@ -688,7 +688,7 @@ class interpreter_dsp_aux : public interpreter_dsp_base {
         */
     }
 
-    virtual void compute(int count, FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
+    virtual void compute(int count, const FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
     {
         if (count == 0) return;  // Beware: compiled loop does not work with an index of 0
 
@@ -869,7 +869,7 @@ class LIBFAUST_API interpreter_dsp : public dsp {
     
     void metadata(MetaGlue* meta);
 
-    void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+    void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
 };
 
 class LIBFAUST_API interpreter_dsp_factory : public dsp_factory, public faust_smartable {

--- a/compiler/generator/interpreter/interpreter_dsp_aux_pe.hh
+++ b/compiler/generator/interpreter/interpreter_dsp_aux_pe.hh
@@ -187,7 +187,7 @@ class interpreter_dsp_aux_pe : public interpreter_dsp_aux<REAL, TRACE> {
              */
         }
     
-        virtual void compute(int count, FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
+        virtual void compute(int count, const FAUSTFLOAT** inputs_aux, FAUSTFLOAT** outputs_aux)
         {
             if (count == 0) return;  // Beware: compiled loop don't work with an index of 0
             

--- a/compiler/generator/klass.cpp
+++ b/compiler/generator/klass.cpp
@@ -371,7 +371,7 @@ void Klass::buildTasksList()
     int index_task = START_TASK_INDEX;
 
     addDeclCode("TaskGraph fGraph;");
-    addDeclCode("FAUSTFLOAT** input;");
+    addDeclCode("const FAUSTFLOAT** input;");
     addDeclCode("FAUSTFLOAT** output;");
     addDeclCode("volatile bool fIsFinished;");
     addDeclCode("int fCount;");

--- a/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -439,7 +439,7 @@ void llvm_dsp::buildUserInterface(UIGlue* glue)
     fDecoder->buildUserInterface(glue, fDSP);
 }
 
-void llvm_dsp::compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+void llvm_dsp::compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
     if (fDecoder->hasDSPProxy()) {
         // Update inputs control
@@ -875,7 +875,7 @@ LIBFAUST_API void buildUserInterfaceCDSPInstance(llvm_dsp* dsp, UIGlue* glue)
     }
 }
 
-LIBFAUST_API void computeCDSPInstance(llvm_dsp* dsp, int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+LIBFAUST_API void computeCDSPInstance(llvm_dsp* dsp, int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
     if (dsp) {
         dsp->compute(count, input, output);

--- a/compiler/generator/llvm/llvm_dsp_aux.hh
+++ b/compiler/generator/llvm/llvm_dsp_aux.hh
@@ -111,7 +111,7 @@ class LIBFAUST_API llvm_dsp : public dsp {
 
     virtual void metadata(MetaGlue* glue);
 
-    virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+    virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
 };
 
 class FaustObjectCache : public llvm::ObjectCache {
@@ -417,7 +417,7 @@ LIBFAUST_API void instanceClearCDSPInstance(llvm_dsp* dsp);
 
 LIBFAUST_API llvm_dsp* cloneCDSPInstance(llvm_dsp* dsp);
 
-LIBFAUST_API void computeCDSPInstance(llvm_dsp* dsp, int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+LIBFAUST_API void computeCDSPInstance(llvm_dsp* dsp, int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
 
 LIBFAUST_API void setCMemoryManager(llvm_dsp_factory* factory, MemoryManagerGlue* manager);
 

--- a/compiler/generator/wasm/wasm_dsp_aux.cpp
+++ b/compiler/generator/wasm/wasm_dsp_aux.cpp
@@ -284,7 +284,7 @@ LIBFAUST_API void wasm_dsp::computeJS(int count, uintptr_t inputs, uintptr_t out
 #endif
 }
 
-LIBFAUST_API void wasm_dsp::compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+LIBFAUST_API void wasm_dsp::compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
 {
 #ifdef AUDIO_WORKLET
     EM_ASM({ AudioWorkletGlobalScope.faust_module.faust.wasm_instance[$0].exports.compute($1, $2, $3, $4); }, fFactory->fInstance, fDSP, count,
@@ -442,7 +442,7 @@ LIBFAUST_API void wasm_dsp::metadata(Meta* m)
 {
 }
 
-LIBFAUST_API void wasm_dsp::compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+LIBFAUST_API void wasm_dsp::compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
 }
 

--- a/compiler/generator/wasm/wasm_dsp_aux.hh
+++ b/compiler/generator/wasm/wasm_dsp_aux.hh
@@ -299,7 +299,7 @@ class LIBFAUST_API wasm_dsp : public dsp, public JSONControl {
 
     virtual void metadata(Meta* m);
 
-    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
+    virtual void compute(int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs);
 
     virtual void computeJS(int count, uintptr_t inputs, uintptr_t outputs);
     

--- a/embedded/faustremote/README.md
+++ b/embedded/faustremote/README.md
@@ -50,7 +50,7 @@ Use instance as any static DSP:
 * `virtual int getNumOutputs()`
 * `virtual void init(int samplingFreq)`
 * `virtual void buildUserInterface(UI* ui)`
-* `virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)`
+* `virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)`
 
 * `void deleteRemoteDSPInstance(remote_dsp* dsp)`
 * `void deleteRemoteDSPFactory(remote_dsp_factory* factory)`

--- a/embedded/faustremote/RemoteClient/remote_dsp_aux.cpp
+++ b/embedded/faustremote/RemoteClient/remote_dsp_aux.cpp
@@ -465,7 +465,7 @@ void remote_dsp_aux::buildUserInterface(UI* ui)
     }
 }
 
-void remote_dsp_aux::setupBuffers(FAUSTFLOAT** input, FAUSTFLOAT** output, int offset)
+void remote_dsp_aux::setupBuffers(const FAUSTFLOAT** input, FAUSTFLOAT** output, int offset)
 {
     for (int i = 0; i < getNumInputs(); i++) {
         fAudioInputs[i] = &input[i][offset];
@@ -497,7 +497,7 @@ void remote_dsp_aux::recvSlice(int buffer_size)
 }
 
 // Compute of the DSP, adding the controls to the input/output passed
-void remote_dsp_aux::compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+void remote_dsp_aux::compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
     if (fRunning) {
         
@@ -1152,7 +1152,7 @@ EXPORT void remote_dsp::buildUserInterface(UI* interface)
     reinterpret_cast<remote_dsp_aux*>(this)->buildUserInterface(interface);
 }
 
-EXPORT void remote_dsp::compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+EXPORT void remote_dsp::compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
 {
     reinterpret_cast<remote_dsp_aux*>(this)->compute(count, input, output);
 }

--- a/embedded/faustremote/RemoteClient/remote_dsp_aux.h
+++ b/embedded/faustremote/RemoteClient/remote_dsp_aux.h
@@ -198,7 +198,7 @@ class remote_dsp_aux : public dsp, public jack_midi {
         JSONUIDecoder*          fJSONDecoder;
     
         void fillBufferWithZerosOffset(int channels, int offset, int size, FAUSTFLOAT** buffer);
-        void setupBuffers(FAUSTFLOAT** input, FAUSTFLOAT** output, int offset);
+        void setupBuffers(const FAUSTFLOAT** input, FAUSTFLOAT** output, int offset);
     
         void sendSlice(int buffer_size);
         void recvSlice(int buffer_size);
@@ -234,7 +234,7 @@ class remote_dsp_aux : public dsp, public jack_midi {
     
         virtual void metadata(Meta* m);
     
-        virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+        virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
         remote_dsp_factory* getFactory() { return fFactory; }
     
@@ -314,7 +314,7 @@ class EXPORT remote_dsp : public dsp, public midi {
     
         int getSampleRate();
     
-        void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+        void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
         // MIDI polyphonic control
         MapUI* keyOn(int channel, int pitch, int velocity);

--- a/embedded/faustremote/remote-dsp.h
+++ b/embedded/faustremote/remote-dsp.h
@@ -198,7 +198,7 @@ class remote_dsp : public dsp, public midi {
     
         void metadata(Meta* m);
     
-        void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output);
+        void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output);
     
         // MIDI polyphonic control
         MapUI* keyOn(int channel, int pitch, int velocity);

--- a/tests/impulse-tests/archs/impulsearch2.cpp
+++ b/tests/impulse-tests/archs/impulsearch2.cpp
@@ -92,12 +92,12 @@ class Cdsp : public dsp {
             metadatamydsp(&glue);
         }
         
-        virtual void compute(int count, FAUSTFLOAT** input, FAUSTFLOAT** output)
+        virtual void compute(int count, const FAUSTFLOAT** input, FAUSTFLOAT** output)
         {
             computemydsp(fDSP, count, input, output);
         }
     
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+        virtual void compute(double /*date_usec*/, int count, const FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
         {
             compute(count, inputs, outputs);
         }


### PR DESCRIPTION
I am in the process of converting my audio backend from [libsoundio](https://github.com/andrewrk/libsoundio) to [miniaudio](https://github.com/mackron/miniaudio), and ran into an issue where miniaudio's main audio callback function provides a `const *input` buffer. To pass this buffer to Faust, I would then have to copy the contents of the const buffer into my own mutable input buffer. (Or maybe use `const_cast`, which is undesirable.) Are there any current use cases where directly modifying the contents of input buffers is desired behavior? If not, I think it would be a nice API improvement to make all `compute` input buffers as `const`.

This PR was generated by replacing all occurrences of `FAUSTFLOAT** input` with `const FAUSTFLOAT** input`. All I did was:
```shell
find -E . -regex '.*\.(c|h|cc|hh|cpp|hpp|md)' -print0 | xargs -0 sed -i '' -e 's/FAUSTFLOAT\*\*\ input/const\ FAUSTFLOAT\*\*\ input/g'
```

and committed.