### PR TITLE
add unity visionOS compatibility and fix unity utilities JSON parser to handle unexpected values

### DIFF
--- a/architecture/unity/FaustPolyUtilities_template.cs
+++ b/architecture/unity/FaustPolyUtilities_template.cs
@@ -282,7 +282,7 @@ namespace FaustUtilities_MODEL {
 
         #if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_WSA_10_0
         const string _dllName = "PLUGNAME";
-        #elif UNITY_IOS
+        #elif UNITY_IOS || UNITY_VISIONOS
         const string _dllName = "__Internal";
         #elif UNITY_EDITOR || UNITY_ANDROID || UNITY_STANDALONE_LINUX
         const string _dllName = "PLUGINNAME";
@@ -457,8 +457,11 @@ namespace FaustUtilities_MODEL {
                             success = parseUI(ref fJSON, ref faustUI.ui, ref numitems);
                             break;
                         default:
-                            // Unknown items should be parsed
-                            success = parseDQString(ref fJSON, out value);
+                            // Parse DQString or Num
+                            var fJsonCache = fJSON;
+                            if (success = parseDQString(ref fJSON, out value)) continue;
+                            fJSON = fJsonCache;
+                            success = parseNum(ref fJSON,  out value);
                             break;
                         }
                     }

--- a/architecture/unity/FaustUtilities_template.cs
+++ b/architecture/unity/FaustUtilities_template.cs
@@ -273,7 +273,7 @@ namespace FaustUtilities_MODEL {
 
         #if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_WSA_10_0
         const string _dllName = "PLUGNAME";
-        #elif UNITY_IOS
+        #elif UNITY_IOS || UNITY_VISIONOS
         const string _dllName = "__Internal";
         #elif UNITY_EDITOR || UNITY_ANDROID || UNITY_STANDALONE_LINUX
         const string _dllName = "PLUGINNAME";
@@ -420,8 +420,11 @@ namespace FaustUtilities_MODEL {
                             success = parseUI(ref fJSON, ref faustUI.ui, ref numitems);
                             break;
                         default:
-                            // Unknown items should be parsed
-                            success = parseDQString(ref fJSON, out value);
+                            // Parse DQString or Num
+                            var fJsonCache = fJSON;
+                            if (success = parseDQString(ref fJSON, out value)) continue;
+                            fJSON = fJsonCache;
+                            success = parseNum(ref fJSON,  out value);
                             break;
                         }
                     }


### PR DESCRIPTION
The utility code generated by faust2unity fails to parse the most recent changes to embedded JSON metadata, particularly the "size" key, which should be ignored.   This patch skips unknown JSON metadata keys as long as they are double-quoted string values or numbers.

In addition, I've added basic compatibility for VisionOS (ie, macro checks now allow for UNITY_VISIONOS) which result in VisionOS projects using ios libs.