### PR TITLE
Clear error message after successful parse in `DSPToBoxes`, to allow for reuse of error string across multiple calls

### DIFF
--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -2219,6 +2219,7 @@ LIBFAUST_API Tree DSPToBoxes(const string& name_app, const string& dsp_content, 
 
     try {
         parseSourceFiles();
+        error_msg = "";
     } catch (faustexception& e) {
         error_msg = e.what();
         return nullptr;


### PR DESCRIPTION
I found this when using a static error message string across multiple calls to `DSPToBoxes`.