### PR TITLE
Always provide const values for rust

### DIFF
--- a/compiler/generator/code_container.cpp
+++ b/compiler/generator/code_container.cpp
@@ -801,15 +801,6 @@ void CodeContainer::printMacros(ostream& fout, int n)
                 tab(n, fout);
             }
             fout << "#endif" << endl;
-        } else if (gGlobal->gOutputLang == "rust") {
-            fout << "pub const FAUST_INPUTS: usize = " << fNumInputs << ";";
-            tab(n, fout);
-            fout << "pub const FAUST_OUTPUTS: usize = " << fNumOutputs << ";";
-            tab(n, fout);
-            fout << "pub const FAUST_ACTIVES: usize = " << fNumActives << ";";
-            tab(n, fout);
-            fout << "pub const FAUST_PASSIVES: usize = " << fNumPassives << ";";
-            tab(n, fout);
         } else {
             cerr << "ASSERT : incorrect backend : " << gGlobal->gOutputLang << endl;
             faustassert(false);

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -174,6 +174,7 @@ void RustCodeContainer::produceClass()
     tab(n, *fOut);
     *fOut << "use std::convert::TryInto;";
 
+
     // Generate gub containers
     generateSubContainers();
 
@@ -261,6 +262,16 @@ void RustCodeContainer::produceClass()
     }
 
     tab(n, *fOut);
+    *fOut << "pub const FAUST_INPUTS: usize = " << fNumInputs << ";";
+    tab(n, *fOut);
+    *fOut << "pub const FAUST_OUTPUTS: usize = " << fNumOutputs << ";";
+    tab(n, *fOut);
+    *fOut << "pub const FAUST_ACTIVES: usize = " << fNumActives << ";";
+    tab(n, *fOut);
+    *fOut << "pub const FAUST_PASSIVES: usize = " << fNumPassives << ";";
+    tab(n, *fOut);
+
+    tab(n, *fOut);
     *fOut << "#[cfg_attr(feature = \"default-boxed\", derive(default_boxed::DefaultBoxed))]";
     if (gGlobal->gReprC) {
         tab(n, *fOut);
@@ -335,9 +346,13 @@ void RustCodeContainer::produceClass()
     // Get sample rate method
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
-    generateGetSampleRate("get_sample_rate", "&self", false, false)->accept(&fCodeProducer);
-
-    produceInfoFunctions(n + 1, "", "&self", false, FunTyped::kDefault, &fCodeProducer);
+    tab(n + 1, *fOut);
+    *fOut << "fn get_sample_rate(&self) -> i32 { self.fSampleRate as i32}";
+    tab(n + 1, *fOut);
+    *fOut << "fn get_num_inputs(&self) -> i32 { FAUST_INPUTS as i32}";
+    tab(n + 1, *fOut);
+    *fOut << "fn get_num_outputs(&self) -> i32 { FAUST_OUTPUTS as i32}";
+    tab(n + 1, *fOut);
 
     // Inits
 
@@ -452,8 +467,7 @@ void RustCodeContainer::produceClass()
     *fOut << "}" << endl;
     tab(n, *fOut);
 
-    // Generate user interface macros if needed
-    printMacros(*fOut, n);
+
 }
 
 void RustCodeContainer::produceMetadata(int n)


### PR DESCRIPTION
This commit removes the -uim flag for rust
and provides the const values by default
and makes use of these const values
in get_num_inputs and get_num_outputs
it also simplifies how this functions are generated they are now just a string

To create arrays for compute_arrays() one needs to know the array sizes at compile time. The const definitions provide these.