### PR TITLE
5) rust: use AsRef/AsMut in compute interface

### DIFF
--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -236,8 +236,6 @@ void RustCodeContainer::produceClass()
     tab(n, *fOut);
     *fOut << "pub type FaustFloat = " << ifloat() << ";";
 
-    tab(n, *fOut);
-    *fOut << "use std::convert::TryInto;";
 
     // Generate gub containers
     generateSubContainers();
@@ -527,7 +525,6 @@ void RustCodeContainer::produceClass()
         generateComputeFrame(n + 1);
     } else {
         generateCompute(n + 1);
-        generateComputeInterface(n + 1);
     }
 
     tab(n, *fOut);
@@ -627,18 +624,18 @@ void RustCodeContainer::generateComputeHeader(int n, std::ostream* fOut, int fNu
 {
     // Compute "compute" declaration
     tab(n, *fOut);
-    *fOut << "pub fn compute_arrays("
-          << "&mut self, " << fFullCount << ": usize, inputs: &[&[FaustFloat] ; " << fNumInputs
-          << "]"
-          << ", outputs: &mut [&mut [FaustFloat] ; " << fNumOutputs << "]) {";
-}
-
-void RustCodeContainer::generateComputeInterfaceHeader(int n, std::ostream* fOut, int fNumInputs,
-                                                       int fNumOutputs)
-{
-    *fOut << "pub fn compute("
-          << "&mut self, " << fFullCount << ": usize, inputs: & [& [FaustFloat] ]"
-          << ", outputs: & mut[& mut[FaustFloat] ]) {";
+    tab(n, *fOut);
+    *fOut << "pub fn compute(";
+    tab(n + 1, *fOut);
+    *fOut << "&mut self,";
+    tab(n + 1, *fOut);
+    *fOut << "count: usize,";
+    tab(n + 1, *fOut);
+    *fOut << "inputs: &[impl AsRef<[FaustFloat]>],";
+    tab(n + 1, *fOut);
+    *fOut << "outputs: &mut[impl AsMut<[FaustFloat]>],";
+    tab(n, *fOut);
+    *fOut << ") {";
     tab(n + 1, *fOut);
 }
 
@@ -683,23 +680,6 @@ void RustCodeContainer::generateComputeFrame(int n)
     tab(n, *fOut);
     *fOut << "}";
     tab(n, *fOut);
-}
-
-void RustCodeContainer::generateComputeInterface(int n)
-{
-    // Generates declaration
-    tab(n, *fOut);
-    generateComputeInterfaceHeader(n, fOut, fNumInputs, fNumOutputs);
-
-    *fOut << "let input_array = inputs.split_at(" << fNumInputs
-          << ").0.try_into().expect(\"too few input buffers\");";
-    tab(n + 1, *fOut);
-    *fOut << "let output_array = outputs.split_at_mut(" << fNumOutputs
-          << ").0.try_into().expect(\"too few output buffers\");";
-    tab(n + 1, *fOut);
-    *fOut << "self.compute_arrays(count, input_array, output_array);";
-    tab(n, *fOut);
-    *fOut << "}" << endl;
 }
 
 // Scalar

--- a/compiler/generator/rust/rust_code_container.hh
+++ b/compiler/generator/rust/rust_code_container.hh
@@ -55,8 +55,6 @@ class RustCodeContainer : public virtual CodeContainer {
 
     virtual void produceClass();
     void         generateComputeHeader(int n, std::ostream* fOut, int fNumInputs, int fNumOutputs);
-    void generateComputeInterfaceHeader(int n, std::ostream* fOut, int fNumInputs, int fNumOutputs);
-    void generateComputeInterface(int tab);
     void generateComputeFrame(int tab);
     virtual void              generateCompute(int tab) = 0;
     void                      produceInternal();

--- a/tests/impulse-tests/Makefile
+++ b/tests/impulse-tests/Makefile
@@ -122,10 +122,9 @@ travis:
 #########################################################################
 # automatic github action test
 github_action:
-	$(MAKE) -f Make.rust outdir=rust/osec CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -os -ec -rnt -a archs/rust/architecture_osecrnt.rs"
-	$(MAKE) -f Make.rust outdir=rust/os CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -os -rnt -a archs/rust/architecture_osrnt.rs"
 	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture_trait.rs"
-	$(MAKE) -f Make.gcc outdir=cpp/double/os lang=cpp arch=impulsearch7ter.cpp FAUSTOPTIONS="-I dsp -double -os"
+	$(MAKE) -f Make.rust outdir=rust/cm CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -cm -a archs/rust/architecture_cm.rs"
+	$(MAKE) -f Make.rust outdir=rust/ecrnt CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -ec -rnt -a archs/rust/architecture_ecrnt.rs"
 	$(MAKE) -f Make.gcc outdir=cpp/double lang=cpp arch=impulsearch.cpp FAUSTOPTIONS="-I ../../libraries/ -I dsp -double"
 
 #########################################################################

--- a/tests/impulse-tests/archs/rust/architecture_ecrnt.rs
+++ b/tests/impulse-tests/archs/rust/architecture_ecrnt.rs
@@ -16,6 +16,8 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ************************************************************************
 ************************************************************************/
 
+// this architecture file use vectors of vectors to test the compute interface
+
 #![allow(unused_parens)]
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
@@ -152,11 +154,11 @@ impl<T: Float + FromPrimitive> UI<T> for ButtonUI {
     fn declare(&mut self, param: Option<ParamIndex>, key: &str, value: &str) {}
 }
 
-// Generated intrinsics:
-<<includeIntrinsic>>
+// // Generated intrinsics:
+// <<includeIntrinsic>>
 
-// Generated class:
-<<includeclass>>
+// // Generated class:
+// <<includeclass>>
 
 const SAMPLE_RATE: i32 = 44100;
 
@@ -211,19 +213,7 @@ fn run_dsp(
         }
 
         dsp.control();
-        dsp.compute(
-            buffer_size,
-            in_buffer
-                .iter()
-                .map(|buffer| buffer.as_slice())
-                .collect::<Vec<&[FaustFloat]>>()
-                .as_slice(),
-            out_buffer
-                .iter_mut()
-                .map(|buffer| buffer.as_mut_slice())
-                .collect::<Vec<&mut [FaustFloat]>>()
-                .as_mut_slice(),
-        );
+        dsp.compute(buffer_size, &in_buffer, &mut out_buffer);
 
         // handle outputs
         for j in 0..buffer_size {

--- a/tests/impulse-tests/archs/rust/architecture_osecrnt.rs
+++ b/tests/impulse-tests/archs/rust/architecture_osecrnt.rs
@@ -29,12 +29,9 @@ extern crate libm;
 extern crate num_traits;
 /* extern crate fastfloat; */
 
-use std::env;
-use std::fs::File;
-use std::io::Write;
-
 use default_boxed::DefaultBoxed;
 use num_traits::{cast::FromPrimitive, float::Float};
+use std::{convert::TryInto, env, fs::File, io::Write};
 
 type F32 = f32;
 type F64 = f64;

--- a/tests/impulse-tests/archs/rust/architecture_osrnt.rs
+++ b/tests/impulse-tests/archs/rust/architecture_osrnt.rs
@@ -29,12 +29,9 @@ extern crate libm;
 extern crate num_traits;
 /* extern crate fastfloat; */
 
-use std::env;
-use std::fs::File;
-use std::io::Write;
-
 use default_boxed::DefaultBoxed;
 use num_traits::{cast::FromPrimitive, float::Float};
+use std::{convert::TryInto, env, fs::File, io::Write};
 
 type F32 = f32;
 type F64 = f64;


### PR DESCRIPTION
the current compute function signature looks like this:
```
	pub fn compute(&mut self, count: usize, inputs: &[&[FaustFloat]], outputs: &mut [&mut [FaustFloat]]){
```
this prevents us from passing a mutable reference as input buffer slice.
in the case one wants to chain dsps where the outputs of one dsp are used as the input of another it would be good if one can pass pass same slice that is used as the output of one dsp as input of another. but in that case one would pass a mutable reference. which is not possible with the current function signature.
this pr changes the functions to be more general. so that one can pass a mutable reference to the the input.
The new now looks like this:
```
	pub fn compute<I, O>(
		&mut self,
		count: usize,
		inputs: &[I],
		outputs: &mut [O],
	) where
		I: AsRef<[FaustFloat]>,
		O: AsMut<[FaustFloat]>,
	{
```
this change should be fully backwards compatible. (as first attemps have shown that needs some review and improvements of testing)

Because I found out that my earlier introduced compute_array interface is not contributing to the performance i removed it here again because it would make this change more complicated.
