### PR TITLE
Fixing naming conflict of DAISY preprocessor flag of the newer libDaisy master branch

### DIFF
--- a/architecture/faust/dsp/poly-dsp.h
+++ b/architecture/faust/dsp/poly-dsp.h
@@ -398,7 +398,7 @@ struct dsp_voice_group {
             ui_interface->closeBox();
 
             // If not grouped, also add individual voices UI
-#ifdef DAISY
+#ifdef DAISY_NO_RTTI
             if (!fGroupControl || ui_interface->isSoundUI()) {
 #else
             if (!fGroupControl || dynamic_cast<SoundUIInterface*>(ui_interface)) {
@@ -761,7 +761,7 @@ class mydsp_poly : public dsp_voice_group, public dsp_poly {
         void buildUserInterface(UI* ui_interface)
         {
             // MidiUI ui_interface contains the midi_handler connected to the MIDI driver
-            #ifdef DAISY
+            #ifdef DAISY_NO_RTTI
             if (ui_interface->isMidiInterface()) {
                 fMidiHandler = reinterpret_cast<midi_interface*>(ui_interface);
                 fMidiHandler->addMidiIn(this);

--- a/architecture/faust/gui/DecoratorUI.h
+++ b/architecture/faust/gui/DecoratorUI.h
@@ -39,7 +39,7 @@ class FAUST_API GenericUI : public UI
         GenericUI() {}
         virtual ~GenericUI() {}
 
-#ifdef DAISY
+#ifdef DAISY_NO_RTTI
         virtual bool isSoundUI() const override { return true; }
 #endif
         

--- a/architecture/faust/gui/MidiUI.h
+++ b/architecture/faust/gui/MidiUI.h
@@ -813,7 +813,7 @@ class MidiUI : public GUI, public midi, public midi_interface, public MetaDataUI
             if (fDelete) delete fMidiHandler;
         }
 
-#ifdef DAISY
+#ifdef DAISY_NO_RTTI
         virtual bool isMidiInterface() const override { return true; }
 #endif
     

--- a/architecture/faust/gui/UI.h
+++ b/architecture/faust/gui/UI.h
@@ -81,7 +81,7 @@ struct FAUST_API UIReal {
 struct FAUST_API UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
-#ifdef DAISY
+#ifdef DAISY_NO_RTTI
     virtual bool isSoundUI() const { return false; }
     virtual bool isMidiInterface() const { return false; }
 #endif

--- a/tools/faust2appls/faust2daisy
+++ b/tools/faust2appls/faust2daisy
@@ -145,8 +145,8 @@ for p in $FILE; do
     # for Buffer Size
     echo "#define MY_BUFFER_SIZE $BS" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
 
-    # for DAISY preprocessor flag (to avoid dynamic casts since libdaisy is compiled with -fno-rtti flag)
-    echo "#define DAISY" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+    # for DAISY_NO_RTTI preprocessor flag (to avoid dynamic casts since libdaisy is compiled with -fno-rtti flag)
+    echo "#define DAISY_NO_RTTI" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
 
     # for POLY
     if [ "$NVOICES" -gt "0" ]; then


### PR DESCRIPTION
Adressing Issue #1090 

When testing the PR #1105 my libDaisy repo was not up to date. 
I updated to commit bd13385 and found out that the newly introduced compiler flag "DAISY" creates a naming conflict, since "DAISY" is used in an enum of libDaisy 

` /libDaisy/src/sys/system.h:161:14: error: expected identifier before ',' token
  161 |         DAISY,`

renamed the preprocessor FLAG to DAISY_NO_RTTI for a  more unique name.


