### PR TITLE
Move osc_compute_callback to fix compilation with JUCE + OSC

### DIFF
--- a/architecture/api/DspFaust.cpp
+++ b/architecture/api/DspFaust.cpp
@@ -139,11 +139,11 @@
 #include "faust/gui/JuceOSCUI.h"
 #else
 #include "faust/gui/OSCUI.h"
-#endif
 static void osc_compute_callback(void* arg)
 {
     static_cast<OSCUI*>(arg)->endBundle();
 }
+#endif
 #endif
 
 #if DYNAMIC_DSP


### PR DESCRIPTION
When `JUCE_DRIVER` and `OSCCTRL` are both defined, the `OSCUI` class is not created, but it is referenced in the implementation of `osc_compute_callback`. This commit moves the implementation into the if block where `OSCUI.h` is included, as it is in other files in the Faust ecosystem.