### PR TITLE
Fix regression because of  #1061

### DIFF
--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -252,7 +252,7 @@ void RustCodeContainer::produceClass()
     if (gGlobal->gFloatSize == 1) {
         *fOut << "mod ffi {";
         tab(n + 1, *fOut);
-        *fOut << "use std::os::raw::{c_float};";
+        *fOut << "use std::os::raw::c_float;";
         tab(n + 1, *fOut);
         *fOut << "// Conditionally compile the link attribute only on non-Windows platforms";
         tab(n + 1, *fOut);

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -538,7 +538,7 @@ class RustInstVisitor : public TextInstVisitor {
 
     virtual void visit(IfInst* inst)
     {
-        *fOut << "(if ";
+        *fOut << "if ";
         inst->fCond->accept(this);
         *fOut << " != 0 {";
         tab(++fTab, *fOut);
@@ -552,7 +552,7 @@ class RustInstVisitor : public TextInstVisitor {
             back(1, *fOut);
             *fOut << "}";
         } else {
-            *fOut << "})";
+            *fOut << "}";
         }
         tab(fTab, *fOut);
     }

--- a/tests/impulse-tests/Make.rust
+++ b/tests/impulse-tests/Make.rust
@@ -70,6 +70,7 @@ all: ir/rust/noise.ir
 all: ir/rust/noiseabs.ir
 all: ir/rust/noisemetadata.ir
 all: ir/rust/notch.ir
+all: ir/rust/osc_enable.ir
 all: ir/rust/osc.ir
 all: ir/rust/osci.ir
 all: ir/rust/panpot.ir


### PR DESCRIPTION
solve unimportant warning 
and 
and solve regression because of fix for #1060.
adding osc_enable.ir to rust impulse tests revealed a mistake in the fix for #1060
This PR removes brackets around if when it is not from a select2 instruction.
