### PR TITLE
Removes deprecated method that fails daisy build

### DIFF
--- a/architecture/daisy/ex_faust.cpp
+++ b/architecture/daisy/ex_faust.cpp
@@ -107,9 +107,6 @@ static void AudioCallback(daisy::AudioHandle::InputBuffer in, daisy::AudioHandle
 int main(void)
 {
     // initialize seed hardware and daisysp modules
-#if (!defined PATCH) && (!defined POD)
-    hw.Configure();
-#endif
     hw.Init();
     
     // allocate DSP

--- a/architecture/daisy/ex_faust.cpp
+++ b/architecture/daisy/ex_faust.cpp
@@ -107,7 +107,7 @@ static void AudioCallback(daisy::AudioHandle::InputBuffer in, daisy::AudioHandle
 int main(void)
 {
     // initialize seed hardware and daisysp modules
-#if (!defined PATCH) || (!defined POD)
+#if (!defined PATCH) && (!defined POD)
     hw.Configure();
 #endif
     hw.Init();


### PR DESCRIPTION
When using the `-patch` and `-pod` arguments, the build will fail because the `Configure` method has been deprecated in the latest Daisy SDK.

Closes #868