### PR TITLE
Fix build error, and allow multiple calls to `DSPToBoxes` without resetting lib context.

### DIFF
--- a/architecture/faust/dsp/libfaust-signal.h
+++ b/architecture/faust/dsp/libfaust-signal.h
@@ -133,7 +133,7 @@ struct Interval {
     {}
 };
 
-std::ostream& operator<<(std::ostream& dst, const Interval& it)
+inline static std::ostream& operator<<(std::ostream& dst, const Interval& it)
 {
     dst << "Interval [" << it.fLo << ", " << it.fHi << ", " << it.fLSB << "]";
     return dst;

--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -1162,6 +1162,8 @@ LIBFAUST_API Tree DSPToBoxes(const string& name_app, const string& dsp_content, 
     /****************************************************************
      1 - process command line
      *****************************************************************/
+    // Reset to allow multiple calls within the same context.
+    gGlobal->reset();
     gGlobal->initDirectories(argc1, argv1);
     gGlobal->processCmdline(argc1, argv1);
 


### PR DESCRIPTION
`createDSPFactoryFromBoxes` already resets the global context (inside `boxesToSignalsAux`), but only a single call to `DSPToBoxes` will currently be successful until the client calls `destroy/createLibContext`.