### PR TITLE
teach kAND/kOR to optimize &(1) and |(1)

### DIFF
--- a/compiler/normalize/simplify.cpp
+++ b/compiler/normalize/simplify.cpp
@@ -83,6 +83,19 @@ Tree simplify(Tree sig)
 
 // Implementation
 
+static bool isSigBool(Tree sig)
+{
+    int opnum;
+    Tree t1, t2;
+
+    if (!isSigBinOp(sig, &opnum, t1, t2))
+        return false;
+    if (isBoolOpcode(opnum))
+        return true;
+
+    return isLogicalOpcode(opnum) && isSigBool(t1) && isSigBool(t2);
+}
+
 static Tree simplification(Tree sig)
 {
     faustassert(sig);
@@ -167,6 +180,12 @@ static Tree simplification(Tree sig)
             if ((opnum == kGE) || (opnum == kLE) || (opnum == kEQ)) return sigInt(1);
             if ((opnum == kGT) || (opnum == kLT) || (opnum == kNE) || (opnum == kRem) || (opnum == kXOR))
                 return sigInt(0);
+
+        } else if ((opnum == kAND) || (opnum == kOR)) {
+            if (isOne(n1) && isSigBool(t2))
+                return opnum == kAND ? t2 : sigInt(1);
+            if (isOne(n2) && isSigBool(t1))
+                return opnum == kAND ? t1 : sigInt(1);
         }
 
         return normalizeAddTerm(sig);


### PR DESCRIPTION
These BinOp's can optimize out the isMinusOne/isZero operands, but since the xxxNeutral/Absorbing predicates take a single argument they can't check another operand and take isOne() into account, so this patch adds the brute force check into simplification.

Random example,

	process = _ <: ==(1) | ==(2) <: &(1==1), |(2!=3);

compiles to

	float fTemp0 = float(input0[i0]);
	int iTemp1 = (fTemp0 == 1.0f) | (fTemp0 == 2.0f);
	output0[i0] = FAUSTFLOAT(iTemp1 & 1);
	output1[i0] = FAUSTFLOAT(iTemp1 | 1);

after this patch we have

	float fTemp0 = float(input0[i0]);
	output0[i0] = FAUSTFLOAT((fTemp0 == 1.0f) | (fTemp0 == 2.0f));
	output1[i0] = FAUSTFLOAT(1);

Should the new isSigBool() function have the "int max_recursion" argument?