### PR TITLE
Fix segfault in llvm-tests on linux

### DIFF
--- a/tests/llvm-tests/Makefile
+++ b/tests/llvm-tests/Makefile
@@ -10,6 +10,8 @@ LIB_OPT1 ?=
 ifeq ($(system), Darwin)
 LIB_OPT1=-framework CoreFoundation
 INC_OPT=/opt/local/include
+else ifeq ($(system), Linux)
+LDFLAGS=-Wl,--export-dynamic
 endif
 
 prefix := $(DESTDIR)$(PREFIX)
@@ -20,7 +22,7 @@ faust-dynamic-engine-test: faust-dynamic-engine-test.cpp $(LIB)/libfaust.a
 	$(CXX) -std=c++11 -O3 faust-dynamic-engine-test.cpp -DLLVM_DSP -DJACK_DRIVER -DPORTAUDIO_DRIVER -DRTAUDIO_DRIVER -DSOUNDFILE -I$(INC) -I$(INC_OPT) -lsndfile -ljack -lportaudio -lrtaudio -L$(LIB) -L$(LIB_OPT) $(LIB_OPT1) $(LIB)/libfaust.a -lpthread `llvm-config --ldflags --libs all --system-libs` -o faust-dynamic-engine-test
 
 llvm-test: llvm-test.cpp $(LIB)/libfaust.a
-	$(CXX) -std=c++11 -O3 llvm-test.cpp -I$(INC) -L$(LIB) -L$(LIB_OPT) $(LIB)/libfaust.a -lpthread `llvm-config --ldflags --libs all --system-libs` -o llvm-test
+	$(CXX) -std=c++11 -O3 llvm-test.cpp -I$(INC) -L$(LIB) -L$(LIB_OPT) $(LIB)/libfaust.a -lpthread `llvm-config --ldflags --libs all --system-libs` $(LDFLAGS) -o llvm-test
 
 # To test the LLVM backend with dynamic libfaust on Apple M1 and Rosetta
 llvm-test-x86: llvm-test.cpp 


### PR DESCRIPTION
Based on findings by @jcelerier Thanks again!

Fixed in ossia/faust-tester: https://github.com/ossia/faust-tester/commit/c780137171e2bc098026cbbf19072c4888a6daa3