### PR TITLE
fix thread-safe preset management

### DIFF
--- a/tools/faust2appls/faust2cagtk
+++ b/tools/faust2appls/faust2cagtk
@@ -137,8 +137,8 @@ EndOfCode
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
         echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"
     fi
-    cat "$PRESETFILE" "${f%.dsp}_tmp.cpp" > "${f%.dsp}.cpp"
-    rm "$PRESETFILE" "${f%.dsp}_tmp.cpp"
+    cat "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp" > "$TMP/${f%.dsp}.cpp"
+    rm "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp"
 
     # compile c++ to binary
     (

--- a/tools/faust2appls/faust2caqt
+++ b/tools/faust2appls/faust2caqt
@@ -210,8 +210,8 @@ EndOfCode
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
         echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"
     fi
-    cat "$PRESETFILE" "${f%.dsp}_tmp.cpp" > "${f%.dsp}.cpp"
-    rm "$PRESETFILE" "${f%.dsp}_tmp.cpp"
+    cat "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp" > "$TMP/${f%.dsp}.cpp"
+    rm "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp"
 
     # compile c++ to binary
     (

--- a/tools/faust2appls/faust2jack
+++ b/tools/faust2appls/faust2jack
@@ -155,8 +155,8 @@ EndOfCode
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
         echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"
     fi
-    cat "$PRESETFILE" "${f%.dsp}_tmp.cpp" > "${f%.dsp}.cpp"
-    rm "$PRESETFILE" "${f%.dsp}_tmp.cpp"
+    cat "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp" > "$TMP/${f%.dsp}.cpp"
+    rm "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp"
     # compile c++ to binary
     (
         $CXX $CXXFLAGS $FAUSTTOOLSFLAGS "${f%.dsp}.cpp" `pkg-config --cflags --libs jack $OCVLIBS gtk+-2.0` $LLVM_LIBS $SOUNDFILELIBS $SAMPLERATELIBS $PROCARCH $OSCDEFS $HTTPDEFS $HTTPLIBS $OCVDEFS $MIDIDEFS $POLYDEFS $SOUNDFILEDEFS $SAMPLERATEDEFS $PRESETDEFS $ARCHLIB $LFLAGS -o "${f%.dsp}"

--- a/tools/faust2appls/faust2jaqt
+++ b/tools/faust2appls/faust2jaqt
@@ -204,8 +204,8 @@ EndOfCode
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
         echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"
     fi
-    cat "$PRESETFILE" "${f%.dsp}_tmp.cpp" > "${f%.dsp}.cpp"
-    rm "$PRESETFILE" "${f%.dsp}_tmp.cpp"
+    cat "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp" > "$TMP/${f%.dsp}.cpp"
+    rm "$PRESETFILE" "$TMP/${f%.dsp}_tmp.cpp"
 
     # compile c++ to binary
     (


### PR DESCRIPTION
My [previous PR](https://github.com/grame-cncm/faust/pull/900) doesn't actually run.
```zsh
faust2jaqt  test.dsp && ./test
cat: test_tmp.cpp: No such file or directory
```
I missed this originally because I made a subtle mistake in my nixos-pkg.  Long story...
