### PR TITLE
Add new `mesh2faust` API method to generate modal model and Faust DSP code independently

### DIFF
--- a/tools/physicalModeling/mesh2faust/src/mesh2faust.h
+++ b/tools/physicalModeling/mesh2faust/src/mesh2faust.h
@@ -49,6 +49,8 @@ Response mesh2faust(const char *objFileName = "", MaterialProperties material = 
 // Material properties are assumed to already be baked into the mesh, but we still need the Rayleigh damping coefficients.
 Response mesh2faust(TetMesh *volumetricMesh, MaterialProperties material = {}, CommonArguments args = {});
 
+ModalModel mesh2modal(TetMesh *volumetricMesh, MaterialProperties material = {}, CommonArguments args = {});
+
 ModalModel mesh2modal(
     const Eigen::SparseMatrix<double> &M, // Mass matrix
     const Eigen::SparseMatrix<double> &K, // Stiffness matrix
@@ -65,6 +67,6 @@ struct DspGenArguments {
 };
 
 // Generate DSP code from a `ModalModel`.
-Response modal2faust(const ModalModel &, DspGenArguments args = {});
+std::string modal2faust(const ModalModel &, DspGenArguments args = {});
 
 } // namespace mesh2faust


### PR DESCRIPTION
This allows users to compute the modal model separately from the DSP code. It is technically API-breaking since the existing `modal2faust` response changes from a `Response` type to a `std::string`, but I doubt anyone else is using these extra methods. The main intended API is the `mesh2faust` methods, which haven't changed. The only thing missing from the `Response`-typed response is the `ModalModel` they passed into the method anyway.