### PR TITLE
Attempt to run impulse tests in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: stable
 
     - name: Run impulse tests (C++)
       run: cd tests/impulse-tests && make cpp

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,7 +2,7 @@ name: Ubuntu
 
 on:
   push:
-    branches: 
+    branches:
         - '*'
   pull_request:
     branches: [ master-dev ]
@@ -16,8 +16,19 @@ jobs:
 
     - name: Install libmicrohttpd
       run: |
-        sudo apt-get update -qq 
+        sudo apt-get update -qq
         sudo apt-get install libmicrohttpd-dev
 
     - name: Build Faust
       run: make
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - name: Run impulse tests (C++)
+      run: cd tests/impulse-tests && make cpp
+
+    - name: Run impulse tests (Rust)
+      run: cd tests/impulse-tests && make rust


### PR DESCRIPTION
Would it be possible to enable the impulse tests in the CI? It would add some confidence during the review process to immediately see that they all pass. Or are there any deeper reasons why the tests have to be executed manually only?
