### PR TITLE
Updated class daisy_midi to be compatible with libDaisy v7.1.0

### DIFF
--- a/architecture/daisy/Makefile
+++ b/architecture/daisy/Makefile
@@ -8,6 +8,9 @@ CPP_SOURCES = ex_faust.cpp
 LIBDAISY_DIR ?= ../../../libdaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
+# Linker Settings
+APP_TYPE = BOOT_SRAM
+
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile

--- a/architecture/daisy/README.md
+++ b/architecture/daisy/README.md
@@ -25,6 +25,10 @@ Other metadata:
 
 - `[scale:lin|log|exp]` metadata is implemented.
 
+## Bootloader configuration:
+
+Setup the board to utilize the manufacturer's bootloader, ensuring that the generated code fits within the board's memory. For detailed instructions on flashing the bootloader, please refer to: [Daisy Bootloader Getting Started Guide](https://electro-smith.github.io/libDaisy/md_doc_2md_2__a7___getting-_started-_daisy-_bootloader.html).
+
 ## DSP examples
 
 Here is a simple example showing how oscillators can be controlled by physical items and MIDI messages:

--- a/architecture/faust/midi/daisy-midi.h
+++ b/architecture/faust/midi/daisy-midi.h
@@ -35,8 +35,9 @@ class daisy_midi : public midi_handler {
     
     private:
     
-        daisy::MidiHandler fMidi;
-    
+        daisy::MidiHandler<daisy::MidiUartTransport> fMidi;
+        daisy::MidiHandler<daisy::MidiUartTransport>::Config config;
+
     public:
     
         daisy_midi():midi_handler("daisy")
@@ -49,7 +50,7 @@ class daisy_midi : public midi_handler {
 
         bool startMidi()
         {
-            fMidi.Init(daisy::MidiHandler::INPUT_MODE_UART1, daisy::MidiHandler::OUTPUT_MODE_NONE);
+            fMidi.Init(config);
             return true;
         }
 


### PR DESCRIPTION
This PR suggest a fix for issue #1084 
> daisy_midi class of daisy architecture is outdated 