### PR TITLE
fixed spelling and grammar errors

### DIFF
--- a/documentation/misc/using-faust-with-ros-src/chapters/introduction.tex
+++ b/documentation/misc/using-faust-with-ros-src/chapters/introduction.tex
@@ -35,10 +35,10 @@ Various principles have guided the design of \faust :
 \subsection{Signal Processor Semantic}
 A \faust program describes a \emph{signal processor}. 
 The role of a \textit{signal processor} is to transform a group  of (possibly empty) \emph{input signals} in order to produce a group of (possibly empty) \emph{output signals}. 
-Most audio equipments can be modeled as \emph{signal processors}. 
+Most audio equipment can be modeled as \emph{signal processors}. 
 They have audio inputs, audio outputs as well as control signals interfaced with sliders, knobs, vu-meters, etc... \\
 
-For more informations about \faust, please see \textit{faust-quick-reference.pdf} and the tutorials in \faust documentation.
+For more information about \faust, please see \textit{faust-quick-reference.pdf} and the tutorials in \faust documentation.
 
 \section{ROS}
 \subsection{What is it ?}
@@ -121,13 +121,13 @@ Nodes are processes that perform computation. \ros is designed to be modular at 
 \subsubsection{Names}
 Names are really important in \ros. Valid names have these characteristics :
 \begin{itemize}
-	\item first chararacter is an alpha character : [a-z][A-Z]
+	\item first character is an alpha character : [a-z][A-Z]
 	\item subsequent characters can be alphanumeric : [a-z][A-Z][0-9], underscores : \_ or forward slash : /
 	\item there is at most one forward slash : /
 
 \end{itemize}
 
-For more informations on \ros and tutorials, please have a look to the website :
+For more information on \ros and tutorials, please have a look to the website :
 \myurl{www.wiki.ros.org}.\\
 \newpage
 \section{Using FAUST with ROS}

--- a/documentation/misc/using-faust-with-ros-src/chapters/messages.tex
+++ b/documentation/misc/using-faust-with-ros-src/chapters/messages.tex
@@ -6,7 +6,7 @@ A \faust node is configured to read a single type of messages : faust\_param.msg
 
 \section{faust\_param.msg}
 When you compile a DSP file, a faust\_msgs package is automatically created next to your file package. As describe above in chapter~\ref{chap:compilation}, the faust\_msgs package contains a msg folder, in which is the faust\_param.msg file. 
-When you make the workspace with \lstinline'catkin_make', a faust\_param.h file is created in the devel/include/faust\_msgs directory. For more informations and details about messages in \ros, refer to \href{http://wiki.ros.org/msg}{\ros documentation}.\\
+When you make the workspace with \lstinline'catkin_make', a faust\_param.h file is created in the devel/include/faust\_msgs directory. For more information and details about messages in \ros, refer to \href{http://wiki.ros.org/msg}{\ros documentation}.\\
 The faust\_param messages definition is very simple :
 \begin{lstlisting}
 float32 value


### PR DESCRIPTION
This PR fixes some spelling and grammar errors of documentation such as:

For more informations ->For more information
chararacter -> character 
Most audio equipments -> Most audio equipment