### PR TITLE
mesh2faust: Fix out-of-order arg in main.

### DIFF
--- a/tools/physicalModeling/mesh2faust/CMakeLists.txt
+++ b/tools/physicalModeling/mesh2faust/CMakeLists.txt
@@ -13,6 +13,12 @@ set(VegaDir ${CMAKE_CURRENT_SOURCE_DIR}/vega/libraries)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 
+if(APPLE)
+  set(EIGEN_INCLUDE_DIR /opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3)
+else()
+  set(EIGEN_INCLUDE_DIR /usr/include/eigen3)
+endif()
+
 add_library(${LIBRARY_NAME} STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src/mesh2faust.cpp
   ${VegaDir}/objMesh/objMesh.cpp
@@ -56,11 +62,7 @@ add_library(${LIBRARY_NAME} STATIC
 set_target_properties(${LIBRARY_NAME} PROPERTIES CXX_STANDARD 14)
 
 target_include_directories(${LIBRARY_NAME} PUBLIC src vega/libraries/include spectra/include)
-if(APPLE)
-  target_include_directories(${LIBRARY_NAME} PRIVATE /opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3)
-else()
-  target_include_directories(${LIBRARY_NAME} PRIVATE /usr/include/eigen3)
-endif()
+target_include_directories(${LIBRARY_NAME} PRIVATE ${EIGEN_INCLUDE_DIR})
 
 find_package(OpenGL REQUIRED)
 target_link_libraries(${LIBRARY_NAME} PRIVATE OpenGL::GL)
@@ -72,8 +74,11 @@ endif()
 if(INCLUDE_EXECUTABLE)
   add_executable(${PROJECT_NAME}-bin ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
 
+  target_include_directories(${PROJECT_NAME}-bin PRIVATE ${EIGEN_INCLUDE_DIR})
+
   # Link static library to the executable.
   target_link_libraries(${PROJECT_NAME}-bin PRIVATE ${LIBRARY_NAME})
-  # Remove the "-bin" suffix from the executable's name. (Only added to avoid name clash with the library.)
+
+  # Remove the "-bin" suffix from the executable's name.
   set_target_properties(${PROJECT_NAME}-bin PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 endif()

--- a/tools/physicalModeling/mesh2faust/README.md
+++ b/tools/physicalModeling/mesh2faust/README.md
@@ -28,7 +28,7 @@ This section walks you through the different steps to build and install `mesh2fa
 - Install the Eigen library:
   - Linux: `sudo apt install libeigen3-dev`
   - MacOS: `brew install eigen`
-- Build and make:
+- Build and make (from this directory):
   - `mkdir build && cd build`
   - `cmake .. && make`
 - To install, simply copy the executable to your desired binary location:

--- a/tools/physicalModeling/mesh2faust/src/main.cpp
+++ b/tools/physicalModeling/mesh2faust/src/main.cpp
@@ -179,9 +179,9 @@ int main(int argc, char **argv)
 
     string dsp = m2f::mesh2faust(
         objectFileName,
+        materialProperties,
         {
             modelName,
-            materialProperties,
             freqControl,
             modesMinFreq,
             modesMaxFreq,


### PR DESCRIPTION
Also fixes Eigen dirs not being included in executable target. (It was only included with library).

Fixes https://github.com/grame-cncm/faust/issues/986

