### PR TITLE
Add missing closing brace in preprocessor directive to fix `libcode.cpp`

### DIFF
--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -746,6 +746,8 @@ static void generateCodeAux1(unique_ptr<ostream>& helpers, unique_ptr<ifstream>&
             DLangCodeContainer::printDRecipeComment(*dst.get(), gContainer->getClassName());
             DLangCodeContainer::printDModuleStmt(*dst.get(), gContainer->getClassName());
         }
+#else
+    }
 #endif
 
         gContainer->printHeader();


### PR DESCRIPTION
Dangling brace introduced in https://github.com/grame-cncm/faust/commit/f7b8c945ba25996a7fedda50456432700558a5e0

