### PR TITLE
rust: fix unecessary mutablity for waveforms

### DIFF
--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -193,7 +193,9 @@ class RustInstVisitor : public TextInstVisitor {
 
     virtual void visit(DeclareVarInst* inst)
     {
-        if (inst->fAddress->isStaticStruct()) {
+        if (inst->fAddress->isStaticStruct() && (inst->getAccess() & Address::kConst )) {
+            *fOut << "static ";
+        } else if (inst->fAddress->isStaticStruct()) {
             *fOut << "static mut ";
         } else if (inst->getAccess() & Address::kStack || inst->getAccess() & Address::kLoop) {
             *fOut << "let mut ";


### PR DESCRIPTION
in rust: currently waveforms are stored in a mutable static variable that doesn't need to be mutable. this pr fixes this.