### PR TITLE
WIP: default preset dir: XDG_CONFIG_HOME/name/

### DIFF
--- a/tools/faust2appls/faust2jaqt
+++ b/tools/faust2appls/faust2jaqt
@@ -199,7 +199,7 @@ EndOfCode
     # add preset management
     if [ $PRESETDIR = "auto" ]; then
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
-        echo "#define PRESETDIR \"/var/tmp/\"" > "$PRESETFILE"
+        echo "#define PRESETDIR \"auto\"" > "$PRESETFILE"
     else
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
         echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"


### PR DESCRIPTION
### Disclaimer:

This is a work in progress.
For now, it is only implemented in ``faust2jaqt``.
Also, there are probably more appropriate places for the new functions my buddy and me created.

### Reasoning:

If I'm making presets, I want to keep them, so I think ``/var/tmp`` is not the best place to store them.
I went with ``XDG_CONFIG_HOME/name`` for now, but maybe there is a more appropriate place somewhere in the users home directory.

Also, it is debatable whether PRESETDIR should be evaluated as a string or as an environment variable.
Maybe the best of both worlds it to fisrt check if the dir exists as a string, for backwards compatibility, and if it doesn't exist, see if there is an environment variable.


Thoughts?  