### PR TITLE
faust2sc broaden test for supercollider headers

### DIFF
--- a/tools/faust2appls/faust2sc.py
+++ b/tools/faust2appls/faust2sc.py
@@ -124,15 +124,14 @@ def faustoptflags():
 
 # Return the header paths if they exists.
 def get_header_paths(headerpath):
-    folders = [
-        path.join(headerpath, "include", "plugin_interface"),
-        path.join(headerpath, "include", "server"),
-        path.join(headerpath, "include",  "common")
-    ]
+    subfolders = [[], ["include"],["include", "SuperCollider"]]
+    headerfolders = ["plugin_interface", "server", "common"]
+    for sf in subfolders:
+      folders = [path.join(headerpath, *sf, hf) for hf in headerfolders];
+      if all(path.exists(f) for f in folders):
+          print("Found SuperCollider headers: %s" % path.join(headerpath, *sf))
+          return folders
 
-    if all(path.exists(folder) for folder in folders):
-        print("Found SuperCollider headers: %s" % headerpath)
-        return folders
 
 # Try and find SuperCollider headers on system
 def find_headers(headerpath):


### PR DESCRIPTION
gcc searches for multiple positions of headers given a path 
this pr broadens the test for supercollider headers so that the script does not cause a false negative about not found supercollider headers