### PR TITLE
Rust backend: store metadata values as raw strings

### DIFF
--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -373,19 +373,19 @@ void RustCodeContainer::produceMetadata(int n)
     for (const auto& i : gGlobal->gMetaDataSet) {
         if (i.first != tree("author")) {
             tab(n + 1, *fOut);
-            *fOut << "m.declare(\"" << *(i.first) << "\", " << **(i.second.begin()) << ");";
+            *fOut << "m.declare(\"" << *(i.first) << "\", r" << **(i.second.begin()) << ");";
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author and sub-levels become
             // "contributor"
             for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(n + 1, *fOut);
-                    *fOut << "m.declare(\"" << *(i.first) << "\", " << **j << ");";
+                    *fOut << "m.declare(\"" << *(i.first) << "\", r" << **j << ");";
                 } else {
                     tab(n + 1, *fOut);
                     *fOut << "m.declare(\""
                           << "contributor"
-                          << "\", " << **j << ");";
+                          << "\", r" << **j << ");";
                 }
             }
         }
@@ -527,7 +527,7 @@ BlockInst* RustVectorCodeContainer::generateDAGLoopVariant0(const string& counte
                                                      InstBuilder::genBasicTyped(Typed::kInt32),
                                                      InstBuilder::genInt32NumInst(gGlobal->gVecSize));
     fComputeBlockInstructions->pushFrontInst(vsize_decl);
-   
+
     block_res->pushBackInst(InstBuilder::genLabelInst("/* Main loop */"));
     BlockInst* loop_code = InstBuilder::genBlockInst();
 


### PR DESCRIPTION
In the generated code for the rust backend, the strings are currently stored as normal string. This leads some special strings, such as Windows file paths to potentially include encoding characters due to backslashes.

Storing them as [raw string literals](https://doc.rust-lang.org/rust-by-example/std/str.html#literals-and-escapes) is a safe way to ensure that the in-memory string is correctly translated in the rust compiler.

Before:

```rs
m.declare("compile_options", "-a C:\Users\Pierre\AppData\Local\Temp\.tmpq2mSuW -lang rust -ct 1 -es 1 -mcd 16 -single -ftz 0");
```

After:

```rs
m.declare("compile_options", r"-a C:\Users\Pierre\AppData\Local\Temp\.tmpq2mSuW -lang rust -ct 1 -es 1 -mcd 16 -single -ftz 0");
```