### PR TITLE
JuceAssertWhenUsingTabs

### DIFF
--- a/architecture/faust/gui/JuceGUI.h
+++ b/architecture/faust/gui/JuceGUI.h
@@ -1592,8 +1592,10 @@ public:
      * \brief   Constructor.
      * \details Initalize the juce::TabbedComponent tabs to be at top, and the uiTabBox size at 0
      */
-    uiTabBox():uiBase(),juce::TabbedComponent(juce::TabbedButtonBar::TabsAtTop)
-    {}
+    uiTabBox(juce::String label):uiBase(),juce::TabbedComponent(juce::TabbedButtonBar::TabsAtTop)
+    {
+        setName(label);
+    }
     
     /**
      * Initialize all his child ratios (1 uiBox per tabs), the LookAndFeel
@@ -1942,7 +1944,7 @@ class JuceGUI : public GUI, public MetaDataUI, public juce::Component
         /** Initialize the uiTabBox component to be visible. */
         virtual void openTabBox(const char* label) override
         {
-            openBox(new uiTabBox());
+            openBox(new uiTabBox(juce::String(label)));
         }
         
         /** Add a new vertical box to the user interface. */


### PR DESCRIPTION
When trying a faust structure with tabs within tabs I hit an assert in juce_TabbedButtonBar.cpp in line 248. This is because the added tab didn't have a name since it was created with openTabBox which in contrast to openVerticalBox or openHorizontalBox doesn't have a label assigned to it.

Fixed this by adding setName to the constructor of uiTabBox but maybe there is a better way to do this since all the other constructors are empty and these type of things are done through member initializers.

Hope this helps.
JuanS