### PR TITLE
MapUI: remove redundant map lookups

### DIFF
--- a/architecture/faust/gui/MapUI.h
+++ b/architecture/faust/gui/MapUI.h
@@ -149,19 +149,19 @@ class FAUST_API MapUI : public UI, public PathBuilder
          */
         void setParamValue(const std::string& str, FAUSTFLOAT value)
         {
-            auto fPathZoneMapIter = fPathZoneMap.find(str);
+            const auto fPathZoneMapIter = fPathZoneMap.find(str);
             if (fPathZoneMapIter != fPathZoneMap.end()) {
                 *fPathZoneMapIter->second = value;
                 return;
             }
             
-            auto fShortnameZoneMapIter = fShortnameZoneMap.find(str);
+            const auto fShortnameZoneMapIter = fShortnameZoneMap.find(str);
             if (fShortnameZoneMapIter != fShortnameZoneMap.end()) {
                 *fShortnameZoneMapIter->second = value;
                 return;
             }
             
-            auto fLabelZoneMapIter = fLabelZoneMap.find(str);
+            const auto fLabelZoneMapIter = fLabelZoneMap.find(str);
             if (fLabelZoneMapIter != fLabelZoneMap.end()) {
                 *fLabelZoneMapIter->second = value;
                 return;

--- a/architecture/faust/gui/MapUI.h
+++ b/architecture/faust/gui/MapUI.h
@@ -149,15 +149,25 @@ class FAUST_API MapUI : public UI, public PathBuilder
          */
         void setParamValue(const std::string& str, FAUSTFLOAT value)
         {
-            if (fPathZoneMap.find(str) != fPathZoneMap.end()) {
-                *fPathZoneMap[str] = value;
-            } else if (fShortnameZoneMap.find(str) != fShortnameZoneMap.end()) {
-                *fShortnameZoneMap[str] = value;
-            } else if (fLabelZoneMap.find(str) != fLabelZoneMap.end()) {
-                *fLabelZoneMap[str] = value;
-            } else {
-                fprintf(stderr, "ERROR : setParamValue '%s' not found\n", str.c_str());
+            auto fPathZoneMapIter = fPathZoneMap.find(str);
+            if (fPathZoneMapIter != fPathZoneMap.end()) {
+                *fPathZoneMapIter->second = value;
+                return;
             }
+            
+            auto fShortnameZoneMapIter = fShortnameZoneMap.find(str);
+            if (fShortnameZoneMapIter != fShortnameZoneMap.end()) {
+                *fShortnameZoneMapIter->second = value;
+                return;
+            }
+            
+            auto fLabelZoneMapIter = fLabelZoneMap.find(str);
+            if (fLabelZoneMapIter != fLabelZoneMap.end()) {
+                *fLabelZoneMapIter->second = value;
+                return;
+            }
+            
+            fprintf(stderr, "ERROR : setParamValue '%s' not found\n", str.c_str());
         }
         
         /**
@@ -169,16 +179,23 @@ class FAUST_API MapUI : public UI, public PathBuilder
          */
         FAUSTFLOAT getParamValue(const std::string& str)
         {
-            if (fPathZoneMap.find(str) != fPathZoneMap.end()) {
-                return *fPathZoneMap[str];
-            } else if (fShortnameZoneMap.find(str) != fShortnameZoneMap.end()) {
-                return *fShortnameZoneMap[str];
-            } else if (fLabelZoneMap.find(str) != fLabelZoneMap.end()) {
-                return *fLabelZoneMap[str];
-            } else {
-                fprintf(stderr, "ERROR : getParamValue '%s' not found\n", str.c_str());
-                return 0;
+            const auto fPathZoneMapIter = fPathZoneMap.find(str);
+            if (fPathZoneMapIter != fPathZoneMap.end()) {
+                return *fPathZoneMapIter->second;
             }
+            
+            const auto fShortnameZoneMapIter = fShortnameZoneMap.find(str);
+            if (fShortnameZoneMapIter != fShortnameZoneMap.end()) {
+                return *fShortnameZoneMapIter->second;
+            }
+            
+            const auto fLabelZoneMapIter = fLabelZoneMap.find(str);
+            if (fLabelZoneMapIter != fLabelZoneMap.end()) {
+                return *fLabelZoneMapIter->second;
+            }
+            
+            fprintf(stderr, "ERROR : getParamValue '%s' not found\n", str.c_str());
+            return 0;
         }
     
         // map access 
@@ -304,13 +321,21 @@ class FAUST_API MapUI : public UI, public PathBuilder
          */
         FAUSTFLOAT* getParamZone(const std::string& str)
         {
-            if (fPathZoneMap.find(str) != fPathZoneMap.end()) {
-                return fPathZoneMap[str];
-            } else if (fShortnameZoneMap.find(str) != fShortnameZoneMap.end()) {
-                return fShortnameZoneMap[str];
-            } else if (fLabelZoneMap.find(str) != fLabelZoneMap.end()) {
-                return fLabelZoneMap[str];
+            const auto fPathZoneMapIter = fPathZoneMap.find(str);
+            if (fPathZoneMapIter != fPathZoneMap.end()) {
+                return fPathZoneMapIter->second;
             }
+            
+            const auto fShortnameZoneMapIter = fShortnameZoneMap.find(str);
+            if (fShortnameZoneMapIter != fShortnameZoneMap.end()) {
+                return fShortnameZoneMapIter->second;
+            }
+            
+            const auto fLabelZoneMapIter = fLabelZoneMap.find(str);
+            if (fLabelZoneMapIter != fLabelZoneMap.end()) {
+                return fLabelZoneMapIter->second;
+            }
+
             return nullptr;
         }
     


### PR DESCRIPTION
The `MapUI.h` architecture file has a few spots where it needs to get/set a parameter value from a `std::map<std::string, FAUSTFLOAT*>`. Previously this was being done with the pattern:
```cpp
if (fPathZoneMap.find(str) != fPathZoneMap.end()) {
    return *fPathZoneMap[str];
}
```
With this approach, both `fPathZoneMap.find(str)` and `fPathZoneMap[str]` are re-doing the same work of finding the relevant entry in the map, which is a $\mathcal{O}(\text{log}(n))$ operation in the size of the map.

This PR re-writes that pattern as
```cpp
const auto fPathZoneMapIter = fPathZoneMap.find(str);
if (fPathZoneMapIter != fPathZoneMap.end()) {
    return *fPathZoneMapIter->second;
}
```
So the work of finding the entry in the map only happens once.