### PR TITLE
Remove use of realpath

### DIFF
--- a/architecture/chaos-stratus/build-effect.sh
+++ b/architecture/chaos-stratus/build-effect.sh
@@ -7,7 +7,7 @@ _term() {
   exit 0
 }
 
-MY_PATH=$(dirname $(realpath $0))
+MY_PATH=$(cd $(dirname $0); pwd
 . ${MY_PATH}/_pedal-tools.sh
 
 EFFECT_CPP=${1:-${EFFECT_CPP:?first argument must be the CPP file path}}

--- a/architecture/chaos-stratus/build-install-effect.sh
+++ b/architecture/chaos-stratus/build-install-effect.sh
@@ -7,7 +7,7 @@ _term() {
   exit 0
 }
 
-MY_PATH=$(dirname $(realpath $0))
+MY_PATH=$(cd $(dirname $0); pwd)
 . ${MY_PATH}/_pedal-tools.sh
 
 EFFECT_DSP=${1:-${EFFECT_DSP:?First argument must be the DSP file path}}

--- a/architecture/chaos-stratus/install-effect.sh
+++ b/architecture/chaos-stratus/install-effect.sh
@@ -7,7 +7,7 @@ _term() {
   exit 0
 }
 
-MY_PATH=$(dirname $(realpath $0))
+MY_PATH=$(cd $(dirname $0); pwd)
 . ${MY_PATH}/_pedal-tools.sh
 
 EFFECT_DSP=${1:-${EFFECT_DSP:?First argument must be the DSP file path}}


### PR DESCRIPTION
realpath is cool, but it hasn't become ubiquitous yet, so I replace it with a more widely compatible technique to get a scripts home location.