### PR TITLE
small tweaks to dplug architecture file

### DIFF
--- a/architecture/dplug.d
+++ b/architecture/dplug.d
@@ -309,10 +309,11 @@ nothrow:
     void updateFaustParams()
     {
         foreach(param; params())
-        {
+        {            
+            int paramIndex = param.index();
             foreach(faustParam; _faustParams)
             {
-                if (param.label() == faustParam.label)
+                if (paramIndex == faustParam.ParamId)
                 {
                     if (cast(FloatParameter)param)
                     {
@@ -354,7 +355,7 @@ nothrow:
             outputs[chan][0..frames] = 0; // D has array slices assignments and operations
     }
 
-private:
+protected:
     FAUSTCLASS _dsp;
     UI _faustUI;
     FaustParam[] _faustParams;


### PR DESCRIPTION
This fixes linking of parameters between Faust and Dplug and allows access to the faust dsp module from a sub-class of FaustClient.