### PR TITLE
2) Make Rust FaustDsp Trait Optional

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,7 +2,7 @@ name: Ubuntu
 
 on:
   push:
-    branches: 
+    branches:
         - '*'
   pull_request:
     branches: [ master-dev ]
@@ -13,11 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
 
     - name: Install libmicrohttpd
       run: |
-        sudo apt-get update -qq 
+        sudo apt-get update -qq
         sudo apt-get install libmicrohttpd-dev
 
     - name: Build Faust
       run: make
+
+    - name: Copy c header to expected path by impulse test
+      run: |
+         mkdir -p architecture/faust/dsp/
+         cp compiler/generator/libfaust.h architecture/faust/dsp/
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+
+    - name: Run impulse tests (C++ and Rust)
+      run: cd tests/impulse-tests && make github_action

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -402,7 +402,7 @@ void RustCodeContainer::produceClass()
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
     tab(n + 1, *fOut);
-    *fOut << "fn get_sample_rate(&self) -> i32 { self.fSampleRate as i32}";
+    *fOut << "pub fn get_sample_rate(&self) -> i32 { self.fSampleRate as i32}";
     tab(n + 1, *fOut);
 
     // Inits
@@ -518,7 +518,9 @@ void RustCodeContainer::produceClass()
     tab(n, *fOut);
     *fOut << "}" << endl;
     tab(n, *fOut);
-    produceFaustDspBlob();
+    if (!gGlobal->gRustNoTraitSwitch) {
+        produceFaustDspBlob();
+    }
 }
 
 void RustCodeContainer::produceMetadata(int n)

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -451,7 +451,9 @@ void global::reset()
     gGroupTaskSwitch = false;
     gFunTaskSwitch   = false;
 
-    gUIMacroSwitch = false;
+    gUIMacroSwitch     = false;
+    gRustNoTraitSwitch = false;
+
     gDumpNorm      = -1;
     gFTZMode       = 0;
     gRangeUI       = false;
@@ -1371,6 +1373,10 @@ bool global::processCmdline(int argc, const char* argv[])
             gUIMacroSwitch = true;
             i += 1;
 
+        } else if (isCmd(argv[i], "-rnt", "--rust-no-faustdsp-trait")) {
+            gRustNoTraitSwitch = true;
+            i += 1;
+
         } else if (isCmd(argv[i], "-t", "--timeout") && (i + 1 < argc)) {
             gTimeout = std::atoi(argv[i + 1]);
             i += 2;
@@ -1661,6 +1667,10 @@ bool global::processCmdline(int argc, const char* argv[])
     // ========================
     // Check options coherency
     // ========================
+
+    if (gRustNoTraitSwitch && gOutputLang != "rust") {
+        throw faustexception("ERROR : '-rnt' option can only be used with rust\n");
+    }
 
     if (gInPlace && gVectorSwitch) {
         throw faustexception("ERROR : '-inpl' option can only be used in scalar mode\n");
@@ -2113,6 +2123,10 @@ string global::printHelp()
     sstr << tab
          << "-uim      --user-interface-macros       add user interface macro definitions to the "
             "output code."
+         << endl;
+    sstr << tab
+         << "-rnt      --rust-no-faustdsp-trait      (Rust only) Don't generate FaustDsp trait"
+         "implmentation."
          << endl;
     sstr << tab << "-xml                                    generate an XML description file."
          << endl;

--- a/compiler/global.hh
+++ b/compiler/global.hh
@@ -138,6 +138,7 @@ struct global {
     bool        gPrintFileListSwitch;  // -flist option
     bool        gInlineArchSwitch;     // -i option
     bool        gUIMacroSwitch;        // -uim option
+    bool        gRustNoTraitSwitch;     // -rnt option
     int         gDumpNorm;             // -norm option
     bool        gMathExceptions;       // -me option, whether to check math functions domains
     bool gLocalCausalityCheck;  // -lcc option, when true trigs local causality errors (negative

--- a/tests/impulse-tests/Make.gcc
+++ b/tests/impulse-tests/Make.gcc
@@ -49,7 +49,7 @@ help:
 	@echo " 'all' (default): generate ir for all the dsp files using the given options"
 	@echo
 	@echo "Options:"
-	@echo " 'outdir' 	   : define the output directory (default to '$(outdir)')"
+	@echo " 'outdir'       : define the output directory (default to '$(outdir)')"
 	@echo " 'lang'         : used for faust -lang option (default to '$(lang)')"
 	@echo " 'arch'         : used for faust -a option (default to '$(arch)')"
 	@echo " 'FAUSTOPTIONS' : define additional faust options (default to $(FAUSTOPTIONS))"
@@ -171,6 +171,12 @@ ir/c1/double/dlt0/osc_enable.c : dsp/osc_enable.dsp
 ir/c1/double/dlt256/osc_enable.c : dsp/osc_enable.dsp
 	@echo "Can only be tested in scalar mode"
 	$(FAUST) -lang $(lang) -double -os -i -A ../../architecture -a archs/$(arch) $< -o $@
+
+ir/$(outdir)/prefix.ir:
+	echo "todo fix bug #1071 to test dsp/prefix.dsp"
+
+ir/cpp/double/mapp/constant.ir:
+	echo "todo fix bug #1074 to test dsp/constant.dsp"
 
 ir/$(outdir)/%.$(ext) : dsp/%.dsp
 	$(FAUST) -lang $(lang) $(FAUSTOPTIONS) -i -A ../../architecture -a archs/$(arch) $< -o $@

--- a/tests/impulse-tests/Make.interp
+++ b/tests/impulse-tests/Make.interp
@@ -37,7 +37,7 @@ help:
 	@echo " 'interp' (default): check the double output using the interp backend"
 	@echo
 	@echo "Options:"
-	@echo " 'outdir' 	   : define the output directory (default to 'llvm')"
+	@echo " 'outdir'       : define the output directory (default to 'llvm')"
 	@echo " 'FAUSTOPTIONS' : define additional faust options (empty by default)"
 	@echo " 'precision'    : define filesCompare expected precision (empty by default)"
 
@@ -62,7 +62,8 @@ impulseinterp: $(SRCDIR)/impulseinterp.cpp $(LIB)
 #########################################################################
 # rules for interp
 
-# Specific rule to test 'control' primitive that currently uses the -lang ocpp backend (still compiling in scalar mode...)
+# Specific rule to test 'control' primitive that currently uses the -lang ocpp backend 
+# (still compiling in scalar mode...)
 ir/$(outdir)/control.ir: dsp/control.dsp reference/control.ir
 	@echo "Cannot be tested with the Interp backend"
 

--- a/tests/impulse-tests/Makefile
+++ b/tests/impulse-tests/Makefile
@@ -120,6 +120,12 @@ travis:
 	#$(MAKE) -f Make.gcc outdir=cpp/double/sch     lang=cpp arch=impulsearch.cpp FAUSTOPTIONS="-I dsp -double -sch"
 
 #########################################################################
+# automatic github action test
+github_action:
+	$(MAKE) -f Make.gcc outdir=cpp/double          lang=cpp arch=impulsearch.cpp FAUSTOPTIONS="-I ../../libraries/ -I dsp -double"
+	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture.rs"
+
+#########################################################################
 # c++ and c backends
 cpp:
 	$(MAKE) -f Make.gcc outdir=cpp/double           lang=cpp arch=impulsearch.cpp FAUSTOPTIONS="-I dsp -double"

--- a/tests/impulse-tests/Makefile
+++ b/tests/impulse-tests/Makefile
@@ -122,8 +122,9 @@ travis:
 #########################################################################
 # automatic github action test
 github_action:
+	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture_normal.rs"
+	$(MAKE) -f Make.rust outdir=rust/rnt CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -rnt -a archs/rust/architecture.rs"
 	$(MAKE) -f Make.gcc outdir=cpp/double          lang=cpp arch=impulsearch.cpp FAUSTOPTIONS="-I ../../libraries/ -I dsp -double"
-	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture.rs"
 
 #########################################################################
 # c++ and c backends
@@ -368,10 +369,10 @@ interp1:
 #########################################################################
 # Rust backend
 rust:
-	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture.rs"
-	$(MAKE) -f Make.rust outdir=rust/fp FAUSTOPTIONS="-I ../../libraries/ -double -fp -a archs/rust/architecture.rs"
-	$(MAKE) -f Make.rust outdir=rust/vec4 CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -vec -vs 4 -a archs/rust/architecture.rs"
-	$(MAKE) -f Make.rust outdir=rust/vec32 FAUSTOPTIONS="-I ../../libraries/ -double -vec -vs 32 -a archs/rust/architecture.rs"
+	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -rnt -a archs/rust/architecture.rs"
+	$(MAKE) -f Make.rust outdir=rust/fp FAUSTOPTIONS="-I ../../libraries/ -double -fp -a archs/rust/architecture_normal.rs"
+	$(MAKE) -f Make.rust outdir=rust/vec4 CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -vec -vs 4 -a archs/rust/architecture_normal.rs"
+	$(MAKE) -f Make.rust outdir=rust/vec32 FAUSTOPTIONS="-I ../../libraries/ -double -vec -vs 32 -a archs/rust/architecture_normal.rs"
 
 #########################################################################
 # Cmajor backend


### PR DESCRIPTION
This PR introduces the new compile flag `-rnt`  `--rust-no-faustdsp-trait` to faust, to not generate the FaustDsp interface.
The aim is to be able to make use of flags like `-ec` or `-os` that change the generated code so that it is not compatible with the FaustDsp trait. 
@bluenote10 
@obsoleszenz
