### PR TITLE
use XDG_DOCUMENTS_DIR as the default preset dir

### DIFF
--- a/architecture/faust/gui/PresetUI.h
+++ b/architecture/faust/gui/PresetUI.h
@@ -27,6 +27,17 @@
 
 #include <string>
 #include <iostream>
+#include <cstdlib>
+#include <cstring>
+#include <climits>
+
+#if __cplusplus < 201703L // If the version of C++ is less than 17
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
 
 #include "faust/gui/DecoratorUI.h"
 #include "faust/gui/FUI.h"
@@ -44,72 +55,186 @@
 class PresetUI : public DecoratorUI {
     
     private:
-    
-        struct LoaderUI : public GUI
-        {
-            LoaderUI(PresetUI* presetui)
-            {
-                // uiCallbackItem(s) are deleted in GUI
-                new uiCallbackItem(this, &presetui->fLoad, PresetUI::load, presetui);
-                new uiCallbackItem(this, &presetui->fSave, PresetUI::save, presetui);
-                new uiCallbackItem(this, &presetui->fReset, PresetUI::reset, presetui);
-            }
-        };
-    
-        int fGroupCount;
-        FAUSTFLOAT fPreset;
-        FAUSTFLOAT fLoad;
-        FAUSTFLOAT fSave;
-        FAUSTFLOAT fReset;
-        FUI fFileUI;
-        LoaderUI fLoaderUI;
-        const std::string fRootPath;
-    
-        static void load(FAUSTFLOAT val, void* arg)
-        {
-            if (val == FAUSTFLOAT(1)) {
-                static_cast<PresetUI*>(arg)->loadState();
+    const char* append_slash_if_missing(const char* path) {
+        size_t len = strlen(path);
+        if (path[len - 1] != '/') {
+            static char buf[PATH_MAX];
+            snprintf(buf, sizeof(buf), "%s/", path);
+            return buf;
+        }
+        return path;
+    }
+
+    bool try_create_subdirectory(const char* base_dir, const char* sub_dir, char* out_dir, size_t out_dir_size) {
+        if (base_dir && (strlen(base_dir) > 0) && sub_dir && (strlen(sub_dir) > 0)) {
+            snprintf(out_dir, out_dir_size, "%s%s/", base_dir, sub_dir);
+            if (try_create_directory(out_dir)) {
+                std::cout << "Using " << base_dir << "/" << sub_dir << ": " << out_dir << std::endl;
+                return true;
+            } else {
+                std::cout << "Cannot use " << base_dir << "/" << sub_dir << std::endl;
             }
         }
-    
-        static void save(FAUSTFLOAT val, void* arg)
-        {
-            if (val == FAUSTFLOAT(1)) {
-                static_cast<PresetUI*>(arg)->saveState();
-            }
+        return false;
+    }
+
+    bool try_create_dir_from_env(const char* env_var_name, const char** out_dir) {
+        const char* dir = getenv(env_var_name);
+        if (try_create_directory(dir)) {
+            std::cout << "Using " << env_var_name << ": " << dir << "." << std::endl;
+            *out_dir = append_slash_if_missing(dir);
+            return true;
+        } else {
+            std::cout << "Cannot use " << env_var_name <<  "." << std::endl;
+            return false;
         }
-    
-        static void reset(FAUSTFLOAT val, void* arg)
+    }
+
+    struct LoaderUI : public GUI
+    {
+        LoaderUI(PresetUI* presetui)
         {
-            if (val == FAUSTFLOAT(1)) {
-                static_cast<PresetUI*>(arg)->loadDefault();
-            }
+            // uiCallbackItem(s) are deleted in GUI
+            new uiCallbackItem(this, &presetui->fLoad, PresetUI::load, presetui);
+            new uiCallbackItem(this, &presetui->fSave, PresetUI::save, presetui);
+            new uiCallbackItem(this, &presetui->fReset, PresetUI::reset, presetui);
         }
+    };
     
-        void checkOpenFirstBox(const char* label)
-        {
-            if (fGroupCount++ == 0) {
-                // Start of top-level group
-                fUI->openHorizontalBox("Preset manager");
-                fUI->addButton("Save", &fSave);
-                fUI->addNumEntry("Preset", &fPreset, FAUSTFLOAT(0), FAUSTFLOAT(0), FAUSTFLOAT(100), FAUSTFLOAT(1));
-                fUI->addButton("Load", &fLoad);
-                fUI->addButton("Reset", &fReset);
-                fUI->closeBox();
-            }
+    int fGroupCount;
+    FAUSTFLOAT fPreset;
+    FAUSTFLOAT fLoad;
+    FAUSTFLOAT fSave;
+    FAUSTFLOAT fReset;
+    FUI fFileUI;
+    LoaderUI fLoaderUI;
+    const std::string fRootPath;
+
+    static void load(FAUSTFLOAT val, void* arg)
+    {
+        if (val == FAUSTFLOAT(1)) {
+            static_cast<PresetUI*>(arg)->loadState();
         }
+    }
+
+    static void save(FAUSTFLOAT val, void* arg)
+    {
+        if (val == FAUSTFLOAT(1)) {
+            static_cast<PresetUI*>(arg)->saveState();
+        }
+    }
+
+    static void reset(FAUSTFLOAT val, void* arg)
+    {
+        if (val == FAUSTFLOAT(1)) {
+            static_cast<PresetUI*>(arg)->loadDefault();
+        }
+    }
+
+    void checkOpenFirstBox(const char* label)
+    {
+        if (fGroupCount++ == 0) {
+            // Start of top-level group
+            fUI->openHorizontalBox("Preset manager");
+            fUI->addButton("Save", &fSave);
+            fUI->addNumEntry("Preset", &fPreset, FAUSTFLOAT(0), FAUSTFLOAT(0), FAUSTFLOAT(100), FAUSTFLOAT(1));
+            fUI->addButton("Load", &fLoad);
+            fUI->addButton("Reset", &fReset);
+            fUI->closeBox();
+        }
+    }
     
     public:
-    
-        PresetUI(UI* ui, const std::string& path):
-            DecoratorUI(ui),
-            fGroupCount(0),
-            fPreset(FAUSTFLOAT(0)),
-            fSave(FAUSTFLOAT(0)),
-            fLoad(FAUSTFLOAT(0)),
-            fReset(FAUSTFLOAT(0)),
-            fLoaderUI(this),
-            fRootPath(path)
+
+    bool try_create_directory(const char* dir_option) {
+        if (dir_option && (strlen(dir_option) > 0)) {
+            // std::cout << "Trying to create: " << dir_option << std::endl;
+            fs::path path_option(dir_option);
+            if (!fs::exists(path_option)) {
+                try {
+                    fs::create_directories(path_option);
+                    std::cout << "Directory created: " << path_option << std::endl;
+                    return true;
+                } catch(const fs::filesystem_error& e) {
+                    std::cerr << "Error creating directory: " << e.what() << std::endl;
+                }
+            } else {
+                // std::cout << "Directory already exists: " << path_option << std::endl;
+                return true;
+            }
+        }
+        return false;
+    }
+/*
+  get_preset_dir attempts to determine a suitable preset directory using the following logic:
+
+  1) If PRESETDIR is "auto", it tries to create a directory using the XDG_DOCUMENTS_DIR environment variable.
+  2) If PRESETDIR is a valid existing directory, it returns the path with a trailing slash.
+  3) If PRESETDIR is an environment variable, it tries to create a directory using its value.
+  4) If HOME is set, it tries to create a directory at HOME/Documents or HOME/PRESETDIR.
+  5) If all else fails, it falls back to /var/tmp/.
+*/
+
+    const char* get_preset_dir() {
+        const char* preset_dir = nullptr;
+
+        std::cout << "Attempting to find or create a suitable directory for preset files." << std::endl;
+        // if the user passes -preset auto
+        if (std::string(PRESETDIR) == "auto") {
+            std::cout << "Attempting to create directory using XDG_DOCUMENTS_DIR environment variable." << std::endl;
+            if (try_create_dir_from_env("XDG_DOCUMENTS_DIR", &preset_dir)) {
+                return preset_dir;
+            }
+        }
+
+        // interpret what the user gave us as a path
+        fs::path preset_path(PRESETDIR);
+        // see if that path exists and is a directory
+        if (fs::exists(preset_path) && fs::is_directory(preset_path)) {
+            std::cout << "Directory " << PRESETDIR << " exists and is a valid directory." << std::endl;
+            // we are done
+            return append_slash_if_missing(PRESETDIR);
+        }
+        // PRESETDIR doesn't exists or is not a directory
+        std::cout << "Directory " << PRESETDIR << " doesn't exist or is not a valid directory." << std::endl;
+
+        // interpret PRESETDIR as an environment variable
+        std::cout << "Attempting to create directory using PRESETDIR environment variable." << std::endl;
+        if (try_create_dir_from_env(PRESETDIR, &preset_dir)) {
+            return preset_dir;
+        }
+
+        std::cout << "No usable XDG_DOCUMENTS_DIR, " << PRESETDIR << " is not a valid directory nor a usable environment variable." << std::endl;
+
+        preset_dir = append_slash_if_missing(getenv("HOME"));
+        // Declare buffers for storing the paths
+        static char buf[PATH_MAX];
+        static char home_preset_dir_buf[PATH_MAX];
+        // Try HOME/Documents
+        if (try_create_subdirectory(preset_dir, "Documents", buf, sizeof(buf))) {
+            return buf;
+        }
+
+        // Try HOME/PRESETDIR
+        if (try_create_subdirectory(preset_dir, PRESETDIR, home_preset_dir_buf, sizeof(home_preset_dir_buf))) {
+            return home_preset_dir_buf;
+        }
+
+        // Fallback to /var/tmp/
+        std::cout << "No suitable directory found, falling back to /var/tmp/" << std::endl;
+        preset_dir = "/var/tmp/";
+        return preset_dir;
+    }
+
+    PresetUI(UI* ui, const std::string& path):
+        DecoratorUI(ui),
+        fGroupCount(0),
+        fPreset(FAUSTFLOAT(0)),
+        fSave(FAUSTFLOAT(0)),
+        fLoad(FAUSTFLOAT(0)),
+        fReset(FAUSTFLOAT(0)),
+        fLoaderUI(this),
+        fRootPath(path)
         {}
     
         virtual ~PresetUI()
@@ -117,22 +242,22 @@ class PresetUI : public DecoratorUI {
     
         void saveDefault()
         {
-            fFileUI.saveState((fRootPath + "_default").c_str());
+            fFileUI.saveState((fRootPath + "default").c_str());
         }
         
         void loadDefault()
         {
-            fFileUI.recallState((fRootPath + "_default").c_str());
+            fFileUI.recallState((fRootPath + "default").c_str());
         }
     
         void saveState()
         {
-            fFileUI.saveState((fRootPath + "_preset" + std::to_string(fPreset)).c_str());
+            fFileUI.saveState((fRootPath + "preset" + std::to_string(fPreset)).c_str());
         }
     
         void loadState()
         {
-            fFileUI.recallState((fRootPath + "_preset" + std::to_string(fPreset)).c_str());
+            fFileUI.recallState((fRootPath + "preset" + std::to_string(fPreset)).c_str());
         }
     
         // -- widget's layouts

--- a/architecture/jack-qt.cpp
+++ b/architecture/jack-qt.cpp
@@ -180,15 +180,37 @@ int main(int argc, char* argv[])
     
     QTGUI* interface = new QTGUI();
     FUI finterface;
-    
+
 #ifdef PRESETUI
-    PresetUI pinterface(interface, string(PRESETDIR) + string(name) + ((nvoices > 0) ? "_poly" : ""));
+    std::string basePath = "";
+    PresetUI presetUI(interface, basePath);
+    std::string fullPath(presetUI.get_preset_dir());
+    fullPath += name;
+    const char* preset_dir = fullPath.c_str();
+    std::cout << "Final preset dir:" << preset_dir << std::endl;
+    presetUI.try_create_directory(preset_dir);
+    PresetUI pinterface(interface, string(preset_dir) + "/" + ((nvoices > 0) ? "poly_" : ""));
     DSP->buildUserInterface(&pinterface);
 #else
     DSP->buildUserInterface(interface);
     DSP->buildUserInterface(&finterface);
 #endif
-    
+
+    // #ifdef PRESETUI
+    // std::string basePath = "";
+    // PresetUI presetUI(interface, basePath);
+    // std::string fullPath(presetUI.get_preset_dir());
+    // fullPath += name;
+    // const char* preset_dir = fullPath.c_str();
+    // std::cout << "Final preset dir:" << preset_dir << std::endl;
+    // presetUI.try_create_directory(preset_dir);
+    // PresetUI pinterface(interface, string(preset_dir) + "/" + ((nvoices > 0) ? "poly_" : ""));
+    // DSP->buildUserInterface(&pinterface);
+    // #else
+    // DSP->buildUserInterface(interface);
+    // DSP->buildUserInterface(&finterface);
+    // #endif
+
 #ifdef HTTPCTRL
     httpdUI httpdinterface(name, DSP->getNumInputs(), DSP->getNumOutputs(), argc, argv);
     DSP->buildUserInterface(&httpdinterface);

--- a/tools/faust2appls/faust2jaqt
+++ b/tools/faust2appls/faust2jaqt
@@ -199,7 +199,7 @@ EndOfCode
     # add preset management
     if [ $PRESETDIR = "auto" ]; then
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
-        echo "#define PRESETDIR \"/var/tmp/\"" > "$PRESETFILE"
+        echo "#define PRESETDIR \"auto\"" > "$PRESETFILE"
     else
         PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
         echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"


### PR DESCRIPTION
This is still a work in progress in the sense that only ``faust2jaqt`` is implemented.
The helper functions should probably not live in ``jack-qt.cpp``, since they will be the same for all architectures that use presets.
I hope this version is better then https://github.com/grame-cncm/faust/pull/903!

## Reasoning

There are two changes:

A) The presets don't go in ``PRESETDIR/name_preset0.000000`` anymore, but instead go in ``PRESETDIR/name/preset0.000000``.
This is a bit more organized, if you ask me.

B) PRESETDIR is chosen a bit more flexible now.
These are the steps the algorithm takes, and my reasoning for each one. 

1) If PRESETDIR is ``auto``, it tries to create a directory using the ``XDG_DOCUMENTS_DIR`` environment variable.
If I am making presets, I probably want to keep them.
In the previous implementation, the presets could be gone after a reboot.
``$XDG_DOCUMENTS_DIR`` is the closest we have to [a standard](https://wiki.archlinux.org/title/XDG_user_directories#Creating_custom_directories) location for files the user wants to keep.

2) If PRESETDIR is a valid existing directory, it returns the path with a trailing slash. 
This is almost the same as in the current implementation: we don't try to create the directory but we just use it.
The difference is that we check if it is a valid directory and if not, go on to the next option.

3) If PRESETDIR is an environment variable, it tries to create a directory using its value. 
This is so you can change the preset directory at runtime.
For example:
```bash
export MY_PRESET_DIR=/home/me/presets
faust2jaqt -preset MY_PRESET_DIR test.dsp
```
We now use ``/home/me/presets/test``
```bash
export MY_PRESET_DIR=/home/me/presets2
./test
```
We now use ``/home/me/presets2/test``
Note we didn't need to recompile for this.
```bash
faust2jaqt -preset $MY_PRESET_DIR test.dsp
```
Note the ``$``; we are now stuck in ``/home/me/presets2/test``.

4) If ``$HOME`` is set, it tries to create a directory at HOME/Documents or HOME/PRESETDIR. 
HOME/Documents in the default value for XDG_DOCUMENTS_DIR, so it seems a good next fallback.
HOME/PRESETDIR is a bit weird, but at least it is in the home dir.

5) If all else fails, it falls back to /var/tmp/.
This is the directory the current implementation uses for ``auto``.
