### PR TITLE
Added Core Audio + Console architecture

### DIFF
--- a/architecture/ca-console.cpp
+++ b/architecture/ca-console.cpp
@@ -1,0 +1,281 @@
+/************************************************************************
+ IMPORTANT NOTE : this file contains two clearly delimited sections :
+ the ARCHITECTURE section (in two parts) and the USER section. Each section
+ is governed by its own copyright and license. Please check individually
+ each section for license and copyright information.
+ *************************************************************************/
+
+/******************* BEGIN ca-console.cpp ****************/
+
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2021 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ 
+ ************************************************************************
+ ************************************************************************/
+
+#include <libgen.h>
+#include <stdlib.h>
+#include <iostream>
+#include <string>
+#include <list>
+
+#include "faust/dsp/proxy-dsp.h"
+#include "faust/dsp/timed-dsp.h"
+#include "faust/dsp/dsp-adapter.h"
+#include "faust/gui/FUI.h"
+#include "faust/gui/GUI.h"
+#include "faust/gui/JSONUI.h"
+#include "faust/gui/PresetUI.h"
+#include "faust/gui/console.h"
+#include "faust/misc.h"
+#include "faust/audio/coreaudio-dsp.h"
+//#ifdef FIXED_POINT
+//#include "faust/dsp/fixed-point.h"
+//#endif
+
+#ifdef OSCCTRL
+#include "faust/gui/OSCUI.h"
+#endif
+
+#ifdef HTTPCTRL
+#include "faust/gui/httpdUI.h"
+#endif
+
+#ifdef SOUNDFILE
+#include "faust/gui/SoundUI.h"
+#endif
+
+// Always include this file, otherwise -nvoices only mode does not compile....
+#include "faust/gui/MidiUI.h"
+
+#ifdef MIDICTRL
+#include "faust/midi/rt-midi.h"
+#include "faust/midi/RtMidi.cpp"
+#endif
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ VECTOR INTRINSICS
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+<<includeIntrinsic>>
+
+/********************END ARCHITECTURE SECTION (part 1/2)****************/
+
+/**************************BEGIN USER SECTION **************************/
+
+<<includeclass>>
+
+/***************************END USER SECTION ***************************/
+
+/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+
+#include "faust/dsp/poly-dsp.h"
+
+#ifdef POLY2
+#include "faust/dsp/dsp-combiner.h"
+#include "effect.h"
+#endif
+
+using namespace std;
+
+dsp* DSP;
+
+list<GUI*> GUI::fGuiList;
+ztimedmap GUI::gTimedZoneMap;
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ MAIN PLAY THREAD
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+int main(int argc, char* argv[])
+{
+    char name[256];
+    char rcfilename[256];
+    char* home = getenv("HOME");
+    bool midi_sync = false;
+    bool midi = false;
+    int nvoices = 0;
+    bool control = true;
+    
+    if (isopt(argv, "-help") || isopt(argv, "-h")) {
+        cout << argv[0] << " [--frequency <val>] [--buffer <val>] [--nvoices <val>] [--control <0/1>] [--group <0/1>] [--virtual-midi <0/1>]\n";
+        exit(1);
+    }
+    
+    mydsp* tmp_dsp = new mydsp();
+    MidiMeta::analyse(tmp_dsp, midi, midi_sync, nvoices);
+    delete tmp_dsp;
+    
+    snprintf(name, 256, "%s", basename(argv[0]));
+    snprintf(rcfilename, 256, "%s/.%src", home, name);
+    
+    long srate = (long)lopt(argv, "--frequency", -1);
+    int fpb = lopt(argv, "--buffer", 512);
+    bool is_virtual = lopt(argv, "--virtual-midi", false);
+    
+#ifdef POLY2
+    nvoices = lopt(argv, "--nvoices", nvoices);
+    control = lopt(argv, "--control", control);
+    int group = lopt(argv, "--group", 1);
+    
+    cout << "Started with " << nvoices << " voices\n";
+    DSP = new mydsp_poly(new mydsp(), nvoices, control, group);
+    
+#if MIDICTRL
+    if (midi_sync) {
+        DSP = new timed_dsp(new dsp_sequencer(DSP, new effect()));
+    } else {
+        DSP = new dsp_sequencer(DSP, new effect());
+    }
+#else
+    DSP = new dsp_sequencer(DSP, new effect());
+#endif
+    
+#else
+    nvoices = lopt(argv, "--nvoices", nvoices);
+    control = lopt(argv, "--control", control);
+    int group = lopt(argv, "--group", 1);
+    
+    if (nvoices > 0) {
+        cout << "Started with " << nvoices << " voices\n";
+        DSP = new mydsp_poly(new mydsp(), nvoices, control, group);
+        
+#if MIDICTRL
+        if (midi_sync) {
+            DSP = new timed_dsp(DSP);
+        }
+#endif
+        
+    } else {
+#if MIDICTRL
+        if (midi_sync) {
+            DSP = new timed_dsp(new mydsp());
+        } else {
+            DSP = new mydsp();
+        }
+#else
+        DSP = new mydsp();
+#endif
+    }
+    
+#endif
+    
+    if (!DSP) {
+        cerr << "Unable to allocate Faust DSP object" << endl;
+        exit(1);
+    }
+    
+    CMDUI* interface = new CMDUI(argc, argv, true);
+    FUI finterface;
+    
+#ifdef PRESETUI
+    string preset_dir = PresetUI::getPresetDir();
+    cout << "Final preset_dir: " << preset_dir << endl;
+    PresetUI::tryCreateDirectory(preset_dir);
+    PresetUI pinterface(interface, preset_dir + "/" + ((nvoices > 0) ? "poly_" : ""));
+    DSP->buildUserInterface(&pinterface);
+#else
+    DSP->buildUserInterface(interface);
+    DSP->buildUserInterface(&finterface);
+#endif
+    
+#ifdef MIDICTRL
+    rt_midi midi_handler(name, is_virtual);
+    MidiUI midiinterface(&midi_handler);
+    DSP->buildUserInterface(&midiinterface);
+    cout << "MIDI is on" << endl;
+#endif
+    
+#ifdef HTTPCTRL
+    httpdUI httpdinterface(name, DSP->getNumInputs(), DSP->getNumOutputs(), argc, argv);
+    DSP->buildUserInterface(&httpdinterface);
+    cout << "HTTPD is on" << endl;
+#endif
+    
+    coreaudio audio(srate, fpb);
+    if (!audio.init(name, DSP)) {
+        cerr << "Unable to init audio" << endl;
+        exit(1);
+    }
+   
+// After audio init to get SR
+#ifdef SOUNDFILE
+    // Use bundle path
+    SoundUI soundinterface("", audio.getSampleRate());
+    DSP->buildUserInterface(&soundinterface);
+#endif
+    
+#ifdef OSCCTRL
+    OSCUI oscinterface(name, argc, argv);
+    DSP->buildUserInterface(&oscinterface);
+    cout << "OSC is on" << endl;
+#endif
+    
+    if (!audio.start()) {
+        cerr << "Unable to start audio" << endl;
+        exit(1);
+    }
+    
+    cout << "ins " << audio.getNumInputs() << endl;
+    cout << "outs " << audio.getNumOutputs() << endl;
+    
+#ifdef HTTPCTRL
+    httpdinterface.run();
+#endif
+    
+#ifdef OSCCTRL
+    oscinterface.run();
+#endif
+    
+#ifdef MIDICTRL
+    if (!midiinterface.run()) {
+        cerr << "MidiUI run error " << endl;
+    }
+#endif
+    
+    // After the allocation of controllers
+    finterface.recallState(rcfilename);
+    
+    interface->run();
+    
+#ifdef MIDICTRL
+    midiinterface.stop();
+#endif
+    
+    audio.stop();
+    finterface.saveState(rcfilename);
+    delete interface;
+    
+    delete DSP;
+    return 0;
+}
+
+/******************** END ca-console.cpp ****************/
+

--- a/tools/faust2appls/faust2caconsole
+++ b/tools/faust2appls/faust2caconsole
@@ -1,0 +1,162 @@
+#! /bin/bash -e
+
+#####################################################################
+#                                                                   #
+#               Compiles Faust programs to CoreAudio-Console        #
+#               (c) Grame, 2021                                     #
+#                                                                   #
+#####################################################################
+
+. faustpath
+. faustoptflags
+. usage.sh
+
+CXXFLAGS+=" $MYGCCFLAGS -I/opt/local/include" # So that additional CXXFLAGS can be used
+
+ARCHFILE=$FAUSTARCH/ca-console.cpp
+
+OSCDEFS=""
+POLY="POLY"
+NVOICES=-1
+SOUNDFILE="0"
+SOUNDFILEDEFS=""
+SOUNDFILELIBS=""
+PRESETDIR="auto"
+PRESETDEFS=""
+
+ARCHLIB+=" -framework CoreMIDI -framework CoreFoundation -framework CoreAudio -framework AudioUnit -framework CoreServices"
+
+echoHelp() 
+{
+    usage faust2caconsole "[options] [Faust options] <file.dsp>"
+    platform MacOS
+    echo "Compiles Faust programs to CLI and CoreAudio"
+    option
+    options -httpd -osc -midi -soundfile -dyn
+    option -resample "to resample soundfiles to the audio driver sample rate."
+    option "-nvoices <num>"
+    option "-effect <effect.dsp>"
+    option "-effect auto"
+    option "-preset <directory>" "add a preset manager on top of GUI and save the preset files in the given directory"
+    option "-preset auto" "add a preset manager on top of GUI and save the preset files in a system temporary directory"
+    option "Faust options"
+    exit
+}
+
+if [ "$#" -eq 0 ]; then
+    echo 'Please, provide a Faust file to process !'
+    echo ''
+    echoHelp
+fi
+
+#PHASE 2 : dispatch command arguments
+while [ $1 ]
+do
+    p=$1
+
+    if [ $p = "-help" ] || [ $p = "-h" ]; then
+       echoHelp
+    elif [ $p = "-nvoices" ]; then
+        POLYDEFS="-DPOLY"
+        shift
+        NVOICES=$1
+        if [ $NVOICES -ge 0 ]; then
+            CXXFLAGS="$CXXFLAGS -DNVOICES=$NVOICES"
+        fi
+    elif [ $p = "-effect" ]; then
+        POLYDEFS="-DPOLY2"
+        POLY="POLY2"
+        shift
+        EFFECT=$1
+    elif [ $p = "-midi" ]; then
+        MIDIDEFS="-DMIDICTRL"
+    elif [ $p = "-dyn" ]; then
+        OPTIONS="$OPTIONS -inj template-llvm.cpp"
+        LLVM_LIBS="$STRIP $FAUSTLDDIR/libfaust.a `llvm-config --ldflags --libs all --system-libs`"
+    elif [ $p = "-soundfile" ]; then
+        SOUNDFILE="1"
+        SOUNDFILEDEFS="-DSOUNDFILE"
+        SOUNDFILELIBS=`pkg-config --cflags --static --libs sndfile`
+    elif [ $p = "-resample" ]; then
+        SAMPLERATEDEFS="-DSAMPLERATE"
+        SAMPLERATELIBS=`pkg-config --cflags --static --libs samplerate`
+    elif [ $p = "-fx" ]; then
+        OPTIONS="$OPTIONS $p"
+        CXXFLAGS="$CXXFLAGS -I /usr/local/include/ap_fixed -DFIXED_POINT"
+    elif [ $p = "-osc" ]; then
+        OSCDEFS="-DOSCCTRL -lOSCFaust"
+    elif [ $p = "-httpd" ]; then
+        HTTPDEFS="-DHTTPCTRL -lHTTPDFaust"
+        HTTPLIBS=`pkg-config --cflags --libs libmicrohttpd`
+    elif [ "$p" = "-preset" ]; then
+        PRESETDEFS="-DPRESETUI"
+        shift
+        PRESETDIR=$1
+    elif [ ${p:0:1} = "-" ]; then
+        OPTIONS="$OPTIONS $p"
+    elif [[ -f "$p" ]] && [ ${p: -4} == ".dsp" ]; then
+        FILES="$FILES $p"
+    else
+        OPTIONS="$OPTIONS $p"
+    fi
+
+shift
+
+done
+
+#-------------------------------------------------------------------
+# compile the *.dsp files using CA-CONSOLE
+#
+for f in $FILES; do
+
+    # compile faust to c++
+    if [ $POLY = "POLY2" ]; then
+        if [ $EFFECT = "auto" ]; then
+            cat > effect.dsp << EndOfCode
+            adapt(1,1) = _;
+            adapt(2,2) = _,_;
+            adapt(1,2) = _ <: _,_;
+            adapt(2,1) = _,_ :> _;
+            adaptor(F,G) = adapt(outputs(F),inputs(G));
+            process = adaptor(library("$f").process, library("$f").effect) : library("$f").effect;
+EndOfCode
+            faust -i -json -a $ARCHFILE $OPTIONS "$f" -o "${f%.dsp}_tmp.cpp" || exit
+            faust -i -cn effect -a minimal-effect.cpp effect.dsp -o effect.h || exit
+            rm effect.dsp
+        else
+            faust -i -json -a $ARCHFILE $OPTIONS "$f" -o "${f%.dsp}_tmp.cpp" || exit
+            faust -i -cn effect -a minimal-effect.cpp "$EFFECT" -o "effect.h" || exit
+        fi
+    else
+        faust -i -a $ARCHFILE $OPTIONS "$f" -o "${f%.dsp}_tmp.cpp"|| exit
+    fi
+
+    # add preset management
+    if [ $PRESETDIR = "auto" ]; then
+        PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
+        echo "#define PRESETDIR \"auto\"" > "$PRESETFILE"
+    else
+        PRESETFILE=`mktemp -t preset.XXXXXXXXXX.cpp` || exit 1
+        echo "#define PRESETDIR \"$PRESETDIR\"" > "$PRESETFILE"
+    fi
+    cat "$PRESETFILE" "${f%.dsp}_tmp.cpp" > "${f%.dsp}.cpp"
+    rm "$PRESETFILE" "${f%.dsp}_tmp.cpp"
+
+    # compile c++ to binary
+    (
+        $CXX $CXXFLAGS $FAUSTTOOLSFLAGS "${f%.dsp}.cpp" `pkg-config --cflags --libs $OCVLIBS` $LLVM_LIBS $SOUNDFILELIBS $SAMPLERATELIBS $PROCARCH $OSCDEFS $HTTPDEFS $HTTPLIBS $OCVDEFS $MIDIDEFS $POLYDEFS $SOUNDFILEDEFS $SAMPLERATEDEFS $PRESETDEFS $ARCHLIB $LFLAGS -o "${f%.dsp}"
+        
+        if [[ $(uname) == Darwin ]];  then
+            codesign --sign - --deep --force "${f%.dsp}"
+        fi
+
+    ) > /dev/null || exit
+
+    # remove temporary files
+    rm -f "${f%.dsp}.cpp" effect.h "$f.json"
+
+    # collect binary file name for FaustWorks
+    BINARIES="$BINARIES${f%.dsp};"
+done
+
+echo $BINARIES


### PR DESCRIPTION
Added coreaudio / console support, derived from Core Audio / GTK, with the GTK part replaced by Console.

This allows local development on Mac OS without dependencies on GTK or QT.  To access a graphical UI, enable Httpd.

Tested to work on Intel/Catalina (2012 MBP) with midi, httpd.  The Core Audio part from Core Audio + GTK is untouched, so it should work with newer Mac computers and OS.

3 lines commented out for Fix Point support, as I'm unsure how this can be tested.  In theory uncommenting them will work.