### PR TITLE
Add lint for nondeterministic pointer comparison

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "tools/physicalModeling/mesh2faust/spectra"]
 	path = tools/physicalModeling/mesh2faust/spectra
 	url = https://github.com/yixuan/spectra.git
+[submodule "node-matcher-plugin"]
+	path = node-matcher-plugin
+	url = git@github.com:nuchi/node-matcher-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/yixuan/spectra.git
 [submodule "node-matcher-plugin"]
 	path = node-matcher-plugin
-	url = git@github.com:nuchi/node-matcher-plugin.git
+	url = https://github.com/nuchi/node-matcher-plugin.git

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ remote : developer
 	$(MAKE) -C embedded/faustremote all
 
 debug :
-	$(MAKE) -C $(BUILDLOCATION) FAUSTDIR=faustdebug CMAKEOPT=-DCMAKE_BUILD_TYPE=Debug
+	$(MAKE) -C $(BUILDLOCATION) FAUSTDIR=faustdebug RELEASE_TYPE=Debug NONDETERMINISM_LINT=yes
 #	$(MAKE) -C compiler debug -f $(MAKEFILE) prefix=$(prefix)
 
 ioslib :

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -40,6 +40,7 @@ option ( INCLUDE_WASM_GLUE   "Include wasm glue targets" on )
 option ( MSVC_STATIC         "Use static runtimes with MSVC" off)
 option ( SELF_CONTAINED_LIBRARY    "Don't search system architecture files." off)
 option ( LINK_LLVM_STATIC "Link LLVM statically" on )
+option ( NONDETERMINISM_LINT "Add compiler warning for nondeterminism" off)
 
 #######################################
 # Check output options
@@ -172,13 +173,20 @@ endif()
 
 ####################################
 # compiler dependent settings
+
+if (NONDETERMINISM_LINT)
+    # Add NodeMatcherPlugin as a submodule
+    add_subdirectory(../node-matcher-plugin node-matcher-plugin)
+    set (EXTRA_CXX_FLAGS "-fplugin=node-matcher-plugin/NodeMatcherPlugin.dylib -fplugin-arg-NodeMatcherPlugin-${CMAKE_CURRENT_SOURCE_DIR}/lint.query")
+endif()
+
 if (MSVC)
     set (FAUST_DEFINITIONS ${FAUST_DEFINITIONS} -DMSVisualStudio)
 else()
     set (FAUST_DEFINITIONS ${FAUST_DEFINITIONS} -DLIBDIR="${LIBSDIR}")
     #set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual -Wshadow")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual -Wshadow")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual")
+    set(CMAKE_CXX_FLAGS_DEBUG "${EXTRA_CXX_FLAGS} -g -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual -Wshadow")
+    set(CMAKE_CXX_FLAGS_RELEASE "${EXTRA_CXX_FLAGS} -O3 -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-overloaded-virtual")
 endif()
 
 ####################################
@@ -186,6 +194,9 @@ endif()
 ####################################
 if (INCLUDE_EXECUTABLE)
     add_executable(faust ${SRC} ${HH})
+    if (NONDETERMINISM_LINT)
+        add_dependencies(faust NodeMatcherPlugin)
+    endif()
     target_compile_definitions (faust PRIVATE ${FAUST_DEFINITIONS})
     if(INCLUDE_LLVM)
         target_link_directories(faust PRIVATE "${LLVM_LIB_DIR}")
@@ -201,6 +212,9 @@ endif()
 # static faust library
 if (INCLUDE_STATIC)
     add_library(staticlib STATIC ${SRC} ${HH})
+    if (NONDETERMINISM_LINT)
+        add_dependencies(staticlib NodeMatcherPlugin)
+    endif()
     target_compile_definitions (staticlib PRIVATE ${FAUST_DEFINITIONS})
     if(INCLUDE_LLVM)
         target_link_directories(staticlib PRIVATE "${LLVM_LIB_DIR}")
@@ -239,6 +253,9 @@ endif()
 # dynamic faust library
 if (INCLUDE_DYNAMIC)
     add_library(dynamiclib SHARED ${SRC} ${HH})
+    if (NONDETERMINISM_LINT)
+        add_dependencies(dynamiclib NodeMatcherPlugin)
+    endif()
     target_compile_definitions (dynamiclib PRIVATE ${FAUST_DEFINITIONS})
     if(INCLUDE_LLVM)
         target_link_directories(dynamiclib PRIVATE "${LLVM_LIB_DIR}")

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -175,9 +175,15 @@ endif()
 # compiler dependent settings
 
 if (NONDETERMINISM_LINT)
+    if(APPLE)
+        set (PLUGIN_EXT "dylib")
+    else()
+        set (PLUGIN_EXT "so")
+    endif()
+
+    set (EXTRA_CXX_FLAGS "-fplugin=node-matcher-plugin/NodeMatcherPlugin.${PLUGIN_EXT} -fplugin-arg-NodeMatcherPlugin-${CMAKE_CURRENT_SOURCE_DIR}/lint.query")
     # Add NodeMatcherPlugin as a submodule
     add_subdirectory(../node-matcher-plugin node-matcher-plugin)
-    set (EXTRA_CXX_FLAGS "-fplugin=node-matcher-plugin/NodeMatcherPlugin.dylib -fplugin-arg-NodeMatcherPlugin-${CMAKE_CURRENT_SOURCE_DIR}/lint.query")
 endif()
 
 if (MSVC)

--- a/build/Makefile
+++ b/build/Makefile
@@ -66,8 +66,18 @@ ifeq ($(WORKLET), on)
 WORKLETOPT = "-DWORKLET=on"
 endif
 
-CMAKEOPT ?= -DCMAKE_BUILD_TYPE=Release $(WORKLETOPT)
-BUILDOPT ?= --config Release
+NONDETERMINISM_LINT ?= no
+NONDETERMINISM_LINT_OPT =
+CXX_COMPILER_OPT =
+ifeq ($(NONDETERMINISM_LINT), yes)
+NONDETERMINISM_LINT_OPT = "-DNONDETERMINISM_LINT=ON"
+CXX_COMPILER_OPT = "-DCMAKE_CXX_COMPILER=$(shell llvm-config --bindir)/clang++"
+endif
+
+RELEASE_TYPE ?= Release
+CMAKEOPT ?=
+BUILDOPT ?= --config $(RELEASE_TYPE)
+CMAKEOPTS = -DCMAKE_BUILD_TYPE=$(RELEASE_TYPE) $(WORKLETOPT) $(CMAKEOPT) $(NONDETERMINISM_LINT_OPT) $(CXX_COMPILER_OPT)
 
 #CMAKEOPT ?= -DCMAKE_BUILD_TYPE=Debug $(WORKLETOPT)
 #BUILDOPT ?= --config Debug
@@ -136,7 +146,8 @@ help:
 	@echo "  FAUSTDIR=<dir>              : the compilation directory. Default to '$(FAUSTDIR)'"
 	@echo "  LIBSDIR                     : the libraries destination directory, default: $(LIBSDIR)"
 	@echo "  GENERATOR=<a cmake generator>: see cmake -h. Default to '$(GENERATOR)'"
-	@echo "  CMAKEOPT=<cmake options>    : pass options to cmake for project generation."
+	@echo "  CMAKEOPT=<cmake options>    : pass extra options to cmake for project generation."
+	@echo "  RELEASE_TYPE                : cmake release type (defaults to Release)."
 	@echo "  BUILDOPT=<cmake options>    : pass options to cmake at build time (default to $(BUILDOPT))."
 	@echo "  BACKENDS=<backends file>    : see 'Backends' below"
 	@echo "  TARGETS=<targets file>      : see 'Targets' below"
@@ -320,7 +331,7 @@ silent: $(FAUSTDIR)
 	cd $(FAUSTDIR) && $(CMAKE) -DCMAKE_VERBOSE_MAKEFILE=OFF ..
 
 cmake: $(FAUSTDIR)
-	cd $(FAUSTDIR) && $(CMAKE) -C ../backends/$(BACKENDS) -C ../targets/$(TARGETS) $(CMAKEOPT) -DINCLUDE_LLVM=$(INCLUDE_LLVM) -DUSE_LLVM_CONFIG=$(USE_LLVM_CONFIG) -DLLVM_PACKAGE_VERSION=$(LLVM_PACKAGE_VERSION) -DLLVM_LIBS="$(LLVM_LIBS)" -DLLVM_LIB_DIR="$(LLVM_LIB_DIR)" -DLLVM_INCLUDE_DIRS="$(LLVM_INCLUDE_DIRS)" -DLLVM_DEFINITIONS="$(LLVM_DEFINITIONS)" -DLLVM_LD_FLAGS="$(LLVM_LD_FLAGS)" $(DEPLOYMENT) -DLIBSDIR=$(LIBSDIR) -DBUILD_HTTP_STATIC=$(BUILD_HTTP_STATIC) -G '$(GENERATOR)' ..
+	cd $(FAUSTDIR) && $(CMAKE) -C ../backends/$(BACKENDS) -C ../targets/$(TARGETS) $(CMAKEOPTS) -DCMAKE_BUILD_TYPE=$(RELEASE_TYPE) $(WORKLETOPT) -DINCLUDE_LLVM=$(INCLUDE_LLVM) -DUSE_LLVM_CONFIG=$(USE_LLVM_CONFIG) -DLLVM_PACKAGE_VERSION=$(LLVM_PACKAGE_VERSION) -DLLVM_LIBS="$(LLVM_LIBS)" -DLLVM_LIB_DIR="$(LLVM_LIB_DIR)" -DLLVM_INCLUDE_DIRS="$(LLVM_INCLUDE_DIRS)" -DLLVM_DEFINITIONS="$(LLVM_DEFINITIONS)" -DLLVM_LD_FLAGS="$(LLVM_LD_FLAGS)" $(DEPLOYMENT) -DLIBSDIR=$(LIBSDIR) -DBUILD_HTTP_STATIC=$(BUILD_HTTP_STATIC) -G '$(GENERATOR)' ..
 	@echo BACKENDS=$(BACKENDS) > $(BCACHE)
 	@echo TARGETS=$(TARGETS) > $(TCACHE)
 	@echo LIBSDIR=$(LIBSDIR) > $(LCACHE)
@@ -353,7 +364,7 @@ checkemcc:
 installLog := $(FAUSTDIR)/install_manifest.txt
 install:
 	if test -d ../.git; then git submodule update --init; fi
-	cd $(FAUSTDIR) && $(CMAKE) .. -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(CMAKEOPT)
+	cd $(FAUSTDIR) && $(CMAKE) .. -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(CMAKEOPTS)
 	$(CMAKE) --build $(FAUSTDIR) --target install
 
 uninstall: $(installLog)

--- a/build/lint.query
+++ b/build/lint.query
@@ -1,0 +1,72 @@
+# Check for a pointer comparison between CTreeBase* / Symbol*
+
+let hasTargetComparisonNoBind binaryOperator(
+  hasAnyOperatorName("<", ">", "<=", ">="),
+  hasEitherOperand(hasType(hasUnqualifiedDesugaredType(pointerType(pointee(hasDeclaration(namedDecl(hasAnyName("CTreeBase", "Symbol"))))).bind("pointer-type"))))
+)
+
+# Or a function call to a function in the STL which has one of those pointer comparisons
+
+let hasTargetComparison hasTargetComparisonNoBind.bind("comparison")
+
+let hasTransitiveTargetCall0 callExpr(callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison))))
+
+# Or nested function calls. We can't do arbitrary recursion, so just go 8 deep
+
+let hasTransitiveTargetCall1 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall0)))
+))
+
+let hasTransitiveTargetCall2 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall1)))
+))
+
+let hasTransitiveTargetCall3 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall2)))
+))
+
+let hasTransitiveTargetCall4 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall3)))
+))
+
+let hasTransitiveTargetCall5 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall4)))
+))
+
+let hasTransitiveTargetCall6 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall5)))
+))
+
+let hasTransitiveTargetCall7 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall6)))
+))
+
+let hasTransitiveTargetCall8 callExpr(anyOf(
+    callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTargetComparison)))
+    , callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall7)))
+))
+
+let hasTransitiveTargetCall hasTransitiveTargetCall8
+
+let Diagnostic "this function call leads to pointer comparison of type %1, don't do that"
+let DiagnosticArgs "root pointer-type"
+
+# Match a function call in a source file (either the .cpp or an included .hh)
+# whose definition is in a system header
+match callExpr(
+  unless(isExpansionInSystemHeader()),
+  callee(decl(isExpansionInSystemHeader(), hasDescendant(hasTransitiveTargetCall)))
+)
+
+let Diagnostic "don't compare pointers of type %1"
+let DiagnosticArgs "root pointer-type"
+
+# Match a pointer comparison in a source file (either .cpp or included .hh)
+match stmt(unless(isExpansionInSystemHeader()), hasTargetComparisonNoBind)


### PR DESCRIPTION
@sletz I figured out a CMake integration for the pointer nondeterminism lint I mentioned to you. I did it by wrapping clang-query into a clang plugin, so that a query can be automatically converted into a compiler warning. The plugin is at https://github.com/nuchi/node-matcher-plugin

(Context for others: code generation is nondeterministic because sometimes the compiler will compare pointers in situations where it needs to arbitrarily choose one. But pointers are generated by malloc/new and therefore change from run to run. One way to eliminate this non-determinism is to not compare pointers. But that can be hard to detect. Hence this new lint step.)

Adds a compiler warning for doing a pointer comparison between `CTreeBase*` or `Symbol*`, in order to better find where nondeterminism is happening.

It's enabled automatically for `make debug`, and can be enabled for other targets by doing
`make compiler NONDETERMINISM_LINT=yes`

Needs `llvm-config` to be in one's PATH; it'll set the C++ compiler to be the version of clang that's shipped with LLVM. (It builds a clang plugin against the installed LLVM, so it needs to use the same C++ compiler.)

Sample cmake output:
```
[  1%] Building CXX object CMakeFiles/faust.dir/Users/nuchi/faust/compiler/box_signal_api.cpp.o
In file included from /Users/nuchi/faust/compiler/box_signal_api.cpp:30:
In file included from /Users/nuchi/faust/compiler/global.hh:39:
In file included from /Users/nuchi/faust/compiler/evaluate/loopDetector.hh:33:
In file included from /Users/nuchi/faust/compiler/boxes/boxes.hh:42:
In file included from /Users/nuchi/faust/compiler/tlib/tlib.hh:162:
In file included from /Users/nuchi/faust/compiler/tlib/list.hh:108:
/Users/nuchi/faust/compiler/tlib/tree.hh:181:46: warning: this function call leads to pointer comparison of type CTreeBase *, don't do that
  181 |     void setProperty(Tree key, Tree value) { fProperties[key] = value; }
      |                                              ^~~~~~~~~~~~~~~~
/Users/nuchi/faust/compiler/tlib/tree.hh:182:36: warning: this function call leads to pointer comparison of type CTreeBase *, don't do that
  182 |     void clearProperty(Tree key) { fProperties.erase(key); }
      |                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/nuchi/faust/compiler/tlib/tree.hh:189:29: warning: this function call leads to pointer comparison of type CTreeBase *, don't do that
  189 |         plist::iterator i = fProperties.find(key);
      |                             ^~~~~~~~~~~~~~~~~~~~~
/Users/nuchi/faust/compiler/tlib/tree.hh:221:22: warning: don't compare pointers of type CTreeBase *
  221 |             } while (new_block < gAllocatedBlock);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
4 warnings generated.
```

Note that it'll be very noisy, because it'll give the same warning for e.g. `tree.hh` in every translation unit that includes it.