### PR TITLE
add varname to Unity template

### DIFF
--- a/architecture/unity/FaustUtilities_template.cs
+++ b/architecture/unity/FaustUtilities_template.cs
@@ -582,6 +582,11 @@ namespace FaustUtilities_MODEL {
                                         uiItems[numItems].url = value.ToString();
                                     }
                                     break;
+                                case "varname":
+                                    if (parseChar(ref s, ':') && parseDQString(ref s, out value)) {
+                                        uiItems[numItems].varname = value.ToString();
+                                    }
+                                    break;
                                 case "meta":
                                     uiItems[numItems].meta = new List < Meta > ();
                                     if (!parseItemMetaData(ref s, uiItems[numItems].meta)) {
@@ -642,6 +647,7 @@ namespace FaustUtilities_MODEL {
         public string shortname;
         public string address;
         public string url;
+        public string varname;
         public List < Meta > meta;
         public List < Group > items;
         public float init;


### PR DESCRIPTION
I imported a Faust2Unity plugin into my Unity project. I was hitting this error which indicated the JSON for generating UI failed to parse. Stepping through in the debugger, it was failing because there was no case for `varname`.

```cs
if (!FaustUI.fJSONParser(ref fJSON, out fUI)) { // Parses the JSON file
      UnityEngine.Debug.LogError("Error JSON Parser");
}
```