### PR TITLE
JAX: improve soundfile path searching

### DIFF
--- a/architecture/jax/minimal.py
+++ b/architecture/jax/minimal.py
@@ -16,6 +16,8 @@
 
 import json
 import re
+import dataclasses
+from pathlib import Path
 from typing import List
 
 import numpy as np
@@ -35,17 +37,28 @@ def remainder(x, y):
 <<includeIntrinsic>>
 <<includeclass>>
 	
-	def load_soundfile(self, filepath):
-		try:
-			audio, sr = librosa.load(filepath, mono=False, sr=None)
-		except FileNotFoundError:
-			return np.zeros((1,1024)), 44100
-		if audio.ndim == 1:
-			audio = np.expand_dims(audio, 0)
-		return audio, sr
+	def load_soundfile(self, filepath: str):
+		# soundfile_dirs should always include at least "".
+		soundfile_dirs = [""] + list(self.soundfile_dirs)
+		# Create a list of potential filepaths to check
+		potential_paths = [Path(filepath)] if Path(filepath).is_absolute() else [Path(d) / filepath for d in soundfile_dirs]
+
+		# Loop through potential paths and try to load the audio file
+		for full_path in potential_paths:
+			try:
+				audio, sr = librosa.load(str(full_path), mono=False, sr=None)
+				if audio.ndim == 1:
+					audio = np.expand_dims(audio, 0)
+				return audio, sr
+			except FileNotFoundError:
+				# If not found at this path, continue to the next
+				continue
+		
+		# If none of the paths worked, return the default silence array and sample rate
+		return np.zeros((1, 1024)), self.sample_rate
 	
 	def add_soundfile(self, state, zone: str, ui_path: List[str], label: str, url: str, x):
-		# todo: better parsing
+		# example url: {'tango.wav';'foo.wav';'bar/baz.wav'}
 		filepaths = url[2:-2].split("';'")
 		fLength, fOffset, fSR, offset = [], [], [], 0
 		audio_data = [self.load_soundfile(filepath) for filepath in filepaths]
@@ -119,7 +132,7 @@ def remainder(x, y):
 		
 	@nn.compact
 	def __call__(self, x, T: int) -> jnp.array:
-		state = self.initialize(self.sample_rate, x, T)
+		state = self.initialize(x, T)
 		state = self.build_interface(state, x, T)
 		# convert any numpy arrays to jax numpy arrays
 		state = jax.tree_map(jnp.array, state)

--- a/compiler/generator/jax/jax_code_container.cpp
+++ b/compiler/generator/jax/jax_code_container.cpp
@@ -177,6 +177,8 @@ void JAXCodeContainer::produceClass()
 
     tab(n + 1, *fOut);
     *fOut << "sample_rate: int";
+    tab(n + 1, *fOut);
+    *fOut << "soundfile_dirs: list[str] = dataclasses.field(default_factory=list)";
 
     tab(n + 1, *fOut);
     gGlobal->gJAXVisitor->Tab(n);
@@ -184,7 +186,7 @@ void JAXCodeContainer::produceClass()
     tab(n + 1, *fOut);
     produceInfoFunctions(n + 1, "", "self", false, FunTyped::kDefault, gGlobal->gJAXVisitor);
     
-    *fOut << "def initialize(self, sample_rate, x, T):";
+    *fOut << "def initialize(self, x, T):";
     {
         tab(n + 2, *fOut);
         *fOut << "state = {}";
@@ -275,6 +277,15 @@ void JAXCodeContainer::generateCompute(int n)
 
     generatePostComputeBlock(gGlobal->gJAXVisitor);
     gGlobal->gJAXVisitor->fUseNumpy = true;
+}
+
+void JAXCodeContainer::generateSR()
+{
+    if (!fGeneratedSR) {
+        pushDeclare(InstBuilder::genDecStructVar("fSampleRate", InstBuilder::genInt32Typed()));
+    }
+    pushPreInitMethod(
+        InstBuilder::genStoreStructVar("fSampleRate", InstBuilder::genLoadFunArgsVar("self.sample_rate")));
 }
 
 // Scalar

--- a/compiler/generator/jax/jax_code_container.hh
+++ b/compiler/generator/jax/jax_code_container.hh
@@ -45,6 +45,8 @@ class JAXCodeContainer : public virtual CodeContainer {
 
     void generateCompute(int n);
 
+    virtual void generateSR();
+
    public:
     JAXCodeContainer()
     {}


### PR DESCRIPTION
Previously, when using soundfiles with JAX, the url file path needed to be either absolute or relative to the python file. Now it's possible to pass a list of directories in which to search for the files. I've tested the following usage in DawDreamer.

```python
module_name = "FaustModule"
with FaustContext():
    jax_code = boxToSource(box, 'jax', module_name, ['-a', 'jax/minimal.py'])

custom_globals = {}
exec(jax_code, custom_globals)
Model = custom_globals[module_name]

soundfile_dirs = ["/Users/admin/assets", ["/Users/admin/more_assets"]
model = Model(44100, soundfile_dirs)

# or explicitly
model = Model(sample_rate=44100, soundfile_dirs=soundfile_dirs)

# this is backwards compatible
model = Model(44100)
```