### PR TITLE
Set repr(C) on the Dsp struct to recover performance

### DIFF
--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -176,6 +176,8 @@ void RustCodeContainer::produceClass()
     tab(n, *fOut);
     *fOut << "#[cfg_attr(feature = \"default-boxed\", derive(default_boxed::DefaultBoxed))]";
     tab(n, *fOut);
+    *fOut << "#[repr(C)]";
+    tab(n, *fOut);
     *fOut << "pub struct " << fKlassName << " {";
     tab(n + 1, *fOut);
 


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/102750 , Rust reorders
fields in repr(Rust) structures based on size/alignment. Applying such
reordering to the Dsp struct substantially hurts performance.

Set repr(C) on the Dsp struct to recover that performance.

See
https://internals.rust-lang.org/t/unexpected-3-x-performance-regression-starting-with-rust-version-1-67/18724
for the test case and investigations that led to this.
