### PR TITLE
Fix std::remainder in JAX architecture

### DIFF
--- a/architecture/jax/minimal.py
+++ b/architecture/jax/minimal.py
@@ -29,8 +29,9 @@ from flax import linen as nn
 
 
 def remainder(x, y):
-	a = jnp.remainder(x, y)
-	return a - y*((a > y/2).astype(jnp.int32))
+	"""C++ std::remainder implemented with jax numpy"""
+	quo = jnp.round(x/y)
+	return x - quo * y
 
 
 # Generated code


### PR DESCRIPTION
This fixes an incorrect implementation of `std::remainder` in JAX. Reference: https://en.cppreference.com/w/cpp/numeric/math/remainder

Previous outputs:
```
>>> remainder(5.1,3)
Array(-0.9000001, dtype=float32, weak_type=True)
>>> remainder(-5.1,3)
Array(0.9000001, dtype=float32, weak_type=True)
>>> remainder(5.1,-3)
Array(2.1, dtype=float32, weak_type=True)
>>> remainder(-5.1,-3)
Array(-2.1, dtype=float32, weak_type=True)
```

New correct outputs:
```
>>> remainder(5.1,3)
Array(-0.9000001, dtype=float32, weak_type=True)
>>> remainder(-5.1,3)
Array(0.9000001, dtype=float32, weak_type=True)
>>> remainder(5.1,-3)
Array(-0.9000001, dtype=float32, weak_type=True)
>>> remainder(-5.1,-3)
Array(0.9000001, dtype=float32, weak_type=True)
```

Note that if we had just used jax.numpy.remainder:
```
>>> jnp.remainder(5.1,3)
Array(2.1, dtype=float32, weak_type=True)
>>> jnp.remainder(-5.1,3)
Array(0.9000001, dtype=float32, weak_type=True)
>>> jnp.remainder(5.1,-3)
Array(-0.9000001, dtype=float32, weak_type=True)
>>> jnp.remainder(-5.1,-3)
Array(-2.1, dtype=float32, weak_type=True)
```

Update: this is okay to merge but I also need to update the architecture impulse tests file: https://github.com/grame-cncm/faust/blob/bb1567047e390f84528ae65d408b0dd627c1cd1e/tests/impulse-tests/archs/impulsejax.py#L29