### PR TITLE
Restore old stack size for wasm builds

### DIFF
--- a/build/emcc/CMakeLists.txt
+++ b/build/emcc/CMakeLists.txt
@@ -27,7 +27,7 @@ set (SRC ${SRC} ${BINDINGS})
 set (WASM_EXPORTED "\"['UTF8ToString', 'stringToUTF8', 'FS']\"")
 file (GLOB LIBSNDFILE ${WASMGLUE}/*.a)
 
-set (WASM_LINK_FLAGS "--no-heap-copy --bind -O3 --memory-init-file 0 -s LINKABLE=0 -s WASM=1 -s EXPORT_NAME=\"'FaustModule'\" -s MODULARIZE=1 --preload-file ../../wasm-filesystem@usr -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=1 -s EXPORTED_RUNTIME_METHODS=${WASM_EXPORTED} ${LIBSNDFILE}")
+set (WASM_LINK_FLAGS "--no-heap-copy --bind -O3 --memory-init-file 0 -s LINKABLE=0 -s WASM=1 -s EXPORT_NAME=\"'FaustModule'\" -s MODULARIZE=1 --preload-file ../../wasm-filesystem@usr -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB -s DISABLE_EXCEPTION_CATCHING=1 -s EXPORTED_RUNTIME_METHODS=${WASM_EXPORTED} ${LIBSNDFILE}")
 
 ####################################
 # Add the different targets

--- a/build/wasmglue/CMakeLists.txt
+++ b/build/wasmglue/CMakeLists.txt
@@ -53,7 +53,7 @@ set (FAUST_INC ${SRCDIR}
 # emscripten support
 set (WASM_EXPORTED "\"['FS']\"")
 set (LIBSNDFILE "${ROOT}/build/wasmglue/libsndfile.a ${ROOT}/build/wasmglue/libogg.a ${ROOT}/build/wasmglue/libvorbis.a ${ROOT}/build/wasmglue/libvorbisenc.a ${ROOT}/build/wasmglue/libFLAC.a")
-set (WASM_LINK_FLAGS "--bind --memory-init-file 0 -s LINKABLE=0 -s WASM=1 -s EXPORT_NAME=\"'FaustModule'\" -s MODULARIZE=1 -s ASSERTIONS=0 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=1 -s EXPORTED_RUNTIME_METHODS=${WASM_EXPORTED} ${LIBSNDFILE} ${WASM_LINK_FLAGS_EXTRA}")
+set (WASM_LINK_FLAGS "--bind --memory-init-file 0 -s LINKABLE=0 -s WASM=1 -s EXPORT_NAME=\"'FaustModule'\" -s MODULARIZE=1 -s ASSERTIONS=0 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=5MB -s DISABLE_EXCEPTION_CATCHING=1 -s EXPORTED_RUNTIME_METHODS=${WASM_EXPORTED} ${LIBSNDFILE} ${WASM_LINK_FLAGS_EXTRA}")
  
 ####################################
 # Add the different targets


### PR DESCRIPTION
Emscripten default stack size was reduced from 5Mb to 64Kb, causing problems when compiling some programs with faustwasm.

See:
- https://github.com/emscripten-core/emscripten/commit/157fcd4650161d9e0261966e2d3b529d62e1babc
- https://github.com/grame-cncm/faustwasm/issues/3
- https://github.com/grame-cncm/faustide/pull/72