### PR TITLE
use DAISY preprocessor to avoid dynamic_cast

### DIFF
--- a/architecture/faust/dsp/poly-dsp.h
+++ b/architecture/faust/dsp/poly-dsp.h
@@ -398,7 +398,11 @@ struct dsp_voice_group {
             ui_interface->closeBox();
 
             // If not grouped, also add individual voices UI
+#ifdef DAISY
+            if (!fGroupControl || ui_interface->isSoundUI()) {
+#else
             if (!fGroupControl || dynamic_cast<SoundUIInterface*>(ui_interface)) {
+#endif
                 for (size_t i = 0; i < fVoiceTable.size(); i++) {
                     char buffer[32];
                     snprintf(buffer, 32, ((fVoiceTable.size() < 8) ? "Voice%ld" : "V%ld"), long(i+1));
@@ -757,10 +761,17 @@ class mydsp_poly : public dsp_voice_group, public dsp_poly {
         void buildUserInterface(UI* ui_interface)
         {
             // MidiUI ui_interface contains the midi_handler connected to the MIDI driver
+            #ifdef DAISY
+            if (ui_interface->isMidiInterface()) {
+                fMidiHandler = reinterpret_cast<midi_interface*>(ui_interface);
+                fMidiHandler->addMidiIn(this);
+            }
+            #else
             if (dynamic_cast<midi_interface*>(ui_interface)) {
                 fMidiHandler = dynamic_cast<midi_interface*>(ui_interface);
                 fMidiHandler->addMidiIn(this);
             }
+            #endif
             dsp_voice_group::buildUserInterface(ui_interface);
         }
 

--- a/architecture/faust/gui/DecoratorUI.h
+++ b/architecture/faust/gui/DecoratorUI.h
@@ -38,6 +38,10 @@ class FAUST_API GenericUI : public UI
         
         GenericUI() {}
         virtual ~GenericUI() {}
+
+#ifdef DAISY
+        virtual bool isSoundUI() const override { return true;
+#endif
         
         // -- widget's layouts
         virtual void openTabBox(const char* label) {}

--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -812,6 +812,10 @@ class MidiUI : public GUI, public midi, public midi_interface, public MetaDataUI
             // TODO: use shared_ptr based implementation
             if (fDelete) delete fMidiHandler;
         }
+
+#ifdef DAISY
+        virtual bool isMidiInterface() const override { return true; }
+#endif
     
         bool run() { return fMidiHandler->startMidi(); }
         void stop() { fMidiHandler->stopMidi(); }

--- a/architecture/faust/gui/UI.h
+++ b/architecture/faust/gui/UI.h
@@ -81,6 +81,10 @@ struct FAUST_API UIReal {
 struct FAUST_API UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
+#ifdef DAISY
+    virtual bool isSoundUI() const { return false; }
+    virtual bool isMidiInterface() const { return false; }
+#endif
 };
 
 #endif


### PR DESCRIPTION
I'm trying to address https://github.com/grame-cncm/faust/issues/1090. Can some Daisy users quality-control this? I'll be away from my Daisy equipment for several days.