### PR TITLE
Change error message format to $file:$line

### DIFF
--- a/compiler/errors/errormsg.cpp
+++ b/compiler/errors/errormsg.cpp
@@ -65,7 +65,7 @@ void lexerror(const char* msg)
 void FAUSTerror(const char* msg)
 {
     stringstream error;
-    error << FAUSTfilename << " : " << FAUSTlineno << " : ERROR : " << msg << endl;
+    error << FAUSTfilename << ":" << FAUSTlineno << " : ERROR : " << msg << endl;
     gGlobal->gErrorCount++;
     throw faustexception(error.str());
 }
@@ -73,7 +73,7 @@ void FAUSTerror(const char* msg)
 void evalerror(const char* filename, int linenum, const char* msg, Tree exp)
 {
     stringstream error;
-    error << filename << " : " << linenum << " : ERROR : " << msg << " : " << boxpp(exp) << endl;
+    error << filename << ":" << linenum << " : ERROR : " << msg << " : " << boxpp(exp) << endl;
     gGlobal->gErrorCount++;
     throw faustexception(error.str());
 }
@@ -81,7 +81,7 @@ void evalerror(const char* filename, int linenum, const char* msg, Tree exp)
 void evalerrorbox(const char* filename, int linenum, const char* msg, Tree exp)
 {
     stringstream error;
-    error << filename << " : " << linenum << " : ERROR : " << msg << " : " << boxpp(exp) << endl;
+    error << filename << ":" << linenum << " : ERROR : " << msg << " : " << boxpp(exp) << endl;
     gGlobal->gErrorCount++;
     throw faustexception(error.str());
 }
@@ -89,14 +89,14 @@ void evalerrorbox(const char* filename, int linenum, const char* msg, Tree exp)
 void evalwarning(const char* filename, int linenum, const char* msg, Tree exp)
 {
     stringstream error;
-    error << filename << " : " << linenum << " : WARNING : " << msg << " : " << boxpp(exp) << endl;
+    error << filename << ":" << linenum << " : WARNING : " << msg << " : " << boxpp(exp) << endl;
     gGlobal->gErrorMessage = error.str();
 }
 
 void evalremark(const char* filename, int linenum, const char* msg, Tree exp)
 {
     stringstream error;
-    error << filename << " : " << linenum << " : REMARK : " << msg << " : " << boxpp(exp) << endl;
+    error << filename << ":" << linenum << " : REMARK : " << msg << " : " << boxpp(exp) << endl;
     gGlobal->gErrorMessage = error.str();
 }
 

--- a/compiler/parser/faustparser.cpp
+++ b/compiler/parser/faustparser.cpp
@@ -388,7 +388,7 @@ int FAUSTlex();
 void yyerror(char* msg) 
 {
     std::stringstream error;
-    error << FAUSTfilename << " : " << FAUSTlineno << " : ERROR : " << msg << endl;
+    error << FAUSTfilename << ":" << FAUSTlineno << " : ERROR : " << msg << endl;
     gGlobal->gErrorCount++;
     throw faustexception(error.str());
 }

--- a/compiler/parser/faustparser.y
+++ b/compiler/parser/faustparser.y
@@ -33,7 +33,7 @@ int FAUSTlex();
 void yyerror(char* msg) 
 {
     std::stringstream error;
-    error << FAUSTfilename << " : " << FAUSTlineno << " : ERROR : " << msg << endl;
+    error << FAUSTfilename << ":" << FAUSTlineno << " : ERROR : " << msg << endl;
     gGlobal->gErrorCount++;
     throw faustexception(error.str());
 }


### PR DESCRIPTION
This allows "jump to error" functionality in many IDEs / editors.