### PR TITLE
Improvements on the interval library and comparison tool

### DIFF
--- a/architecture/comparator/README.md
+++ b/architecture/comparator/README.md
@@ -1,0 +1,21 @@
+# Comparator
+fixedpoint/float faust compilation comparator
+
+## Compile with make
+
+* `make all` (to create fixed.cpp float.cpp out)
+* `./out`
+
+* to clean everything `make clean`
+
+## Compile with faust2comparator script
+
+## Run the complete test 
+
+Use script `compare.sh <file.dsp>`.
+
+# Comparator options
+
+* `-l`: log the fixed-point and floating-point samples to a text file (named `samples-<program name>.log`)
+* `-w`: write the fixed-point and floating-point outputs to sound files (named respectively `fixed-<program name>.wav` and `float-<program name>.wav`)
+* `-h`: display help

--- a/architecture/comparator/compclass.cpp
+++ b/architecture/comparator/compclass.cpp
@@ -1,0 +1,304 @@
+#include "float.cpp"
+#include "fixed.cpp"
+#include <libgen.h>
+
+#include <sndfile.h>
+#include "faust/dsp/dsp-tools.h"
+#include <unistd.h>
+#include <iostream>
+#include <fstream>
+
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+// typedef sf_count_t (* sample_read)(SNDFILE* sndfile, void* buffer, sf_count_t frames);
+typedef sf_count_t (* sample_write)(SNDFILE* sndfile, void* buffer, sf_count_t frames);
+
+class comparateur {
+
+    private:
+        
+        int buffersize = 24;
+        FAUSTFLOAT** inputs;
+        FAUSTFLOAT** FX_outputs;
+        FAUSTFLOAT** FL_outputs;
+        FAUSTFLOAT** comp;
+        dsp* FL;
+        dsp* FX;
+        int sizechosen;
+        float snr;
+
+    public : 
+        
+        FAUSTFLOAT** createbuffer (int chan, int buffer_size)
+        {
+            
+            FAUSTFLOAT** buffer = new FAUSTFLOAT*[chan];
+                for (int i = 0; i < chan; i++) {
+                    buffer[i] = new FAUSTFLOAT[buffer_size];
+                    memset(buffer[i], 0, sizeof(FAUSTFLOAT) * buffer_size);
+                }
+                return buffer;
+        }
+
+        void deletebuffer (FAUSTFLOAT** buffer, int chan)
+        {
+                for (int i = 0; i <chan; i++) {
+                    delete [] buffer[i];
+                }
+                delete [] buffer;
+        }
+
+
+
+        comparateur(dsp* fl, dsp* fx)
+        {
+            FL = fl;
+            FX = fx; 
+            inputs = createbuffer(FL->getNumInputs(), buffersize);
+            FL_outputs = createbuffer(FL->getNumOutputs(), buffersize);
+            FX_outputs = createbuffer(FX->getNumOutputs(), buffersize);
+            comp = nullptr;
+        }
+
+  void compare(int size, bool logging, std::string name="")
+        {   
+            if (comp != nullptr) {
+                deletebuffer(comp, FL->getNumOutputs());
+            }
+
+	    std::ofstream logging_file;
+
+	    if (logging)
+	      {
+		std::string filename = "samples-"+name+".log";
+		logging_file.open(filename.c_str());
+	      }
+	    
+            sizechosen = size;
+            int slice = size;
+            
+            comp = createbuffer(FL->getNumOutputs(),size);
+
+	    snr = 0; //signal to noise ratio
+	    float power_signal = 0;
+	    float power_noise = 0;
+            
+            int t = 0; 
+            do {
+	      int blocsize = std::min(buffersize, slice);
+	      FX->compute(blocsize, inputs, FX_outputs);
+	      FL->compute(blocsize, inputs, FL_outputs);
+	      
+	      for (int chan=0; chan<FL->getNumOutputs(); ++chan)
+		{
+		  FAUSTFLOAT* sub_comp = comp[chan];
+		  FAUSTFLOAT* sub_FL_outputs = FL_outputs[chan];
+		  FAUSTFLOAT* sub_FX_outputs = FX_outputs[chan];
+		  for (int frame=0; frame<blocsize; ++frame) {
+                    std::cout << "FL " << sub_FL_outputs[frame] << " | FX " << sub_FX_outputs[frame] << std::endl;
+                    sub_comp[frame+(t*buffersize)] = sub_FL_outputs[frame] - sub_FX_outputs[frame];
+		    
+		    if (logging and chan == 0) // we only log one channel
+		      logging_file << sub_FL_outputs[frame] << ";" << sub_FX_outputs[frame] << ";" << std::endl;
+		    
+		    power_signal += sub_FL_outputs[frame]*sub_FL_outputs[frame];
+		    power_noise += sub_comp[frame+(t*buffersize)]*sub_comp[frame+(t*buffersize)];
+		  }
+		}
+	      ++t;
+	      slice = slice - buffersize;
+            }while (slice > 0);
+	    
+	    snr = log(power_signal/power_noise);
+        }
+                    
+        void display()
+        {   
+            FAUSTFLOAT totalcomp = 0;
+            FAUSTFLOAT compmax=0;
+
+            for (int frame=0; frame < sizechosen; ++frame) 
+            { 
+                std::cout << "frame: "<< frame;
+                for (int chan=0; chan< FL->getNumOutputs(); ++chan) 
+		  {
+                    FAUSTFLOAT* sub_comp = comp[chan];
+
+                    std::cout << " | Channel " << chan+1 << " :" << sub_comp[frame] << "\t";
+                    
+                    totalcomp = totalcomp + std::abs(sub_comp[frame]);
+                    compmax = std::max(compmax,std::abs(sub_comp[frame]));
+		  }
+
+                std::cout << std::endl;
+            }
+            std :: cout << "Total Amount : " << totalcomp << std::endl;
+	    std :: cout << "Relative error : " << totalcomp/(FL->getNumOutputs()*sizechosen) << std::endl;
+            std :: cout << "Max : " << compmax << std::endl;
+	    std :: cout << "SNR : " << snr << std::endl;
+        }
+
+        virtual ~comparateur()
+        {
+            deletebuffer(inputs, FL->getNumInputs());
+            deletebuffer(FL_outputs, FL->getNumOutputs());
+            deletebuffer(FX_outputs, FX->getNumOutputs());
+        }
+
+};
+
+std::list<GUI*> GUI::fGuiList;
+ztimedmap GUI::gTimedZoneMap;
+
+int main(int argc, char* argv[])
+{
+  // sample rate and buffer size
+  int samplerate = 44100;
+  int buffersize = 512;
+	
+  // parsing of options
+  int opt;
+
+  bool execute = false;
+  bool logging = false;
+  bool help = false;
+
+  while((opt = getopt(argc, argv, ":lwh")) != -1)
+    {
+      switch(opt)
+	{
+	case 'l':
+	  logging = true;
+	  break;
+	case 'w':
+	  execute = true;
+	  break;
+	case 'h':
+	  help = true;
+	  break;
+	}
+    }
+
+  if (help)
+    {
+      std::cout << "Usage: "
+		<< argv[0] << " [options]" << std::endl
+		<< "Options :"<< std::endl
+		<< "\t -w : writes the floating-point and fixed-point outputs to sound files" << std::endl
+		<< "\t -l : logs the floating-point and fixed-point samples to a text file" << std::endl
+		<< "\t -h : displays this help message" << std::endl ;
+	return 0;
+    }
+  
+  // init 
+  fldsp FL;
+  fxdsp FX;
+  FL.init(samplerate);
+  FX.init(samplerate);
+
+  std::string executable_name(argv[0]);
+  std::string filename = executable_name.substr(executable_name.rfind("/")+1);  
+    
+  if (execute){
+      // number of samples to compute for each DSP
+      int audiolength = 3;
+      int samplenb = audiolength*samplerate;
+      
+      sample_write writer;
+      if (sizeof(FAUSTFLOAT) == 4) 
+        writer = reinterpret_cast<sample_write>(sf_writef_float);
+      else 
+	writer = reinterpret_cast<sample_write>(sf_writef_double);
+
+      ////////////////////////////////////
+      // execute floating-point version //
+      ////////////////////////////////////
+      char name[256];
+      snprintf(name, 256, "%s", ("float-"+filename+".wav").c_str());
+
+      /* FAUSTFLOAT** inputs = new FAUSTFLOAT*[FL.getNumInputs()];
+      for (int i=0; i< FL.getNumInputs(); i++){
+	inputs[i] = new FAUSTFLOAT[buffersize];
+	memset(inputs[i], 0, sizeof(FAUSTFLOAT) * buffersize);
+	}*/ 
+
+      SF_INFO out_info = {
+	samplenb,
+	samplerate,
+	FL.getNumOutputs(),
+	SF_FORMAT_WAV|SF_FORMAT_PCM_24|SF_ENDIAN_LITTLE,
+	0,
+	0
+      };
+
+      SNDFILE* out_sf_fl = sf_open(name, SFM_WRITE, &out_info);
+      if (!out_sf_fl) {
+	std::cerr << "ERROR : cannot write output file " << name << std::endl;
+	sf_perror(out_sf_fl);
+	exit(1);
+      }
+
+      Interleaver ilvFL(buffersize, FL.getNumOutputs(), FL.getNumOutputs());
+
+      // compute samples
+      int cur_frame = 0;
+      do {
+	int blocsize = std::min(buffersize, samplenb - cur_frame);
+
+	FL.compute(blocsize, nullptr, ilvFL.inputs());
+	ilvFL.interleave();
+	writer(out_sf_fl, ilvFL.output(), blocsize);
+	cur_frame += blocsize;
+      } while (cur_frame < samplenb);
+
+      sf_close(out_sf_fl);
+      
+      /////////////////////////////////
+      // execute fixed-point version //
+      /////////////////////////////////
+      snprintf(name, 256, "%s", ("fixed-"+filename+".wav").c_str());
+
+      out_info = {
+	samplenb,
+	samplerate,
+	FX.getNumOutputs(),
+	SF_FORMAT_WAV|SF_FORMAT_PCM_24|SF_ENDIAN_LITTLE,
+	0,
+	0
+      };
+      std::cout << "Format = " << (int)(SF_FORMAT_WAV|SF_FORMAT_PCM_24|SF_ENDIAN_LITTLE) << std::endl;
+      SNDFILE* out_sf_fx = sf_open(name, SFM_WRITE, &out_info);
+      if (!out_sf_fx) {
+	std::cerr << "ERROR : cannot write output file " << name << std::endl;
+	sf_perror(out_sf_fx);
+	exit(1);
+      }
+
+      Interleaver ilvFX(buffersize, FX.getNumOutputs(), FX.getNumOutputs());
+
+      // compute samples
+      cur_frame = 0;
+      do {
+	int blocsize = std::min(buffersize, samplenb - cur_frame);
+
+	FX.compute(blocsize, nullptr, ilvFX.inputs());
+	ilvFX.interleave();
+	writer(out_sf_fx, ilvFX.output(), blocsize);
+	cur_frame += blocsize;
+      } while (cur_frame < samplenb);
+
+      sf_close(out_sf_fx);
+
+      
+    }
+
+    FL.init(48000);
+    FX.init(48000);
+
+    comparateur comp((dsp*) &FL, (dsp*) &FX);
+    comp.compare(200, logging, filename);
+    comp.display();
+}

--- a/architecture/comparator/minimal-fixed-point.cpp
+++ b/architecture/comparator/minimal-fixed-point.cpp
@@ -1,0 +1,287 @@
+/************************************************************************
+ IMPORTANT NOTE : this file contains two clearly delimited sections :
+ the ARCHITECTURE section (in two parts) and the USER section. Each section
+ is governed by its own copyright and license. Please check individually
+ each section for license and copyright information.
+ *************************************************************************/
+
+/******************* BEGIN minimal-fixed-point.cpp ****************/
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2019 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ 
+ ************************************************************************
+ ************************************************************************/
+ 
+#include <algorithm>
+#include <cmath>
+
+#include "faust/gui/PrintUI.h"
+#include "faust/gui/UI.h"
+#include "faust/gui/meta.h"
+#include "faust/dsp/dsp.h"
+#include "faust/audio/dummy-audio.h"
+#include "faust/dsp/one-sample-dsp.h"
+
+#if defined(SOUNDFILE)
+#include "faust/gui/SoundUI.h"
+#endif
+
+#include "ap_fixed.h"
+
+
+
+typedef ap_fixed<32,8,AP_RND_CONV,AP_SAT> fixpoint_t;
+// m: position of the most significant bit of the value, without taking the sign bit into account
+// l: LSB with negative coding
+#define sfx_t(m,l) ap_fixed<((m+1)-l+1),(m+1)+1,AP_RND_CONV,AP_SAT>
+#define ufx_t(m,l) ap_ufixed<((m+1)-l),(m+1),AP_RND_CONV,AP_SAT>
+
+/*
+// fx version
+inline fixpoint_t fabsfx(fixpoint_t x)
+{
+    return fixpoint_t(std::fabs(float(x)));
+}
+inline fixpoint_t acosfx(fixpoint_t x)
+{
+    return fixpoint_t(std::acos(float(x)));
+}
+inline fixpoint_t asinfx(fixpoint_t x)
+{
+    return fixpoint_t(std::asin(float(x)));
+}
+inline fixpoint_t atanfx(fixpoint_t x)
+{
+    return fixpoint_t(std::atan(float(x)));
+}
+inline fixpoint_t atan2fx(fixpoint_t x, fixpoint_t y)
+{
+    return fixpoint_t(std::atan2(float(x), float(y)));
+}
+inline fixpoint_t ceilfx(fixpoint_t x)
+{
+    return fixpoint_t(std::ceil(float(x)));
+}
+inline fixpoint_t cosfx(fixpoint_t x)
+{
+    return fixpoint_t(std::cos(float(x)));
+}
+inline fixpoint_t expfx(fixpoint_t x)
+{
+    return fixpoint_t(std::exp(float(x)));
+}
+inline fixpoint_t exp2fx(fixpoint_t x)
+{
+    return fixpoint_t(std::exp2(float(x)));
+}
+inline fixpoint_t exp10fx(fixpoint_t x)
+{
+#ifdef __APPLE__
+    return fixpoint_t(__exp10f(float(x)));
+#else
+    return fixpoint_t(std::exp10(float(x)));
+#endif
+}
+inline fixpoint_t floorfx(fixpoint_t x)
+{
+    return fixpoint_t(std::floor(float(x)));
+}
+inline fixpoint_t fmodfx(fixpoint_t x, fixpoint_t y)
+{
+    return fixpoint_t(std::fmod(float(x), float(y)));
+}
+inline fixpoint_t logfx(fixpoint_t x)
+{
+    return fixpoint_t(std::log(float(x)));
+}
+inline fixpoint_t log2fx(fixpoint_t x)
+{
+    return fixpoint_t(std::log2(float(x)));
+}
+inline fixpoint_t log10fx(fixpoint_t x)
+{
+    return fixpoint_t(std::log10(float(x)));
+}
+inline fixpoint_t powfx(fixpoint_t x, fixpoint_t y)
+{
+    return fixpoint_t(std::pow(float(x), float(y)));
+}
+inline fixpoint_t remainderfx(fixpoint_t x, fixpoint_t y)
+{
+    return fixpoint_t(std::remainder(float(x), float(y)));
+}
+inline fixpoint_t rintfx(fixpoint_t x)
+{
+    return fixpoint_t(std::rint(float(x)));
+}
+inline fixpoint_t roundfx(fixpoint_t x)
+{
+    return fixpoint_t(std::round(float(x)));
+}
+inline fixpoint_t sinfx(fixpoint_t x)
+{
+    return fixpoint_t(std::sin(float(x)));
+}
+inline fixpoint_t sqrtfx(fixpoint_t x)
+{
+    return fixpoint_t(std::sqrt(float(x)));
+}
+inline fixpoint_t tanfx(fixpoint_t x)
+{
+    return fixpoint_t(std::tan(float(x)));
+}
+// min/max
+inline fixpoint_t fminfx(fixpoint_t x, fixpoint_t y)
+{
+    return fixpoint_t(std::min(float(x), float(y)));
+}
+inline fixpoint_t fmaxfx(fixpoint_t x, fixpoint_t y)
+{
+    return fixpoint_t(std::max(float(x), float(y)));
+}
+*/
+
+// fx version
+inline float fabsfx(float x)
+{
+    return std::fabs(x);
+}
+inline float acosfx(float x)
+{
+    return std::acos(x);
+}
+inline float asinfx(float x)
+{
+    return std::asin(x);
+}
+inline float atanfx(float x)
+{
+    return std::atan(x);
+}
+inline float atan2fx(float x, float y)
+{
+    return std::atan2(x, y);
+}
+inline float ceilfx(float x)
+{
+    return std::ceil(x);
+}
+inline float cosfx(float x)
+{
+    return std::cos(x);
+}
+inline float expfx(float x)
+{
+    return std::exp(x);
+}
+inline float exp2fx(float x)
+{
+    return std::exp2(x);
+}
+inline float exp10fx(float x)
+{
+#ifdef __APPLE__
+    return __exp10f(x);
+#else
+    return exp10(x);
+#endif
+}
+inline float floorfx(float x)
+{
+    return std::floor(x);
+}
+inline float fmodfx(float x, float y)
+{
+    return std::fmod(x, y);
+}
+inline float logfx(float x)
+{
+    return std::log(x);
+}
+inline float log2fx(float x)
+{
+    return std::log2(x);
+}
+inline float log10fx(float x)
+{
+    return std::log10(x);
+}
+inline float powfx(float x, float y)
+{
+    return std::pow(x, y);
+}
+inline float remainderfx(float x, float y)
+{
+    return std::remainder(x, y);
+}
+inline float rintfx(float x)
+{
+    return std::rint(x);
+}
+inline float roundfx(float x)
+{
+    return std::round(x);
+}
+inline float sinfx(float x)
+{
+    return std::sin(x);
+}
+inline float sqrtfx(float x)
+{
+    return std::sqrt(x);
+}
+inline float tanfx(float x)
+{
+    return std::tan(x);
+}
+// min/max
+/*
+#define minfx(x, y) { (((x) < (y)) ? (x) : (y)) }
+#define maxfx(x, y) { (((x) < (y)) ? (y) : (x)) }
+*/
+
+inline float minfx(float x, float y) { return (x < y) ? x : y; }
+inline float maxfx(float x, float y) { return (x < y) ? y : x; }
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ VECTOR INTRINSICS
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+<<includeIntrinsic>>
+
+/********************END ARCHITECTURE SECTION (part 1/2)****************/
+
+/**************************BEGIN USER SECTION **************************/
+
+<<includeclass>>
+
+/***************************END USER SECTION ***************************/
+
+/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+
+
+
+/******************* END minimal-fixed-point.cpp ****************/

--- a/architecture/comparator/minimal-floating-point.cpp
+++ b/architecture/comparator/minimal-floating-point.cpp
@@ -1,0 +1,66 @@
+/************************************************************************
+ IMPORTANT NOTE : this file contains two clearly delimited sections :
+ the ARCHITECTURE section (in two parts) and the USER section. Each section
+ is governed by its own copyright and license. Please check individually
+ each section for license and copyright information.
+ *************************************************************************/
+
+/******************* BEGIN minimal.cpp ****************/
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2019 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ 
+ ************************************************************************
+ ************************************************************************/
+
+#include <iostream>
+
+#include "faust/gui/PrintUI.h"
+#include "faust/gui/meta.h"
+#include "faust/audio/dummy-audio.h"
+#include "faust/dsp/one-sample-dsp.h"
+
+// faust -a minimal.cpp noise.dsp -o noise.cpp && c++ -std=c++11 noise.cpp -o noise && ./noise
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ VECTOR INTRINSICS
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+<<includeIntrinsic>>
+
+/********************END ARCHITECTURE SECTION (part 1/2)****************/
+
+/**************************BEGIN USER SECTION **************************/
+
+<<includeclass>>
+
+/***************************END USER SECTION ***************************/
+
+/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+
+
+
+/******************* END minimal.cpp ****************/
+

--- a/architecture/faust/dsp/fixed-point.h
+++ b/architecture/faust/dsp/fixed-point.h
@@ -33,7 +33,7 @@ typedef ap_fixed<32,8,AP_RND_CONV,AP_SAT> fixpoint_t;
 
 // m: position of the most significant bit of the value, without taking the sign bit into account
 // l: LSB with negative coding
-#define sfx_t(m,l) ap_fixed<((m+1)-l+1),(m+1),AP_RND_CONV,AP_SAT>
+#define sfx_t(m,l) ap_fixed<((m+1)-l+1),(m+1)+1,AP_RND_CONV,AP_SAT>
 #define ufx_t(m,l) ap_ufixed<((m+1)-l),(m+1),AP_RND_CONV,AP_SAT>
 
 /*

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -442,7 +442,7 @@ install (
 )
 
 # install folders
-set (ARCHSRC android api AU audiokit autodiff daisy esp32 iOS jax juce julia cmajor max-msp nodejs osclib sam smartKeyboard svgplot teensy unity vcvrack webaudio)
+set (ARCHSRC android api AU audiokit autodiff comparator daisy esp32 iOS jax juce julia cmajor max-msp nodejs osclib sam smartKeyboard svgplot teensy unity vcvrack webaudio)
 foreach (dir ${ARCHSRC})
 	set(ARCHFOLDERS ${ARCHFOLDERS} ${ARCHDIR}/${dir})
 endforeach()

--- a/compiler/generator/type_manager.hh
+++ b/compiler/generator/type_manager.hh
@@ -126,6 +126,9 @@ class CStringTypeManager : public StringTypeManager {
 
         // fx_typed is a subclass of basic_typed, so has to be tested first
         if (fx_typed) {
+            if (fx_typed->fLSB >= 0) { // if there are no bits after the fixed point, ie if it's an integer
+                return fTypeDirectTable[Typed::kInt32]; // 32 or 64 bits?
+            }
             if (fx_typed->fIsSigned) {
                 // return "sfx_t(" + std::to_string(std::max<int>(0, std::min<int>(20, fx_typed->fMSB))) + "," + std::to_string(fx_typed->fLSB) + ")";
                 if (gGlobal->gFixedPointSize > 0) {

--- a/compiler/generator/type_manager.hh
+++ b/compiler/generator/type_manager.hh
@@ -141,9 +141,11 @@ class CStringTypeManager : public StringTypeManager {
                 // return "ufx_t(" + std::to_string(std::max<int>(0, std::min<int>(20, fx_typed->fMSB))) + "," + std::to_string(fx_typed->fLSB) + ")";
                 if (gGlobal->gFixedPointSize > 0) {
                     int msb = calcMSB(fx_typed->fMSB);
-                    return "ufx_t(" + std::to_string(msb) + "," + std::to_string(msb - gGlobal->gFixedPointSize) + ")";
+                    // return "ufx_t(" + std::to_string(msb) + "," + std::to_string(msb - gGlobal->gFixedPointSize) + ")";
+                    return "sfx_t(" + std::to_string(msb) + "," + std::to_string(msb - gGlobal->gFixedPointSize) + ")";
                 } else {
-                    return "ufx_t(" + std::to_string(fx_typed->fMSB) + "," + std::to_string(fx_typed->fLSB) + ")";
+                    // return "ufx_t(" + std::to_string(fx_typed->fMSB) + "," + std::to_string(fx_typed->fLSB) + ")";
+                    return "sfx_t(" + std::to_string(fx_typed->fMSB) + "," + std::to_string(fx_typed->fLSB) + ")";
                 }
             }
         } else if (basic_typed) {

--- a/compiler/interval/intervalAdd.cpp
+++ b/compiler/interval/intervalAdd.cpp
@@ -30,27 +30,47 @@ static double add(double x, double y)
     return x + y;
 }
 
+static double addint(double x, double y)
+{
+    return (int)x + (int)y;
+}
+
 interval interval_algebra::Add(const interval& x, const interval& y)
 {
     if (x.isEmpty() || y.isEmpty()) {
         return {};
     }
 
+    if (x.lsb() >= 0 and y.lsb() >= 0) { // if both intervals are integers
+        // if we're dealing with integers the interval has to wrap around 0
+        const int xlo = (int)x.lo();
+        const int xhi = (int)x.hi();
+        const int ylo = (int)y.lo();
+        const int yhi = (int)y.hi();
+
+        // detect wrapping
+        if (xhi + yhi < std::max(xhi, yhi) or xlo + ylo > std::max(xlo, ylo))
+            return {(double) INT_MIN, (double) INT_MAX, std::min(x.lsb(), y.lsb())};
+
+        return {(double)(xlo + ylo), (double)(xhi + yhi), std::min(x.lsb(), y.lsb())};
+    }
+
     return {x.lo() + y.lo(), x.hi() + y.hi(),
-            std::max(x.lsb(),
-                     y.lsb())};  // the result of an addition needs to be only as precise as the least precise of the operands
+            std::min(x.lsb(),
+                     y.lsb())};  // the result of an addition needs to be only as precise as the most precise of the operands
 }
 
 void interval_algebra::testAdd()
 {
     // check("test algebra Add", Add(interval(0, 100), interval(10, 500)), interval(10, 600));
-    analyzeBinaryMethod(10, 2000, "add", interval(0, 10, 0), interval(0, 10, 0), add, &interval_algebra::Add);
-    analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -5), interval(0, 10, 0), add, &interval_algebra::Add);
+    // analyzeBinaryMethod(10, 2000, "add", interval(0, 10, 0), interval(0, 10, 0), add, &interval_algebra::Add);
+    analyzeBinaryMethod(10, 2000, "add", interval(0, pow(2, 31), 0), interval(0, pow(2, 31), 0), addint, &interval_algebra::Add);
+    /* analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -5), interval(0, 10, 0), add, &interval_algebra::Add);
     analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -10), interval(0, 10, 0), add, &interval_algebra::Add);
     analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -15), interval(0, 10, 0), add, &interval_algebra::Add);
     analyzeBinaryMethod(10, 2000, "add", interval(0, 10, 0), interval(0, 10, -10), add, &interval_algebra::Add);
     analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -5), interval(0, 10, -10), add, &interval_algebra::Add);
     analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -10), interval(0, 10, -10), add, &interval_algebra::Add);
-    analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -15), interval(0, 10, -10), add, &interval_algebra::Add);
+    analyzeBinaryMethod(10, 2000, "add", interval(0, 10, -15), interval(0, 10, -10), add, &interval_algebra::Add);*/
 }
 }  // namespace itv

--- a/compiler/interval/intervalEq.cpp
+++ b/compiler/interval/intervalEq.cpp
@@ -35,8 +35,8 @@ interval interval_algebra::Eq(const interval& x, const interval& y)
 {
     // boolean value => precision 0
     if (x.isEmpty() || y.isEmpty()) return interval{};
-    if (x.lo() == x.hi() && x.lo() == y.lo() && x.lo() == y.hi()) return singleton(1,0);
-    if (x.hi() < y.lo() || x.lo() > y.hi()) return singleton(0,0);
+    if (x.lo() == x.hi() && x.lo() == y.lo() && x.lo() == y.hi()) return interval{1,1,0};
+    if (x.hi() < y.lo() || x.lo() > y.hi()) return interval{0, 0, 0};
     return interval{0, 1, 0};
 }
 

--- a/compiler/interval/intervalGe.cpp
+++ b/compiler/interval/intervalGe.cpp
@@ -35,8 +35,8 @@ interval interval_algebra::Ge(const interval& x, const interval& y)
 {
     // boolean value => precision 0
     if (x.isEmpty() || y.isEmpty()) return interval{};
-    if (x.lo() >= y.hi()) return singleton(1,0);
-    if (x.hi() < y.lo()) return singleton(0,0);
+    if (x.lo() >= y.hi()) return interval{1,1,0};
+    if (x.hi() < y.lo()) return interval{0,0,0};
     return interval{0, 1, 0};
 }
 

--- a/compiler/interval/intervalGt.cpp
+++ b/compiler/interval/intervalGt.cpp
@@ -37,10 +37,10 @@ interval interval_algebra::Gt(const interval& x, const interval& y)
         return interval{};
     }
     if (x.lo() > y.hi()) {
-        return singleton(1, 0);
+        return interval{1,1,0};
     }
     if (x.hi() <= y.lo()) {
-        return singleton(0, 0);
+        return interval{0,0,0};
     }
     return interval{0, 1, 0};
 }

--- a/compiler/interval/intervalNe.cpp
+++ b/compiler/interval/intervalNe.cpp
@@ -32,10 +32,10 @@ interval interval_algebra::Ne(const interval& x, const interval& y)
         return {};
     }
     if ((x.hi() < y.lo()) || x.lo() > y.hi()) {
-        return singleton(1.0, 0);
+        return interval{1,1,0};
     }
     if ((x.hi() == y.lo()) || x.lo() == y.hi()) {
-        return singleton(0.0, 0);
+        return interval{0,0,0};
     }
     return {0, 1, 0};
 }

--- a/compiler/interval/intervalPow.cpp
+++ b/compiler/interval/intervalPow.cpp
@@ -34,7 +34,7 @@ static interval ipow(const interval& x, int y)
 {
     assert(y >= 0);
     if (y == 0) {
-        return singleton(1.0, 0);
+        return interval{1,1,0};
     }
 
     // explicit expression because passing an anonymous function to exactPrecisionUnary is complicated

--- a/compiler/interval/interval_def.hh
+++ b/compiler/interval/interval_def.hh
@@ -186,17 +186,22 @@ inline interval reunion(const interval& i, const interval& j)
     }
 }
 
-inline interval singleton(double x, int lsb = -24)
+inline interval singleton(double x)
 {
     if (x == 0) {
         return {0, 0, 0};
     }
 
-    int precision = lsb;
+    /* int precision = lsb;
 
     while (floor(x * pow(2, -precision - 1)) == x * pow(2, -precision - 1) and x != 0) {
         precision++;
-    }
+    }*/
+
+    int m = std::floor(std::log2(std::abs(x)));
+
+    int precision = m - 32; // 32 = set width
+
     return {x, x, precision};
 }
 

--- a/compiler/interval/interval_def.hh
+++ b/compiler/interval/interval_def.hh
@@ -118,13 +118,18 @@ class interval {
         // amplitude of the interval
         // can be < 1.0, in which case the msb will be negative and indicate the number of implicit leading zeroes
         double range = std::max(std::abs(fLo), std::abs(fHi));
+        
 
         if (std::isinf(range)) {
-            return 20;  // max MSB of the VHDL design; TODO: change when integrating in the compiler
+            // if (fLSB == 0) // if we're dealing with integers: is that a good criterion?
+                return 31;
+            // return 20;  // max MSB of the VHDL design; TODO: change when integrating in the compiler
         }
 
+        int l = int(std::ceil(std::log2(range)));
+
         // The sign bit will be added later on
-        return int(std::floor(std::log2(range)));
+        return l;
     }
 
     std::string to_string() const

--- a/compiler/interval/utils.hh
+++ b/compiler/interval/utils.hh
@@ -23,6 +23,22 @@ static double max4(double a, double b, double c, double d)
 }
 
 /**
+ * @brief Computes the minimum of four ints
+ */
+static double min4(int a, int b, int c, int d)
+{
+    return std::min(std::min(a, b), std::min(c, d));
+}
+
+/**
+ * @brief Computes the maximum of four ints
+ */
+static double max4(int a, int b, int c, int d)
+{
+    return std::max(std::max(a, b), std::max(c, d));
+}
+
+/**
  * @brief Computes the value with minimum absolute value among the bounds of an interval
 */
 static double minValAbs(interval x)

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,3 +17,4 @@ The following tools are currently available:
   * several 'waveforms' for separated mono channels
   * a resulting 'processor' that simply output all mono 'waveforms' 
 * `benchmark` folder contains additional tools to test the C++, LLVM, WebAssembly and Interpreter backends, and the performance of their generated code. 
+* `faust2comparator` allows to compare the fixed-point and floating-point versions of a program.

--- a/tools/faust2appls/faust2comparator
+++ b/tools/faust2appls/faust2comparator
@@ -1,0 +1,77 @@
+#! /bin/bash -e
+
+
+# Define some common paths
+. faustpath
+# Define compilation flags
+. faustoptflags
+# Helper file to build the 'help' option
+. usage.sh
+
+CXXFLAGS+=" $MYGCCFLAGS"  # So that additional CXXFLAGS can be used
+
+# The architecture file name
+ARCHFILE1=$FAUSTARCH/comparator/minimal-floating-point.cpp
+ARCHFILE2=$FAUSTARCH/comparator/minimal-fixed-point.cpp
+
+
+# Global variables
+OPTIONS=""
+FILES=""
+
+
+#-------------------------------------------------------------------
+# dispatch command arguments
+#-------------------------------------------------------------------
+
+while [ $1 ]
+do
+  p=$1
+
+  if [ $p = "-help" ] || [ $p = "-h" ]; then
+     usage faust2comparator "[options] [Faust options] <file.dsp>"
+     exit
+  fi
+
+  echo "dispatch command arguments"
+
+  if [ ${p:0:1} = "-" ]; then
+       OPTIONS="$OPTIONS $p"
+    elif [[ -f "$p" ]] && [ ${p: -4} == ".dsp" ]; then
+       FILES="$FILES $p"
+    else
+       OPTIONS="$OPTIONS $p"        
+  fi
+
+shift
+
+done
+
+
+#-------------------------------------------------------------------
+# compile the *.dsp files 
+#-------------------------------------------------------------------
+
+for f in $FILES; do
+
+    # compile the DSP to c++ using the architecture file
+    echo "compile the DSP to c++ using the architecture file"
+    faust -i -a $ARCHFILE1 -cn "fldsp" "$f" -o "float.cpp"|| exit
+    faust -i -a $ARCHFILE2 -fx -cn "fxdsp" "$f" -o "fixed.cpp"|| exit
+
+    # compile c++ to binary
+    echo "compile c++ to binary"
+    (
+        $CXX $CXXFLAGS -g "$FAUSTARCH/comparator/compclass.cpp" "-I/usr/local/include/ap_fixed" `pkg-config --cflags --static --libs sndfile jack gtk+-2.0` -o "${f%.dsp}"
+    ) > /dev/null || exit
+
+  # remove tempory files # actually, they're useful to have to track bugs in FX inference
+    # rm -f "float.cpp"
+    # rm -f "fixed.cpp"
+
+    # collect binary file name for FaustWorks
+    BINARIES="$BINARIES${f%.dsp};"
+done
+
+echo $BINARIES
+


### PR DESCRIPTION
Adds support for integer intervals on the interval library (with proper representation of wrapping behaviour).
Corrects (once again) definition of fixed-point types and MSB.
Adds a tool (faust2comparator) that allows to compare outputs of fixed-point and floating-point versions of programs, both sample-wise and on sound files.