### PR TITLE
Fix mpg123 issue on macos arm64 github action

### DIFF
--- a/.github/workflows/libfaust.yml
+++ b/.github/workflows/libfaust.yml
@@ -171,6 +171,7 @@ jobs:
     - name: Brew install requirements (arm64)
       if: ${{ endsWith( matrix.name, 'arm64') }}
       # todo: should we bother with brew update?
+      # todo: add mpg123 so that faustgen and other projects can decode mp3
       run: |
         brew update
         PACKAGES=(ncurses gtk+ liblo lame flac libogg libtool libvorbis opus)
@@ -193,7 +194,16 @@ jobs:
 
     - name: Brew install requirements (x64)
       if: ${{ endsWith( matrix.name, 'x64') }}
-      run: brew install pkg-config ncurses gtk+ qt@5 liblo lame flac libogg libtool libvorbis opus mpg123
+      run: brew install pkg-config ncurses gtk+ liblo lame flac libogg libtool libvorbis opus mpg123
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: '5.15.2'
+        host: 'mac'
+        target: 'desktop'
+        dir: '${{ github.workspace }}/qt_install'
+        # tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
 
     - name: Download LLVM
       run: |
@@ -241,7 +251,7 @@ jobs:
     - name: Build everything
       # todo: do we need to specify the qt@5 path for PKG_CONFIG_PATH?
       run: |
-        export PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig:$PWD/libsndfile/install/lib/pkgconfig:$PWD/libmicrohttpd/libmicrohttpd/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$QT_ROOT_DIR/lib/pkgconfig:$PWD/libsndfile/install/lib/pkgconfig:$PWD/libmicrohttpd/libmicrohttpd/lib/pkgconfig"
         export LLVM_DIR=$PWD/llvm/lib/cmake/llvm
         export LLVM_LIB_DIR=$PWD/llvm/lib
         export LLVM_INCLUDE_DIRS=$PWD/llvm/include

--- a/.github/workflows/libfaust.yml
+++ b/.github/workflows/libfaust.yml
@@ -74,7 +74,7 @@ jobs:
       id: cache-llvm-restore
       uses: actions/cache/restore@v3
       with:
-        path: llvm-project
+        path: llvm-project/llvm/llvm
         key: cache-llvm-${{env.LLVM_PACKAGE_VERSION}}-${{ matrix.name }}
 
     - name: Clone LLVM
@@ -97,18 +97,18 @@ jobs:
       id: cache-llvm-save
       uses: actions/cache/save@v3
       with:
-        path: llvm-project
+        path: llvm-project/llvm/llvm
         key: ${{ steps.cache-llvm-restore.outputs.cache-primary-key }}
 
     - name: Build libfaust
       run: |
-        export PATH="${{ github.workspace }}/llvm-project/llvm/build/bin:$PATH"
+        export LLVM_DIR=$LLVM_ROOT
+        export PATH="$LLVM_ROOT/bin:$PATH"
         cd build
-        cmake  -C ./backends/all.cmake . -Bbuild ${{matrix.cmake-options}} -DINCLUDE_DYNAMIC=ON -DINCLUDE_STATIC=ON -DINCLUDE_LLVM=ON -DUSE_LLVM_CONFIG=ON -DLLVM_CONFIG=$LLVM_CONFIG -DCMAKE_PREFIX_PATH="$LLVM_DIR"
+        cmake  -C ./backends/all.cmake . -Bbuild ${{matrix.cmake-options}} -DINCLUDE_DYNAMIC=ON -DINCLUDE_STATIC=ON -DINCLUDE_LLVM=ON -DUSE_LLVM_CONFIG=ON -DLLVM_CONFIG="$LLVM_ROOT/bin/llvm-config" -DCMAKE_PREFIX_PATH="$LLVM_ROOT/lib/cmake/llvm"
         cmake --build build --config Release
       env:
-        LLVM_DIR: ${{ github.workspace }}/llvm-project/llvm/build/lib/cmake/llvm
-        LLVM_CONFIG: ${{ github.workspace }}/llvm-project/llvm/build/bin/llvm-config
+        LLVM_ROOT: ${{ github.workspace }}/llvm-project/llvm/llvm
    
     - name: Make distribution
       run: |

--- a/.github/workflows/libfaust.yml
+++ b/.github/workflows/libfaust.yml
@@ -138,12 +138,14 @@ jobs:
             ARCHS: "-arch arm64"
             CMAKE_OSX_ARCHITECTURES: arm64
             HOST: aarch64-apple-darwin
+            ENABLE_MPEG: OFF
           - name: x64
             os: macos-11
             llvm-url: https://github.com/grame-cncm/faust/releases/download/2.59.5-llvm/llvm-15.0.7-macos10.15-x86_64.zip
             ARCHS: "-arch x86_64"
             CMAKE_OSX_ARCHITECTURES: x86_64
             HOST: x86_64-apple-darwin
+            ENABLE_MPEG: ON
 
     runs-on: ${{ matrix.os }}
 
@@ -171,7 +173,7 @@ jobs:
       # todo: should we bother with brew update?
       run: |
         brew update
-        PACKAGES=(ncurses gtk+ qt@5 liblo lame flac libogg libtool libvorbis opus mpg123)
+        PACKAGES=(ncurses gtk+ liblo lame flac libogg libtool libvorbis opus)
         DEPS=($(brew deps --union --topological $(echo $PACKAGES) | tr '\n' ' '))
         PACKAGES=("${DEPS[@]}" "${PACKAGES[@]}")
         export HOMEBREW_NO_INSTALL_CLEANUP=1
@@ -215,7 +217,7 @@ jobs:
         cd libsndfile
         LIBSNDFILE_INSTALL_PREFIX="$PWD/install"
         mkdir CMakeBuild && cd CMakeBuild
-        cmake .. -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$LIBSNDFILE_INSTALL_PREFIX" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_OSX_ARCHITECTURES=$CMAKE_OSX_ARCHITECTURES -DCMAKE_OSX_DEPLOYMENT_TARGET=$CMAKE_OSX_DEPLOYMENT_TARGET -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF
+        cmake .. -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$LIBSNDFILE_INSTALL_PREFIX" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_OSX_ARCHITECTURES=$CMAKE_OSX_ARCHITECTURES -DCMAKE_OSX_DEPLOYMENT_TARGET=$CMAKE_OSX_DEPLOYMENT_TARGET -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_MPEG=${{ matrix.ENABLE_MPEG }}
         make && make install
         otool -L $LIBSNDFILE_INSTALL_PREFIX/lib/libsndfile.a
         echo "Testing pkg-config for sndfile"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,16 +7,15 @@ on:
   pull_request:
     branches: [ master-dev ]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    if: github.repository == 'grame-cncm' || github.event_name == 'pull_request'
     runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Build Faust
-        run: make
+    - name: Build Faust
+      run: make

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,9 +9,8 @@ on:
 
 jobs:
   build:
-
+    if: github.repository == 'grame-cncm' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 
@@ -19,5 +18,6 @@ jobs:
       run: |
         sudo apt-get update -qq 
         sudo apt-get install libmicrohttpd-dev
+
     - name: Build Faust
       run: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,10 +1,6 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Windows
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the dev branch
   push:
     branches:
         - '*'
@@ -14,26 +10,20 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    if: github.repository == 'grame-cncm' || github.event_name == 'pull_request'
     runs-on: windows-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      # Runs a set of commands using the runners shell
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
-    
-      - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@latest
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+  
+    - name: Get latest CMake and ninja
+      uses: lukka/get-cmake@latest
 
-      - name: Build Faust
-        run: |
-          make -C build cmake BACKENDS=regular.cmake TARGETS=win-ci.cmake
-          make -C build
+    - name: Build Faust
+      run: |
+        make -C build cmake BACKENDS=regular.cmake TARGETS=win-ci.cmake
+        make -C build

--- a/build/misc/llvm.cmake
+++ b/build/misc/llvm.cmake
@@ -125,9 +125,6 @@ macro (llvm_config)
     string ( APPEND LLVM_LIBS " ${LLVM_SYS_LIBS}")
     string ( REPLACE " " ";" LLVM_LIBS ${LLVM_LIBS} )
 
-    # fix for when LLVM is built but not "installed"
-    set(LLVM_INCLUDE_DIRS ${LLVM_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS}/../build/include)
-
 endmacro()
 
 ####################################

--- a/embedded/faustgen/CMakeLists.txt
+++ b/embedded/faustgen/CMakeLists.txt
@@ -69,7 +69,7 @@ else()
 		pkg_check_modules(VORBIS REQUIRED IMPORTED_TARGET vorbis)
 		pkg_check_modules(OGG REQUIRED IMPORTED_TARGET ogg)
 		pkg_check_modules(OPUS REQUIRED IMPORTED_TARGET opus)
-		pkg_check_modules(MPG123 REQUIRED IMPORTED_TARGET libmpg123)
+		pkg_check_modules(MPG123 IMPORTED_TARGET libmpg123) # libmpg123 is not REQUIRED because it requires macos 12
 		list(POP_BACK PKG_CONFIG_EXECUTABLE)  # undo the append above
 	else()
 		# We expect the user to have installed sndfile with
@@ -80,7 +80,7 @@ else()
 		pkg_check_modules(VORBIS REQUIRED IMPORTED_TARGET vorbis)
 		pkg_check_modules(OGG REQUIRED IMPORTED_TARGET ogg)
 		pkg_check_modules(OPUS REQUIRED IMPORTED_TARGET opus)
-		pkg_check_modules(MPG123 REQUIRED IMPORTED_TARGET libmpg123)
+		pkg_check_modules(MPG123 IMPORTED_TARGET libmpg123) # libmpg123 is not REQUIRED because it requires macos 12
 	endif()
 endif()
 


### PR DESCRIPTION
It succeeded here: https://github.com/DBraun/faust/actions/runs/6844214830

* mpg123 is not installed anymore for macos arm64.
* QT5 is installed with a dedicated github action instead of brew. We can do this on the FaustLive repo too soon.
* LLVM caching was slightly cleaned up.

Earlier today I was also trying to get an ubuntu aarch64 libfaust working but ran into issues, so I'm just submitting this simpler PR.