### PR TITLE
Rust code generation independent of FaustDsp trait

### DIFF
--- a/compiler/generator/rust/rust_code_container.hh
+++ b/compiler/generator/rust/rust_code_container.hh
@@ -59,6 +59,7 @@ class RustCodeContainer : public virtual CodeContainer {
     void generateComputeInterface(int tab);
     virtual void              generateCompute(int tab) = 0;
     void                      produceInternal();
+    void                      produceFaustDspBlob();
     virtual dsp_factory_base* produceFactory();
     virtual void              produceInfoFunctions(int tabs, const std::string& classname,
                                                    const std::string& obj, bool ismethod,

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -280,12 +280,6 @@ class RustInstVisitor : public TextInstVisitor {
 
         // Only generates additional functions
         if (fMathLibTable.find(inst->fName) == fMathLibTable.end()) {
-            // Prototype
-            // Since functions are attached to a trait they must not be prefixed with "pub".
-            // In case we need a mechanism to attach functions to both traits and normal
-            // impls, we need a mechanism to forward the information whether to use "pub"
-            // or not. In the worst case, we have to prefix the name string like "pub fname",
-            // and handle the prefix here.
             *fOut << "fn " << inst->fName;
             generateFunDefArgs(inst);
             generateFunDefBody(inst);


### PR DESCRIPTION
faust code generation should not specify traits.
this pr introduces this change.
It is tested against the impulse-tests using the architecture file in its subfolder.
How much architecture files need to change depends on how traits are used.

The jack cpal and minimal architecture files could be compiled after minimal changes, 
but need more cleanup work.