### PR TITLE
fix #1060 using parenthesis

### DIFF
--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -565,18 +565,18 @@ class RustInstVisitor : public TextInstVisitor {
 
     virtual void visit(Select2Inst* inst)
     {
-        *fOut << "if ";
+        *fOut << "(if ";
         inst->fCond->accept(this);
         *fOut << " != 0 {";
         inst->fThen->accept(this);
         *fOut << "} else {";
         inst->fElse->accept(this);
-        *fOut << "}";
+        *fOut << "})";
     }
 
     virtual void visit(IfInst* inst)
     {
-        *fOut << "if ";
+        *fOut << "(if ";
         inst->fCond->accept(this);
         *fOut << " != 0 {";
         tab(++fTab, *fOut);
@@ -590,7 +590,7 @@ class RustInstVisitor : public TextInstVisitor {
             back(1, *fOut);
             *fOut << "}";
         } else {
-            *fOut << "}";
+            *fOut << "})";
         }
         tab(fTab, *fOut);
     }


### PR DESCRIPTION
rust fails to differentiate between multiplication binary-operator and deference unary-operator, in the context of if-else clauses. because of this we need to wrap if-else clauses in a parenthesis through it becomes clear to the compiler that we expect a return value, and this implies that * means multiplication.