### PR TITLE
Fix LLVM-17 optimization level

### DIFF
--- a/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
@@ -344,7 +344,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
         
         // Create the pass manager.
         OptimizationLevel opt_table[] = {OptimizationLevel::O0, OptimizationLevel::O1, OptimizationLevel::O2, OptimizationLevel::O3};
-        fOptLevel = std::max(fOptLevel, 3);
+        fOptLevel = std::min(fOptLevel, 3);
         ModulePassManager MPM = PB.buildPerModuleDefaultPipeline(opt_table[fOptLevel]);
         
         if ((debug_var != "") && (debug_var.find("FAUST_LLVM1") != string::npos)) {


### PR DESCRIPTION
I found this while debugging memory access error crash during stack unwinding during exception handling when parsing fails (which I'm still investigating, still not sure if that's on my end or Faust's).

Running with `-fsanitize=address` gave:
```
==53040==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00016b443df8 at pc 0x00010e10ca50 bp 0x00016b442c70 sp 0x00016b442420
READ of size 8 at 0x00016b443df8 thread T0
    #0 0x10e10ca4c in __asan_memcpy+0x37c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x50a4c)
    #1 0x10fd9e33c in llvm_dynamic_dsp_factory_aux::initJIT(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) llvm_dynamic_dsp_aux.cpp:348
    #2 0x10fda5944 in createDSPFactoryFromSignals(std::__1::basic_string<char, 
    ...
```

This looks like a simple `min`/`max` typo bug to me.