### PR TITLE
1) improve impulse-test makefile for rust

### DIFF
--- a/tests/impulse-tests/Make.rust
+++ b/tests/impulse-tests/Make.rust
@@ -15,114 +15,51 @@ MAKE ?= make
 
 outdir ?= rust
 FAUSTOPTIONS ?= -double
+CARGOOPTIONS ?= --release
 precision ?=		# filesCompare precision (empty by default)
 
 .PHONY: test
 .DELETE_ON_ERROR:
 
-alldspfiles := $(wildcard dsp/*.dsp)
-allirfiles = $(alldspfiles:dsp/%.dsp=ir/rust/%.ir)
+dspfiles := $(wildcard dsp/*.dsp)
+listfiles = $(dspfiles:dsp/%.dsp=ir/$1/%.ir)
 
-all: filesCompare
+#########################################################################
+all: filesCompare ir/$(outdir) $(call listfiles,$(outdir))
 
-# Currently this lists all dependencies manually to allow for easily enabling/disabling
-# individual test cases. Later this can be replaced by the wildcard dependency:
-# all: $(allirfiles)
+#########################################################################
+# output directories
+ir/$(outdir):
+	mkdir -p ir/$(outdir)
 
-all: ir/rust/APF.ir
-all: ir/rust/BPF.ir
-all: ir/rust/HPF.ir
-all: ir/rust/LPF.ir
-all: ir/rust/UITester.ir
-all: ir/rust/bandfilter.ir
-all: ir/rust/bargraph.ir
-all: ir/rust/bs.ir
-all: ir/rust/capture.ir
-all: ir/rust/carre_volterra.ir
-all: ir/rust/comb_bug_exp.ir
-all: ir/rust/comb_delay1.ir
-all: ir/rust/comb_delay2.ir
-all: ir/rust/constant.ir
-all: ir/rust/cubic_distortion.ir
-all: ir/rust/dbmeter.ir
-all: ir/rust/delays.ir
-all: ir/rust/echo_bug.ir
-all: ir/rust/echo.ir
-all: ir/rust/freeverb.ir
-all: ir/rust/gate_compressor.ir
-all: ir/rust/harpe.ir
-all: ir/rust/highShelf.ir
-all: ir/rust/karplus.ir
-all: ir/rust/karplus32.ir
-all: ir/rust/lfboost.ir
-all: ir/rust/logical.ir
-all: ir/rust/lowboost.ir
-all: ir/rust/lowcut.ir
-all: ir/rust/lowShelf.ir
-all: ir/rust/math.ir
-all: ir/rust/math_simp.ir
-all: ir/rust/matrix.ir
-all: ir/rust/midi_tester.ir
-all: ir/rust/mixer.ir
-all: ir/rust/modulations.ir
-all: ir/rust/multibandfilter.ir
-all: ir/rust/noise.ir
-all: ir/rust/noiseabs.ir
-all: ir/rust/noisemetadata.ir
-all: ir/rust/notch.ir
-all: ir/rust/osc_enable.ir
-all: ir/rust/osc.ir
-all: ir/rust/osci.ir
-all: ir/rust/panpot.ir
-all: ir/rust/parametric_eq.ir
-all: ir/rust/peakingEQ.ir
-all: ir/rust/peakNotch.ir
-all: ir/rust/phaser_flanger.ir
-all: ir/rust/pitch_shifter.ir
-all: ir/rust/pow.ir
-all: ir/rust/precision.ir
-#all: ir/rust/prefix.ir
-all: ir/rust/priority.ir
-all: ir/rust/priority1.ir
-all: ir/rust/quadecho.ir
-all: ir/rust/reverb_designer.ir
-all: ir/rust/reverb_tester.ir
-all: ir/rust/smoothdelay.ir
-#all: ir/rust/sound.ir
-all: ir/rust/spat.ir
-all: ir/rust/spectral_level.ir
-all: ir/rust/spectral_tilt.ir
-all: ir/rust/stereoecho.ir
-all: ir/rust/switcher.ir
-all: ir/rust/table.ir
-all: ir/rust/table1.ir
-all: ir/rust/table2.ir
-all: ir/rust/tapiir.ir
-all: ir/rust/tester.ir
-all: ir/rust/tester2.ir
-all: ir/rust/tf_exp.ir
-all: ir/rust/thru_zero_flanger.ir
-all: ir/rust/UITester.ir
-all: ir/rust/vcf_wah_pedals.ir
-all: ir/rust/virtual_analog_oscillators.ir
-all: ir/rust/volume.ir
-all: ir/rust/vumeter.ir
-all: ir/rust/waveform1.ir
-all: ir/rust/waveform2.ir
-all: ir/rust/waveform3.ir
-all: ir/rust/waveform4.ir
-all: ir/rust/waveform5.ir
-all: ir/rust/waveform6.ir
-all: ir/rust/zita_rev1.ir
 
-filesCompare:
+#########################################################################
+# tools
+filesCompare: 
 	$(MAKE) filesCompare
 
 #########################################################################
 # rules
-ir/$(outdir)/%.ir: reference/%.ir
-	mkdir -p ir/$(outdir)
-	$(FAUST) -lang rust $(FAUSTOPTIONS) -i -A ../../architecture -a archs/rust/architecture.rs dsp/$*.dsp -o archs/rust/src/bin/$*.rs
-	#cd archs/rust/ && cargo run --bin $* ../../$@
-	cd archs/rust/ && cargo run --release --bin $* ../../$@
-	$(COMPARE) $@ reference/$(notdir $@) $(precision)
+
+ir/$(outdir)/sound.ir: dsp/sound.dsp 
+	$(FAUST) -lang rust $(FAUSTOPTIONS) dsp/sound.dsp -o archs/rust/src/bin/sound.rs > $@ 2>&1 || (echo "expected failure")
+	grep "ERROR : 'soundfile' primitive not yet supported for Rust" $@
+
+ir/rust/vec4/osc_enable.ir: dsp/osc_enable.dsp 
+	$(FAUST) -lang rust $(FAUSTOPTIONS) dsp/osc_enable.dsp -o archs/rust/src/bin/osc_enable.rs > $@ 2>&1 || (echo "expected failure")
+	grep "ERROR : 'control/enable' can only be used in scalar mode" $@
+
+ir/rust/vec32/osc_enable.ir: dsp/osc_enable.dsp 
+	$(FAUST) -lang rust $(FAUSTOPTIONS) dsp/osc_enable.dsp -o archs/rust/src/bin/osc_enable.rs > $@ 2>&1 || (echo "expected failure")
+	grep "ERROR : 'control/enable' can only be used in scalar mode" $@
+
+ir/rust/vec4/prefix.ir: 
+	echo "todo fix bug #1071 to test dsp/prefix.dsp"
+
+ir/rust/vec32/prefix.ir: 
+	echo "todo fix bug #1071 to test dsp/prefix.dsp"
+
+ir/$(outdir)/%.ir: dsp/%.dsp reference/%.ir
+	$(FAUST) -lang rust $(FAUSTOPTIONS) dsp/$*.dsp -o archs/rust/src/bin/$*.rs
+	cd archs/rust/ && cargo run $(CARGOOPTIONS) --bin $* ../../$@
+	$(COMPARE) $@ reference/$(notdir $@) $(precision) || (rm -f $@; false)

--- a/tests/impulse-tests/Makefile
+++ b/tests/impulse-tests/Makefile
@@ -362,13 +362,10 @@ interp1:
 #########################################################################
 # Rust backend
 rust:
-	$(MAKE) -f Make.rust FAUSTOPTIONS="-I dsp -double"
-	rm -rf ir/rust
-	$(MAKE) -f Make.rust FAUSTOPTIONS="-I dsp -double -fp"
-	rm -rf ir/rust
-	$(MAKE) -f Make.rust FAUSTOPTIONS="-I dsp -double -vec -vs 4"
-	rm -rf ir/rust
-	$(MAKE) -f Make.rust FAUSTOPTIONS="-I dsp -double -vec -vs 32"
+	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture.rs"
+	$(MAKE) -f Make.rust outdir=rust/fp FAUSTOPTIONS="-I ../../libraries/ -double -fp -a archs/rust/architecture.rs"
+	$(MAKE) -f Make.rust outdir=rust/vec4 CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -vec -vs 4 -a archs/rust/architecture.rs"
+	$(MAKE) -f Make.rust outdir=rust/vec32 FAUSTOPTIONS="-I ../../libraries/ -double -vec -vs 32 -a archs/rust/architecture.rs"
 
 #########################################################################
 # Cmajor backend

--- a/tests/impulse-tests/archs/rust/Cargo.toml
+++ b/tests/impulse-tests/archs/rust/Cargo.toml
@@ -12,3 +12,5 @@ default-boxed = "0.2"
 [features]
 default = ["default-boxed"]
 default-boxed = []
+
+[workspace]


### PR DESCRIPTION
The aim of this pr is to make the Makefile for rust tests more concise similar to the Make.gcc .
The motivation is to also test  osc_enable.dsp where applicable. 
Unlike that Makefile i also test for error messages.
Any comments?
@sletz 
@bluenote10 
