### PR TITLE
Add parameter tracking and FFun/FVar in SDF3 backend

### DIFF
--- a/compiler/generator/sdf3/SDF.cpp
+++ b/compiler/generator/sdf3/SDF.cpp
@@ -101,6 +101,11 @@ void Actor::addInputSignalName(const string& name)
     this->inputSignals.push_back(name);
 }
 
+void Actor::addParameter(const std::string& paramName, const std::string& paramVal)
+{
+    this->params[paramName] = paramVal;
+}
+
 void Actor::addPort(Port newPort)
 {
     this->ports.push_back(newPort);
@@ -143,6 +148,11 @@ pair<string, int> Actor::getArg()
 vector<string> Actor::getInputSignalNames()
 {
     return this->inputSignals;
+}
+
+std::map<std::string, std::string> Actor::getParams()
+{
+    return this->params;
 }
 
 // replace old signal name with new signal name (order must be retained)

--- a/compiler/generator/sdf3/SDF.hh
+++ b/compiler/generator/sdf3/SDF.hh
@@ -48,19 +48,21 @@ class Port {
 class Actor {
    public:
     Actor(const std::string&, const std::string&);
-    void                        setName(const std::string&);
-    void                        setType(const std::string&);
-    void                        addPort(Port);
-    void                        removePort(const std::string&);
-    void                        setDelayInputSigName(const std::string&);
-    void                        setArg(const std::string&, int);
-    void                        addInputSignalName(const std::string&);
-    std::string                 getName();
-    std::string                 getType();
-    std::vector<Port>           getPorts();
-    std::string                 getDelayInputSigName();
-    std::pair<std::string, int> getArg();
-    std::vector<std::string>    getInputSignalNames();
+    void              setName(const std::string&);
+    void              setType(const std::string&);
+    void              addPort(Port);
+    void              removePort(const std::string&);
+    void              setDelayInputSigName(const std::string&);
+    void              setArg(const std::string&, int);
+    void              addInputSignalName(const std::string&);
+    void              addParameter(const std::string& paramName, const std::string& paramVal);
+    std::string       getName();
+    std::string       getType();
+    std::vector<Port> getPorts();
+    std::string       getDelayInputSigName();
+    std::pair<std::string, int>        getArg();
+    std::vector<std::string>           getInputSignalNames();
+    std::map<std::string, std::string> getParams();
     void replaceInputSignalName(const std::string& oldName, const std::string& newName);
     void writeToXML(std::ostream& fout);
     void writePropertiesToXML(std::ostream& fout);
@@ -75,6 +77,8 @@ class Actor {
     std::pair<std::string, int> args;
     std::vector<std::string> inputSignals;  // track list of input signals for rec operator in order
                                             // to bypass it in SDF representation
+    std::map<std::string, std::string>
+        params;  // track parameters for given actor (i.e. init, min, max)
 };
 
 class Channel {

--- a/compiler/generator/sdf3/signal2SDF.hh
+++ b/compiler/generator/sdf3/signal2SDF.hh
@@ -48,6 +48,7 @@ class Signal2SDF : public TreeTraversal {
     std::vector<std::string>       delayActors;
     std::vector<std::string>       recActors;
     std::vector<std::string>       inputArgTrackedActors;
+    std::vector<std::string>       uiActors;
 
     void visit(Tree t) override;
 
@@ -67,6 +68,9 @@ class Signal2SDF : public TreeTraversal {
     void        logRecActor(Tree sig, Tree le, const std::string& type);
     void        logBinopActor(Tree sig, Tree x, Tree y, const std::string& type);
     void        logUIActor(Tree sig, Tree init);
+    void        logUISliderActor(Tree sig, const std::string& type, Tree init, Tree min, Tree max,
+                                 Tree step);
+    void        logUIGraphActor(Tree sig, const std::string& type, Tree min, Tree max, Tree t0);
     void        logPowActor(Tree sig, Tree x, Tree y, const std::string& type);
     void        logCastActor(Tree sig, Tree x, const std::string& type);
     bool        isSigPow(Tree sig, int* i, Tree& x, Tree& y);


### PR DESCRIPTION
Updated SDF3 backend to account for FFun and FVar nodes; would previously throw errors when encountered. Also track UI and delay parameter details in SDF actor names.