### PR TITLE
Adding new arch & faust2paconsole for PortAudio console

### DIFF
--- a/architecture/pa-console.cpp
+++ b/architecture/pa-console.cpp
@@ -1,0 +1,256 @@
+/************************************************************************
+ IMPORTANT NOTE : this file contains two clearly delimited sections :
+ the ARCHITECTURE section (in two parts) and the USER section. Each section
+ is governed by its own copyright and license. Please check individually
+ each section for license and copyright information.
+ *************************************************************************/
+
+/******************* BEGIN pa-console.cpp ****************/
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2003-2019 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ 
+ ************************************************************************
+ ************************************************************************/
+
+#include <libgen.h>
+#include <math.h>
+#include <iostream>
+#include <list>
+#include <vector>
+
+#include "faust/dsp/timed-dsp.h"
+#include "faust/gui/PathBuilder.h"
+#include "faust/gui/FUI.h"
+#include "faust/misc.h"
+#include "faust/gui/GUI.h"
+#include "faust/gui/JSONUI.h"
+#include "faust/gui/console.h"
+#include "faust/misc.h"
+#include "faust/audio/portaudio-dsp.h"
+#include "faust/gui/JSONUIDecoder.h"
+
+#ifdef HTTPCTRL
+#include "faust/gui/httpdUI.h"
+#endif
+
+#ifdef OSCCTRL
+#include "faust/gui/OSCUI.h"
+#endif
+
+
+// Always include this file, otherwise -nvoices only mode does not compile....
+#include "faust/gui/MidiUI.h"
+
+#ifdef MIDICTRL
+#include "faust/midi/rt-midi.h"
+#include "faust/midi/RtMidi.cpp"
+#endif
+
+using namespace std;
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ VECTOR INTRINSICS
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+<<includeIntrinsic>>
+
+/********************END ARCHITECTURE SECTION (part 1/2)****************/
+
+/**************************BEGIN USER SECTION **************************/
+
+<<includeclass>>
+
+/***************************END USER SECTION ***************************/
+
+/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+
+#include "faust/dsp/poly-dsp.h"
+
+#ifdef POLY2
+#include "faust/dsp/dsp-combiner.h"
+#include "effect.h"
+#endif
+
+dsp* DSP;
+
+list<GUI*> GUI::fGuiList;
+ztimedmap GUI::gTimedZoneMap;
+
+//-------------------------------------------------------------------------
+// 									MAIN
+//-------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    char name[256];
+    char rcfilename[256];
+    char* home = getenv("HOME");
+    bool midi_sync = false;
+    int nvoices = 0;
+    bool control = true;
+    
+    mydsp* tmp_dsp = new mydsp();
+    MidiMeta::analyse(tmp_dsp, midi_sync, nvoices);
+    delete tmp_dsp;
+
+    snprintf(name, 256, "%s", basename(argv[0]));
+    snprintf(rcfilename, 256, "%s/.%src", home, name);
+  
+    CMDUI interface(argc, argv, true);
+    FUI finterface;
+    
+    if (isopt(argv, "-h")) {
+        cout << argv[0] << " [--frequency <val>] [--buffer <val>] [--nvoices <num>] [--control <0/1>] [--group <0/1>] [--virtual-midi <0/1>]\n";
+        exit(1);
+    }
+
+    long srate = (long)lopt(argv, "--frequency", 44100);
+    int fpb = lopt(argv, "--buffer", 128);
+    bool is_virtual = lopt(argv, "--virtual-midi", false);
+     
+#ifdef POLY2
+    nvoices = lopt(argv, "--nvoices", nvoices);
+    control = lopt(argv, "--control", control);
+    int group = lopt(argv, "--group", 1);
+    
+    cout << "Started with " << nvoices << " voices\n";
+    DSP = new mydsp_poly(new mydsp(), nvoices, control, group);
+    
+#if MIDICTRL
+    if (midi_sync) {
+        DSP = new timed_dsp(new dsp_sequencer(DSP, new effect()));
+    } else {
+        DSP = new dsp_sequencer(DSP, new effect());
+    }
+#else
+    DSP = new dsp_sequencer(DSP, new effect());
+#endif
+    
+#else
+    nvoices = lopt(argv, "--nvoices", nvoices);
+    control = lopt(argv, "--control", control);
+    int group = lopt(argv, "--group", 1);
+    cout << "nvoices  " << nvoices << " voices\n";
+    
+    if (nvoices > 0) {
+        cout << "Started with " << nvoices << " voices\n";
+        DSP = new mydsp_poly(new mydsp(), nvoices, control, group);
+        
+#if MIDICTRL
+        if (midi_sync) {
+            DSP = new timed_dsp(DSP);
+        }
+#endif
+    } else {
+#if MIDICTRL
+        if (midi_sync) {
+            DSP = new timed_dsp(new mydsp());
+        } else {
+            DSP = new mydsp();
+        }
+#else
+        DSP = new mydsp();
+#endif
+    }
+#endif
+    
+    if (!DSP) {
+        cerr << "Unable to allocate Faust DSP object" << endl;
+        exit(1);
+    }
+    DSP->buildUserInterface(&interface);
+    DSP->buildUserInterface(&finterface);
+    
+    if (isopt(argv, "-h") || isopt(argv, "-help")) {
+        cout << argv[0] << " [--nvoices <num>] [--control <0/1>] [--group <0/1>]\n";
+        interface.printhelp_init();
+    }
+ 
+#ifdef HTTPCTRL
+    httpdUI httpdinterface(name, DSP->getNumInputs(), DSP->getNumOutputs(), argc, argv);
+    DSP->buildUserInterface(&httpdinterface);
+    cout << "HTTPD is on" << endl;
+#endif
+    
+    
+    portaudio audio(srate, fpb);
+    if (!audio.init(name, DSP)) {
+        cerr << "Unable to init audio" << endl;
+        exit(1);
+    }
+    
+#ifdef OSCCTRL
+    OSCUI oscinterface(name, argc, argv);
+    DSP->buildUserInterface(&oscinterface);
+#endif
+
+#ifdef MIDICTRL
+    rt_midi midi_handler(name, is_virtual);
+    MidiUI midiinterface(&midi_handler);
+    DSP->buildUserInterface(&midiinterface);
+    cout << "MIDI is on" << endl;
+#endif
+    
+    // First restore the state
+    finterface.recallState(rcfilename);
+    
+    // The process commands possibly updates it
+    interface.process_command();
+    
+    if (!audio.start()) {
+        cerr << "Unable to start audio" << endl;
+        exit(1);
+    }
+
+    cout << "ins " << audio.getNumInputs() << endl;
+    cout << "outs " << audio.getNumOutputs() << endl;
+ 
+#ifdef HTTPCTRL
+    httpdinterface.run();
+#endif
+
+#ifdef OSCCTRL
+    oscinterface.run();
+#endif
+    
+#ifdef MIDICTRL
+    if (!midiinterface.run()) {
+        cerr << "MidiUI run error\n";
+    }
+#endif
+    
+    interface.run();
+   
+#ifdef MIDICTRL
+    midiinterface.stop();
+#endif
+
+    audio.stop();
+    finterface.saveState(rcfilename);
+
+    return 0;
+}
+
+/******************* END pa-console.cpp ****************/

--- a/tools/faust2appls/faust2paconsole
+++ b/tools/faust2appls/faust2paconsole
@@ -1,0 +1,150 @@
+#! /bin/bash -e
+
+#######################################################
+#                                                     #
+#    Compiles Faust programs to PortAudio (no GUI)    #
+#    (c) Grame, 2009-2019                             #
+#                                                     #
+#######################################################
+
+. faustpath
+. faustoptflags
+. usage.sh
+
+CXXFLAGS+=" $MYGCCFLAGS"  # So that additional CXXFLAGS can be used
+
+ARCHFILE=$FAUSTARCH/pa-console.cpp
+
+OSCDEFS=""
+NVOICES=-1
+SOUNDFILE="0"
+SOUNDFILEDEFS=""
+SOUNDFILELIBS=""
+
+# Check Darwin specifics
+#
+if [[ $(uname) == Darwin ]]; then
+    ARCHLIB="-L/usr/local/lib -lportaudio -framework CoreMIDI -framework CoreFoundation -framework CoreAudio -framework AudioUnit -framework CoreServices"
+else
+    ARCHLIB="-L/usr/local/lib -lportaudio -lasound"
+fi
+
+
+echoHelp()
+{
+    usage faust2paconsole "[options] [Faust options] <file.dsp>"
+    require PortAudio
+    echo "Compiles Faust programs to PortAudio"
+    option
+    options -httpd -osc -midi
+    option "-nvoices <num>"
+    option "-effect <effect.dsp>"
+    option "-effect auto"
+    option "Faust options"
+    exit
+}
+
+if [ "$#" -eq 0 ]; then
+    echo 'Please, provide a Faust file to process !'
+    echo ''
+    echoHelp
+fi
+
+#-------------------------------------------------------------------
+# Analyze command arguments :
+# faust options                 -> OPTIONS
+# existing *.dsp files          -> FILES
+#
+
+# dispatch command arguments
+while [ $1 ]
+do
+    p=$1
+
+    if [ $p = "-help" ] || [ $p = "-h" ]; then
+        echoHelp
+    elif [ $p = "-osc" ]; then
+        OSCDEFS="-DOSCCTRL -lOSCFaust"
+    elif [ $p = "-httpd" ]; then
+        HTTPDEFS="-DHTTPCTRL -lHTTPDFaust"
+        HTTPLIBS=`pkg-config --cflags --libs libmicrohttpd`
+    elif [ $p = "-nvoices" ]; then
+        POLYDEFS="-DPOLY"
+        shift
+        NVOICES=$1
+        if [ $NVOICES -ge 0 ]; then
+            CXXFLAGS="$CXXFLAGS -DNVOICES=$NVOICES"
+        fi
+    elif [ $p = "-effect" ]; then
+        POLYDEFS="-DPOLY2"
+        POLY="POLY2"
+        shift
+        EFFECT=$1
+    elif [ $p = "-midi" ]; then
+        MIDIDEFS="-DMIDICTRL"
+    elif [ $p = "-soundfile" ]; then
+        SOUNDFILE="1"
+        SOUNDFILEDEFS="-DSOUNDFILE"
+        SOUNDFILELIBS=`pkg-config --cflags --static --libs sndfile`
+    elif [ $p = "-arch32" ]; then
+        PROCARCH="-m32 -L/usr/lib32"
+    elif [ $p = "-arch64" ]; then
+        PROCARCH="-m64"
+    elif [ ${p:0:1} = "-" ]; then
+        OPTIONS="$OPTIONS $p"
+    elif [[ -f "$p" ]] && [ ${p: -4} == ".dsp" ]; then
+        FILES="$FILES $p"
+    else
+        OPTIONS="$OPTIONS $p"
+    fi
+
+shift
+
+done
+
+#-------------------------------------------------------------------
+# compile the *.dsp files
+#
+for f in $FILES; do
+
+    # compile faust to c++
+    if [ $POLY = "POLY2" ]; then
+        if [ $EFFECT = "auto" ]; then
+            cat > effect.dsp << EndOfCode
+            adapt(1,1) = _;
+            adapt(2,2) = _,_;
+            adapt(1,2) = _ <: _,_;
+            adapt(2,1) = _,_ :> _;
+            adaptor(F,G) = adapt(outputs(F),inputs(G));
+            process = adaptor(library("$f").process, library("$f").effect) : library("$f").effect;
+EndOfCode
+            faust -i -json -a $ARCHFILE $OPTIONS "$f" -o "$f.cpp" || exit
+            faust -i -cn effect -a minimal-effect.cpp effect.dsp -o effect.h || exit
+            rm effect.dsp
+        else
+            faust -i -json -a $ARCHFILE $OPTIONS "$f" -o "$f.cpp" || exit
+            faust -i -cn effect -a minimal-effect.cpp "$EFFECT" -o "effect.h" || exit
+        fi
+    else
+        faust -i -a $ARCHFILE $OPTIONS "$f" -o "$f.cpp"|| exit
+    fi
+
+    # compile c++ to binary
+    (
+        $CXX $CXXFLAGS $FAUSTTOOLSFLAGS "$f.cpp" -I/usr/local/include -L/usr/local/lib \
+            $PROCARCH $SOUNDFILELIBS $OSCDEFS $HTTPDEFS $HTTPLIBS $MIDIDEFS $POLYDEFS \
+            $SOUNDFILEDEFS $ARCHLIB \
+            -ldl -pthread -o "${f%.dsp}"
+        if [[ $(uname) == Darwin ]]; then
+            codesign --sign - --deep --force "${f%.dsp}"
+        fi
+    ) > /dev/null || exit
+
+    # remove temporary files
+    rm -f "$f.cpp" effect.h "$f.json"
+
+    # collect binary file name for FaustWorks
+    BINARIES="$BINARIES${f%.dsp};"
+done
+
+echo $BINARIES


### PR DESCRIPTION
This PR adds the ability for users to build GUI-less/console-only apps for the PortAudio cross-platform lib.

N.B. not tested on Mac or Windows, but heavily based on the existing files for `faust2jackconsole`, so I based the structure here on that, and intel gathered in the `faust2paqt` and `pa-qt.cpp` files. I can verify that for sure this compiled and worked fine on Linux.