### PR TITLE
rust: FaustDsp trait improvements

### DIFF
--- a/architecture/rust/cpal.rs
+++ b/architecture/rust/cpal.rs
@@ -58,8 +58,8 @@ pub trait FaustDsp {
     fn new() -> Self where Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_params(&mut self);
     fn instance_clear(&mut self);
@@ -70,7 +70,12 @@ pub trait FaustDsp {
     fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {

--- a/architecture/rust/jack-double.rs
+++ b/architecture/rust/jack-double.rs
@@ -57,8 +57,8 @@ pub trait FaustDsp {
     fn new() -> Self where Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_params(&mut self);
     fn instance_clear(&mut self);
@@ -69,7 +69,12 @@ pub trait FaustDsp {
     fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {

--- a/architecture/rust/jack-float.rs
+++ b/architecture/rust/jack-float.rs
@@ -57,8 +57,8 @@ pub trait FaustDsp {
     fn new() -> Self where Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_params(&mut self);
     fn instance_clear(&mut self);
@@ -69,7 +69,12 @@ pub trait FaustDsp {
     fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {

--- a/architecture/rust/minimal.rs
+++ b/architecture/rust/minimal.rs
@@ -61,8 +61,8 @@ pub trait FaustDsp {
     fn new() -> Self where Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_params(&mut self);
     fn instance_clear(&mut self);
@@ -73,7 +73,12 @@ pub trait FaustDsp {
     fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {

--- a/architecture/rust/portaudio-double.rs
+++ b/architecture/rust/portaudio-double.rs
@@ -57,8 +57,8 @@ pub trait FaustDsp {
     fn new() -> Self where Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_params(&mut self);
     fn instance_clear(&mut self);
@@ -69,7 +69,12 @@ pub trait FaustDsp {
     fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {

--- a/architecture/rust/portaudio-float.rs
+++ b/architecture/rust/portaudio-float.rs
@@ -57,8 +57,8 @@ pub trait FaustDsp {
     fn new() -> Self where Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32) where Self: Sized;
     fn instance_reset_params(&mut self);
     fn instance_clear(&mut self);
@@ -69,7 +69,12 @@ pub trait FaustDsp {
     fn build_user_interface_static(ui_interface: &mut dyn UI<Self::T>) where Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut[&mut[Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -182,11 +182,11 @@ void RustCodeContainer::produceFaustDspBlob()
     *fOut << tab << "fn get_sample_rate(&self) -> i32 {" << endl;
     *fOut << tab << tab << "self.get_sample_rate()" << endl;
     *fOut << tab << "}" << endl;
-    *fOut << tab << "fn get_num_inputs(&self) -> i32 {" << endl;
-    *fOut << tab << tab << "FAUST_INPUTS as i32" << endl;
+    *fOut << tab << "fn get_num_inputs(&self) -> usize {" << endl;
+    *fOut << tab << tab << "FAUST_INPUTS" << endl;
     *fOut << tab << "}" << endl;
-    *fOut << tab << "fn get_num_outputs(&self) -> i32 {" << endl;
-    *fOut << tab << tab << "FAUST_OUTPUTS as i32" << endl;
+    *fOut << tab << "fn get_num_outputs(&self) -> usize {" << endl;
+    *fOut << tab << tab << "FAUST_OUTPUTS" << endl;
     *fOut << tab << "}" << endl;
     *fOut << tab << "fn class_init(sample_rate: i32) where Self: Sized {" << endl;
     *fOut << tab << tab << "Self::class_init(sample_rate);" << endl;
@@ -221,11 +221,13 @@ void RustCodeContainer::produceFaustDspBlob()
     *fOut << tab << "fn set_param(&mut self, param: ParamIndex, value: Self::T) {" << endl;
     *fOut << tab << tab << "self.set_param(param, value)" << endl;
     *fOut << tab << "}" << endl;
-    *fOut << tab
-          << "fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut [&mut "
-             "[Self::T]]) {"
-          << endl;
-    *fOut << tab << tab << "self.compute(count as usize, inputs, outputs)" << endl;
+    *fOut << tab << "fn compute(" << endl;
+    *fOut << tab << "&mut self," << endl;
+    *fOut << tab << "count: usize," << endl;
+    *fOut << tab << "inputs: &[impl AsRef<[Self::T]>]," << endl;
+    *fOut << tab << "outputs: &mut [impl AsMut<[Self::T]>]," << endl;
+    *fOut << tab << ") {" << endl;
+    *fOut << tab << tab << "self.compute(count, inputs, outputs)" << endl;
     *fOut << tab << "}" << endl;
     *fOut << "}" << endl;
 }

--- a/tests/impulse-tests/archs/rust/architecture_cm.rs
+++ b/tests/impulse-tests/archs/rust/architecture_cm.rs
@@ -65,8 +65,8 @@ pub trait FaustDsp {
         Self: Sized;
     fn metadata(&self, m: &mut dyn Meta);
     fn get_sample_rate(&self) -> i32;
-    fn get_num_inputs(&self) -> i32;
-    fn get_num_outputs(&self) -> i32;
+    fn get_num_inputs(&self) -> usize;
+    fn get_num_outputs(&self) -> usize;
     fn class_init(sample_rate: i32)
     where
         Self: Sized;
@@ -81,7 +81,12 @@ pub trait FaustDsp {
         Self: Sized;
     fn get_param(&self, param: ParamIndex) -> Option<Self::T>;
     fn set_param(&mut self, param: ParamIndex, value: Self::T);
-    fn compute(&mut self, count: i32, inputs: &[&[Self::T]], outputs: &mut [&mut [Self::T]]);
+    fn compute(
+        &mut self,
+        count: usize,
+        inputs: &[impl AsRef<[Self::T]>],
+        outputs: &mut [impl AsMut<[Self::T]>],
+    );
 }
 
 pub trait Meta {
@@ -132,7 +137,7 @@ pub struct ButtonUI {
 }
 
 impl ButtonUI {
-    fn set_button_parameters_to(&self, dsp: &mut dyn FaustDsp<T = f64>, value: f64) {
+    fn set_button_parameters_to(&self, dsp: &mut impl FaustDsp<T = f64>, value: f64) {
         for button_param in &self.all_button_params {
             dsp.set_param(*button_param, value);
         }


### PR DESCRIPTION
This PR has braking changes to the faust interface via the FaustDsp trait.
I provides the same type signature of compute in FaustDsp as I do for direct use.
I think this simplifies code significantly as vectors as well as slices can be used as arguments.
Additionally i change the type of the return value of get_num_input get_num_output methods. 
The change implies some changes as the change makes FaustDsp lose its  trait-object safty.
faust-state in rust-faust needs to be changed from a dyn box (dynamic dispatch) to a impl (static dispatch) as [done here](https://github.com/crop2000/rust-faust/commit/4d767a09dfa468a90b6aca5fdd7a348efebf7ded#diff-d0ff5010397e73912922507f32118dccd0d21b8d39dec3ad5eecc0411b83ea37R290). 


