### PR TITLE
pd: fix outlet order regression

### DIFF
--- a/tools/faust2appls/faust2puredata
+++ b/tools/faust2appls/faust2puredata
@@ -16,7 +16,7 @@ CXXFLAGS+=" $MYGCCFLAGS"  # So that additional CXXFLAGS can be used
 COMPILE=yes
 ARCHFILE=$FAUSTARCH/puredata.cpp
 
-MI="1"
+NEWIO="0"
 
 echoHelp()
 {
@@ -27,7 +27,7 @@ echoHelp()
     option -arch32 "compile a 32 bits architecture."
     option -arch64 "compile a 64 bits architecture."
     option -poly "generates a polyphonic self-contained DSP."
-    option -msi "use a first inlet handing messages and signal."
+    option -newio "use new inlet and outlet structure."
     option -tosource "skip the C++ compiling step and only generate the C++ source file."
     option "Faust options"
     exit
@@ -57,8 +57,8 @@ for p in $@; do
         F2PDPOLY="-n 8"
     elif [ $p = "-arch64" ]; then
         PROCARCH="-m64"
-    elif [ $p = "-msi" ]; then
-        MI="0"
+    elif [ $p = "-newio" ]; then
+        NEWIO="1"
     elif [ $p = "-tosource" ]; then
         COMPILE=no
     elif [ ${p:0:1} = "-" ]; then
@@ -116,11 +116,11 @@ for p in $FILES; do
         if [[ $(uname) == Darwin || $CROSSTARGET == Darwin ]]; then
             # universal binaries produced on M1
             if [ $(uname -p) == arm ]; then
-                $CXX -arch arm64 $CXXFLAGS  $FAUSTTOOLSFLAGS -DMESSAGE_INLET=$MI $OMP $LIB -Dmydsp=${f%.dsp} -o ${f%.dsp}.arm64 $CXX_SOURCE || exit
-                $CXX -arch x86_64 $CXXFLAGS $FAUSTTOOLSFLAGS -DMESSAGE_INLET=$MI $OMP $LIB -Dmydsp=${f%.dsp} -o ${f%.dsp}.x86_64 $CXX_SOURCE || exit
+                $CXX -arch arm64 $CXXFLAGS  $FAUSTTOOLSFLAGS -DNEWIO=$NEWIO $OMP $LIB -Dmydsp=${f%.dsp} -o ${f%.dsp}.arm64 $CXX_SOURCE || exit
+                $CXX -arch x86_64 $CXXFLAGS $FAUSTTOOLSFLAGS -DNEWIO=$NEWIO $OMP $LIB -Dmydsp=${f%.dsp} -o ${f%.dsp}.x86_64 $CXX_SOURCE || exit
                 $LIPO -create "${f%.dsp}.arm64" "${f%.dsp}.x86_64" -output "${f%.dsp}$EXT" || exit
             else
-                $CXX $CXXFLAGS $FAUSTTOOLSFLAGS -DMESSAGE_INLET=$MI $OMP $LIB -Dmydsp=${f%.dsp} -o "${f%.dsp}$EXT" $CXX_SOURCE || exit
+                $CXX $CXXFLAGS $FAUSTTOOLSFLAGS -DNEWIO=$NEWIO $OMP $LIB -Dmydsp=${f%.dsp} -o "${f%.dsp}$EXT" $CXX_SOURCE || exit
             fi
             if which codesign > /dev/null; then
                 codesign --sign - --deep --force "${f%.dsp}$EXT"
@@ -129,10 +129,10 @@ for p in $FILES; do
             $CXX $CXXFLAGS $FAUSTTOOLSFLAGS $PROCARCH $OMP $LIB -Dmydsp=${f%.dsp} -o ${f%.dsp}$EXT $CXX_SOURCE || exit
         fi
         if [ $(which faust2pd) ]; then
-            if [ "$MI" == "1" ]; then
+            if [ "$NEWIO" == "0" ]; then
                 faust2pd -s $F2PDPOLY $f.xml
             else
-                echo "WARNING : -msi cannot yet be used with faust2pd"
+                echo "WARNING : -newio cannot yet be used with faust2pd"
             fi
         fi
         ) > /dev/null || exit
@@ -141,7 +141,7 @@ for p in $FILES; do
         cp "$TMP/${f%.dsp}$EXT" "$SRCDIR/${f%.dsp}$EXT"
         # collects all the files produced
         OUTPUTS="$OUTPUTS$SRCDIR/${f%.dsp}$EXT;"
-        if [[ $(which faust2pd) && "$MI" == "1" ]]; then
+        if [[ $(which faust2pd) && "$NEWIO" == "0" ]]; then
             cp "$TMP/${f%.dsp}.pd" "$SRCDIR/${f%.dsp}.pd"
             OUTPUTS="$OUTPUTS$SRCDIR/${f%.dsp}.pd;"
         fi


### PR DESCRIPTION
See https://github.com/grame-cncm/faust/pull/1037#issuecomment-2228487205

I've renamed `MESSAGE_INLET` to `NEWIO` because the new behavior changes both the inlet and outlet structure. (The old behavior is still the default due to backwards compatibility.)

I've also renamed '-msi'  to '-newio' in 'faust2puredata' script. If you find a better name, feel free to edit :)

@alainbonardi I'm pretty optimistic that I didn't break anything, but to be 100% sure, please test again with the four combinations.