### PR TITLE
Add missing cstdint include required by gcc 15

### DIFF
--- a/compiler/DirectedGraph/DirectedGraph.hh
+++ b/compiler/DirectedGraph/DirectedGraph.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Fixes https://github.com/grame-cncm/faust/issues/1144.