### PR TITLE
Update faust2lv2 to support arbitrary compilation toolchains

### DIFF
--- a/tools/faust2appls/faust2lv2
+++ b/tools/faust2appls/faust2lv2
@@ -38,8 +38,7 @@ STYLE=""
 
 PROCARCH="-fPIC"
 dllext=".so"
-CXXFLAGS+=" -std=c++11 -fvisibility=hidden -O3"  # WARNING: don't modify this setting
-
+CXXFLAGS+=" -std=c++11 -fvisibility=hidden -O3 "  # WARNING: don't modify this setting
 echo $CXXFLAGS
 
 # Darwin specifics
@@ -178,7 +177,13 @@ if [ -n "$STYLE" ]; then
     STYLE_CXXFLAGS="QMAKE_CXXFLAGS+=-DSTYLE=\"$STYLE\""
 fi
 
+if [ -z ${CXX} ]; then
 CXX=g++
+echo "Using ${CXX}"
+else
+echo "compiler overridden: using ${CXX}"
+fi
+
 CPPFLAGS="-DPLUGIN_URI=\"$URI_PREFIX/$clsname\" -DFAUST_META=$FAUST_META -DFAUST_MIDICC=$FAUST_MIDICC -DFAUST_MTS=$FAUST_MTS -DFAUST_UI=$FAUST_UI -DVOICE_CTRLS=$VOICE_CTRLS"
 if [ $NVOICES -ge 0 ]; then
 CPPFLAGS="$CPPFLAGS -DNVOICES=$NVOICES"
@@ -378,4 +383,4 @@ else
     rm -rf $tmpdir
 fi
 # Print the name of the generated bundle zip file.
-echo "$SRCDIR/$lv2name;"
+echo "LV2 plugin generated at $SRCDIR/$lv2name;"

--- a/tools/faust2appls/faust2lv2
+++ b/tools/faust2appls/faust2lv2
@@ -184,6 +184,8 @@ else
 echo "compiler overridden: using ${CXX}"
 fi
 
+HOST_CXX=g++
+
 CPPFLAGS="-DPLUGIN_URI=\"$URI_PREFIX/$clsname\" -DFAUST_META=$FAUST_META -DFAUST_MIDICC=$FAUST_MIDICC -DFAUST_MTS=$FAUST_MTS -DFAUST_UI=$FAUST_UI -DVOICE_CTRLS=$VOICE_CTRLS"
 if [ $NVOICES -ge 0 ]; then
 CPPFLAGS="$CPPFLAGS -DNVOICES=$NVOICES"
@@ -365,7 +367,7 @@ EOF
 fi
 # This compiles the plugin to an executable which is run to generate the
 # plugin-specific part of the manifest.
-$CXX $CXXFLAGS -DDLLEXT="\"$dllext\"" $FAUSTTOOLSFLAGS -I"$ABSDIR" $CPPFLAGS "$tmpdir/$cppname" -o "$tmpdir/$clsname" || exit 1
+$HOST_CXX $CXXFLAGS -DDLLEXT="\"$dllext\"" $FAUSTTOOLSFLAGS -I"$ABSDIR" $CPPFLAGS "$tmpdir/$cppname" -o "$tmpdir/$clsname" || exit 1
 "$tmpdir/$clsname" > "$tmpdir/$lv2name/$clsname.ttl"
 rm -f "$tmpdir/$clsname"
 fi


### PR DESCRIPTION
This lets us do stuff like cross-compilation rather than only compiling for the host architecture. Can be used like 

`( CXX=aarch64-linux-gnu-g++ " my_plugin.dsp)`

to cross-compile to arm64 from an x86 machine.