### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Build status: [![Ubuntu](https://github.com/grame-cncm/faust/actions/workflows/u
 
 Faust (Functional Audio Stream) is a functional programming language specifically designed for real-time signal processing and synthesis. A distinctive characteristic of Faust is to be fully compiled.
 
-The Faust compiler translates DSP specifications into very efficient code for various languages (C++, C, JAVA, LLVM IR, WebAssembly etc.) working at sample level. It targets high-performance signal processing applications, libraries and audio plug-ins for a variety of audio platforms and standards. A same Faust specification can be used to easily generate various kinds of native standalone applications, iOS and Android apps, as well as Csound, LADSPA, Max/MSP, PD, Q, SuperCollider, VST, AU plugins, etc. (see the README in the `/architecture` folder for an exhaustive list).
+The Faust compiler translates DSP specifications into very efficient code for various languages (C++, C, JAVA, LLVM IR, WebAssembly etc.) working at sample level. It targets high-performance signal processing applications, libraries, and audio plug-ins for a variety of audio platforms and standards. A same Faust specification can be used to easily generate various kinds of native standalone applications, iOS and Android apps, as well as Csound, LADSPA, Max/MSP, PD, Q, SuperCollider, VST, AU plugins, etc. (see the README in the `/architecture` folder for an exhaustive list).
 
 While there are Faust contributors everywhere across the globe, Faust is mainly being developed at Grame, Centre National de Creation Musicale (<https://www.grame.fr>), its birthplace.
 
 ## Versions and Branches
 
-The Faust distribution can be downloaded on the Faust Github repository: <https://github.com/grame-cncm/faust>. Official releases packages are also available here: <https://github.com/grame-cncm/faust/releases>.
+The Faust distribution can be downloaded on the Faust Github repository: <https://github.com/grame-cncm/faust>. Official release packages are also available here: <https://github.com/grame-cncm/faust/releases>.
 
 In the following subsections, details about the branches of the repository are given.
 


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Introduction**" and "**Versions and Branches**"

"** applications, libraries and audio**"  should be "** applications, libraries, and audio**"

" **Official releases packages are also **"  should be " **Official release packages are also **"

Screenshot-

![Screenshot (120)](https://github.com/grame-cncm/faust/assets/115995339/1f05e85f-fdfa-49f4-920d-a14fc2ffc993)

