### PR TITLE
Pd multichannel improvements

### DIFF
--- a/architecture/puredata.cpp
+++ b/architecture/puredata.cpp
@@ -349,11 +349,6 @@ static t_class *faust_class;
 
 struct t_faust {
     t_object x_obj;
-#ifdef __MINGW32__
-    /* This seems to be necessary as some as yet undetermined Pd routine seems
-     to write past the end of x_obj on Windows. */
-    int fence; /* dummy field (not used) */
-#endif
     mydsp *dsp;
     PdUI *ui;
     std::string *label;


### PR DESCRIPTION
Continuation of https://github.com/grame-cncm/faust/pull/1034.

Tries to address the issues raised in https://github.com/grame-cncm/faust/pull/1034#issuecomment-2225892623.

First, make the first inlet a pure message inlet, so users can not accidentally connect it to a signal.

As a second step, add the `MESSAGE_INLET` macro to control the behavior of the first inlet at compile time.

If 0, the first inlet is a signal inlet and also takes messages, which is more idiomatic, but not backwards compatible.

If 1, keep the old behavior (= default).