### PR TITLE
6) Rust: make `-inpl` possible

### DIFF
--- a/compiler/generator/rust/rust_code_container.hh
+++ b/compiler/generator/rust/rust_code_container.hh
@@ -54,9 +54,11 @@ class RustCodeContainer : public virtual CodeContainer {
     virtual ~RustCodeContainer() {}
 
     virtual void produceClass();
-    void         generateComputeHeader(int n, std::ostream* fOut, int fNumInputs, int fNumOutputs);
+    void         generateComputeHeader(int n, std::ostream* fOut);
+    void         generateComputeIOHeader(int n, std::ostream* fOut);
     void generateComputeFrame(int tab);
     virtual void              generateCompute(int tab) = 0;
+    virtual void              generateComputeIO(int tab) {};
     void                      produceInternal();
     void                      produceFaustDspBlob();
     virtual dsp_factory_base* produceFactory();
@@ -82,6 +84,7 @@ class RustScalarCodeContainer : public RustCodeContainer {
     virtual ~RustScalarCodeContainer() {}
 
     void generateCompute(int tab);
+    void generateComputeIO(int tab);
 };
 
 // The Vector code container.

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -32,6 +32,7 @@ inline std::string makeNameSingular(const std::string& name)
     std::string result = name;
     result             = std::regex_replace(result, std::regex("inputs"), "input");
     result             = std::regex_replace(result, std::regex("outputs"), "output");
+    result             = std::regex_replace(result, std::regex("ios"), "io");
     return result;
 }
 
@@ -243,9 +244,13 @@ class RustInstVisitor : public TextInstVisitor {
         }
         *fOut << ".. ] = " << name;
         if (inst->fMutable) {
-                *fOut << ".as_mut() else { panic!(\"wrong number of outputs\"); };";
+            if (gGlobal->gInPlace){
+                *fOut << ".as_mut() else { panic!(\"wrong number of IO buffers\"); };";
+            } else {
+                *fOut << ".as_mut() else { panic!(\"wrong number of output buffers\"); };";
+            }
         } else {
-                *fOut << ".as_ref() else { panic!(\"wrong number of inputs\"); };";
+                *fOut << ".as_ref() else { panic!(\"wrong number of input buffers\"); };";
         }
 
         // Build fixed size iterator variables

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -1672,6 +1672,10 @@ bool global::processCmdline(int argc, const char* argv[])
         throw faustexception("ERROR : '-rnt' option can only be used with rust\n");
     }
 
+    if (!gRustNoTraitSwitch && gInPlace && gOutputLang == "rust") {
+        throw faustexception("ERROR : for 'rust' the '-inpl' flag must be combined with '-rnt' flag\n");
+    }
+
     if (gInPlace && gVectorSwitch) {
         throw faustexception("ERROR : '-inpl' option can only be used in scalar mode\n");
     }

--- a/tests/impulse-tests/Makefile
+++ b/tests/impulse-tests/Makefile
@@ -122,9 +122,8 @@ travis:
 #########################################################################
 # automatic github action test
 github_action:
+	$(MAKE) -f Make.rust outdir=rust/inpl CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -inpl -rnt -a archs/rust/architecture_inpl.rs"
 	$(MAKE) -f Make.rust outdir=rust/no CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -a archs/rust/architecture_trait.rs"
-	$(MAKE) -f Make.rust outdir=rust/cm CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -cm -a archs/rust/architecture_cm.rs"
-	$(MAKE) -f Make.rust outdir=rust/ecrnt CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -ec -rnt -a archs/rust/architecture_ecrnt.rs"
 	$(MAKE) -f Make.gcc outdir=cpp/double lang=cpp arch=impulsearch.cpp FAUSTOPTIONS="-I ../../libraries/ -I dsp -double"
 
 #########################################################################
@@ -371,6 +370,7 @@ interp1:
 #########################################################################
 # Rust backend
 rust:
+	$(MAKE) -f Make.rust outdir=rust/inpl CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -inpl -rnt -a archs/rust/architecture_inpl.rs"
 	$(MAKE) -f Make.rust outdir=rust/osec CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -os -ec -rnt -a archs/rust/architecture_osecrnt.rs"
 	$(MAKE) -f Make.rust outdir=rust/os CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -os -rnt -a archs/rust/architecture_osrnt.rs"
 	$(MAKE) -f Make.rust outdir=rust/cm CARGOOPTIONS="" FAUSTOPTIONS="-I ../../libraries/ -double -cm -a archs/rust/architecture_cm.rs"

--- a/tests/impulse-tests/archs/rust/architecture_cm.rs
+++ b/tests/impulse-tests/archs/rust/architecture_cm.rs
@@ -31,12 +31,12 @@ extern crate libm;
 extern crate num_traits;
 /* extern crate fastfloat; */
 
+use default_boxed::DefaultBoxed;
+use num_traits::cast::FromPrimitive;
+use num_traits::float::Float;
 use std::env;
 use std::fs::File;
 use std::io::Write;
-
-use default_boxed::DefaultBoxed;
-use num_traits::{cast::FromPrimitive, float::Float};
 
 type F32 = f32;
 type F64 = f64;
@@ -181,11 +181,11 @@ impl<T: Float + FromPrimitive> UI<T> for ButtonUI {
     fn declare(&mut self, param: Option<ParamIndex>, key: &str, value: &str) {}
 }
 
-// // Generated intrinsics:
-// <<includeIntrinsic>>
+// Generated intrinsics:
+<<includeIntrinsic>>
 
-// // Generated class:
-// <<includeclass>>
+// Generated class:
+<<includeclass>>
 
 fn print_header(dsp: &impl FaustDsp<T = FaustFloat>, output_file: &mut File) {
     writeln!(output_file, "number_of_inputs  : {}", dsp.get_num_inputs()).unwrap();

--- a/tests/impulse-tests/archs/rust/architecture_ecrnt.rs
+++ b/tests/impulse-tests/archs/rust/architecture_ecrnt.rs
@@ -31,12 +31,12 @@ extern crate libm;
 extern crate num_traits;
 /* extern crate fastfloat; */
 
+use default_boxed::DefaultBoxed;
+use num_traits::cast::FromPrimitive;
+use num_traits::float::Float;
 use std::env;
 use std::fs::File;
 use std::io::Write;
-
-use default_boxed::DefaultBoxed;
-use num_traits::{cast::FromPrimitive, float::Float};
 
 type F32 = f32;
 type F64 = f64;
@@ -154,11 +154,11 @@ impl<T: Float + FromPrimitive> UI<T> for ButtonUI {
     fn declare(&mut self, param: Option<ParamIndex>, key: &str, value: &str) {}
 }
 
-// // Generated intrinsics:
-// <<includeIntrinsic>>
+// Generated intrinsics:
+<<includeIntrinsic>>
 
-// // Generated class:
-// <<includeclass>>
+// Generated class:
+<<includeclass>>
 
 const SAMPLE_RATE: i32 = 44100;
 

--- a/tests/impulse-tests/archs/rust/architecture_osecrnt.rs
+++ b/tests/impulse-tests/archs/rust/architecture_osecrnt.rs
@@ -30,8 +30,12 @@ extern crate num_traits;
 /* extern crate fastfloat; */
 
 use default_boxed::DefaultBoxed;
-use num_traits::{cast::FromPrimitive, float::Float};
-use std::{convert::TryInto, env, fs::File, io::Write};
+use num_traits::cast::FromPrimitive;
+use num_traits::float::Float;
+use std::convert::TryInto;
+use std::env;
+use std::fs::File;
+use std::io::Write;
 
 type F32 = f32;
 type F64 = f64;
@@ -150,10 +154,10 @@ impl<T: Float + FromPrimitive> UI<T> for ButtonUI {
 }
 
 // Generated intrinsics:
-//<<includeIntrinsic>>
+<<includeIntrinsic>>
 
 // Generated class:
-//<<includeclass>>
+<<includeclass>>
 
 const SAMPLE_RATE: i32 = 44100;
 

--- a/tests/impulse-tests/archs/rust/architecture_trait.rs
+++ b/tests/impulse-tests/archs/rust/architecture_trait.rs
@@ -29,11 +29,11 @@ extern crate libm;
 extern crate num_traits;
 /* extern crate fastfloat; */
 
+use num_traits::cast::FromPrimitive;
+use num_traits::float::Float;
 use std::env;
 use std::fs::File;
 use std::io::Write;
-
-use num_traits::{cast::FromPrimitive, float::Float};
 
 type F32 = f32;
 type F64 = f64;
@@ -289,10 +289,5 @@ fn main() {
 
     print_header(new_dsp(), num_total_samples, &mut output_file);
 
-    // Only test mono DSP for now
     run_dsp(new_dsp(), block_size, 0, &mut output_file);
-
-    //run_dsp(new_dsp(), block_size, 1 * block_size, &mut output_file);
-    //run_dsp(new_dsp(), block_size, 2 * block_size, &mut output_file);
-    //run_dsp(new_dsp(), block_size, 3 * block_size, &mut output_file);
 }


### PR DESCRIPTION
In rust it is not possible to have two references to the same buffer if one is mutable. 
This makes it impossible to write to the same place from which one reads, if one wants to have different variables holding references to do so.  This is the case for our input and output buffer references in the compute function.

To circumvent this limitation of rust I propose to introduce a different compute interface if the `-inpl` flag is used.
I propose to have a single variable for input and output.
Instead of `pub fn compute(&mut self, count: usize, inputs: &[&[FaustFloat]], outputs: &mut [&mut [FaustFloat]])`, I propose: `pub fn compute(&mut self, count: usize, outputs: &mut [&mut [FaustFloat]])` 

Or to be more precise for the case PR #1087 is accepted:
```
	pub fn compute<IOType>(
		&mut self,
		count: usize,
		mut ios: impl borrow::BorrowMut<[IOType]>,
	) where
		IOType: borrow::BorrowMut<[FaustFloat]>,
	{
``` 
This is less flexible then it is currently in C/Cpp where buffer order can be freely arranged for input and output buffers.

I also looked at the option to use unsafe, but when we read from two different variables holding pointers to the same address auto vectorization will not be done. 

with the proposed solution auto vectorization is possible.
