### PR TITLE
-i flag to languages

### DIFF
--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -1661,8 +1661,9 @@ bool global::processCmdline(int argc, const char* argv[])
     // Check options coherency
     // ========================
 
-    if (gRustNoTraitSwitch && gOutputLang != "rust") {
-        throw faustexception("ERROR : '-rnt' option can only be used with rust\n");
+   if (option_i && targetLang == "rust") {
+    std::cerr << "Warning: The -i flag has no effect when compiling to Rust." << std::endl;
+    option_i = false; // Disable the flag for Rust
     }
 
     if (!gRustNoTraitSwitch && gInPlace && gOutputLang == "rust") {

--- a/compiler/parser/enrobage.cpp
+++ b/compiler/parser/enrobage.cpp
@@ -142,7 +142,12 @@ class myparser {
 /**
  * True if string s match '#include <faust/fname>' or include("/usr/local/share/faust/julia/fname")
  */
-static bool isFaustInclude(const string& line, string& fname)
+static bool isFaustInclude(const string& line, string& fname, const string& targetLang){
+
+if (targetLang == "rust") {
+        return false;
+
+}
 {
     myparser P(line);
     // C/C++ case
@@ -154,7 +159,7 @@ static bool isFaustInclude(const string& line, string& fname)
         myparser Q(fname);
         return Q.parse("/usr/local/share/faust/julia");
     } else {
-        return false;
+        return true;
     }
 }
 


### PR DESCRIPTION
Fixes #1070 

updated the code to check the target language whenever the -i flag is used.

If the target language is Rust, the flag is disabled,

modified the file enrobage.cpp to ensure the -i flag logic only applies to languages where it makes sense.