### PR TITLE
[draft] safe static mut based on `RwLock`

### DIFF
--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -55,11 +55,8 @@ class CollectStaticVarsVisitor : public DispatchVisitor {
 
     virtual void visit(DeclareVarInst* inst)
     {
-        std::cout << "VISITING DeclareVarInst\n";
-        std::cout << inst->getName() << " " << inst->fAddress->isStaticStruct() << " " << (inst->getAccess() & Address::kConst) << " " << (inst->getAccess() & Address::kMutable) << "\n";
         if (inst->fAddress->isStaticStruct() && !(inst->getAccess() & Address::kConst)) {
             fStaticVarNames.push_back(inst->getName());
-            std::cout << "ADDING " << inst->getName() << "\n";
         }
     }
 
@@ -264,8 +261,7 @@ void RustCodeContainer::produceFaustDspBlob()
 
 void RustCodeContainer::produceClass()
 {
-    // Initialize fStaticVarNames by collecting static vars from static init instructions.
-    std::cout << "Collecting static vars...\n";
+    // Initialize fStaticVarNames by collecting static vars from global declarations.
     CollectStaticVarsVisitor collectStaticVarsVisitor{};
     generateGlobalDeclarations(&collectStaticVarsVisitor);
     fStaticVarNames = collectStaticVarsVisitor.getStaticVarNames();

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -417,6 +417,14 @@ void RustCodeContainer::produceClass()
         // Local visitor here to avoid DSP object type wrong generation
         RustInstVisitor codeproducer(fOut, "");
         codeproducer.Tab(n + 2);
+        // Obtain write locks on RwLock instances
+        *fOut << "// Obtaining write locks on " << fSubContainers.size() << " subcontainers";
+        tab(n + 1, *fOut);
+        for (const auto& subContainer : fSubContainers) {
+            const auto& staticVarName = "ftbl0" + subContainer->getFullClassName();
+            *fOut << "let mut " << staticVarName << "_guard = " << staticVarName << ".write().unwrap();";
+            tab(n + 2, *fOut);
+        }
         generateStaticInit(&codeproducer);
     }
     back(1, *fOut);
@@ -703,6 +711,15 @@ void RustScalarCodeContainer::generateCompute(int n)
     generateComputeHeader(n, fOut);
     tab(n + 1, *fOut);
     fCodeProducer.Tab(n + 1);
+
+    // Obtain read locks on RwLock instances
+    *fOut << "// Obtaining read locks on " << fSubContainers.size() << " subcontainers";
+    tab(n + 1, *fOut);
+    for (const auto& subContainer : fSubContainers) {
+        const auto& staticVarName = "ftbl0" + subContainer->getFullClassName();
+        *fOut << "let " << staticVarName << "_guard = " << staticVarName << ".read().unwrap();";
+        tab(n + 1, *fOut);
+    }
 
     generateComputeBlock(&fCodeProducer);
 

--- a/compiler/generator/rust/rust_code_container.hh
+++ b/compiler/generator/rust/rust_code_container.hh
@@ -29,6 +29,8 @@
 #include "vec_code_container.hh"
 #include "wss_code_container.hh"
 
+#include <vector>
+
 #ifdef WIN32
 #pragma warning(disable : 4250)
 #endif
@@ -39,6 +41,7 @@ class RustCodeContainer : public virtual CodeContainer {
    protected:
     RustInstVisitor fCodeProducer;
     std::ostream*   fOut;
+    std::vector<std::string> fStaticVarNames;
 
     void produceMetadata(int tabs);
 
@@ -46,7 +49,7 @@ class RustCodeContainer : public virtual CodeContainer {
 
    public:
     RustCodeContainer(const std::string& name, int numInputs, int numOutputs, std::ostream* out)
-        : fCodeProducer(out, name), fOut(out)
+        : fCodeProducer(out, name), fOut(out), fStaticVarNames{}
     {
         initialize(numInputs, numOutputs);
         fKlassName = name;
@@ -84,8 +87,8 @@ class RustScalarCodeContainer : public RustCodeContainer {
                             std::ostream* out, int sub_container_type);
     virtual ~RustScalarCodeContainer() {}
 
-    void generateCompute(int tab);
-    void generateComputeIO(int tab);
+    void generateCompute(int tab) override;
+    void generateComputeIO(int tab) override;
 };
 
 // The Vector code container.
@@ -110,7 +113,7 @@ class RustOpenMPCodeContainer : public OpenMPCodeContainer, public RustCodeConta
                             std::ostream* out);
     virtual ~RustOpenMPCodeContainer() {}
 
-    void generateCompute(int tab);
+    void generateCompute(int tab) override;
 };
 
 // The WorkStealing code container (not implemented yet).
@@ -122,7 +125,7 @@ class RustWorkStealingCodeContainer : public WSSCodeContainer, public RustCodeCo
                                   std::ostream* out);
     virtual ~RustWorkStealingCodeContainer() {}
 
-    void generateCompute(int tab);
+    void generateCompute(int tab) override;
 };
 
 #endif

--- a/compiler/generator/rust/rust_code_container.hh
+++ b/compiler/generator/rust/rust_code_container.hh
@@ -54,6 +54,7 @@ class RustCodeContainer : public virtual CodeContainer {
     virtual ~RustCodeContainer() {}
 
     virtual void              produceClass();
+    void                      generateLockGuards(int n, bool read);
     void                      generateComputeHeader(int n, std::ostream* fOut);
     void                      generateComputeIOHeader(int n, std::ostream* fOut);
     void                      generateComputeFrame(int tab);

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -348,9 +348,6 @@ class RustInstVisitor : public TextInstVisitor {
     virtual void visit(IndexedAddress* indexed)
     {
         indexed->fAddress->accept(this);
-        // if (indexed->isStaticStruct()) {
-        //     *fOut << "_guard";
-        // }
         if (isInt32Num(indexed->getIndex())) {
             *fOut << "[";
             indexed->getIndex()->accept(this);

--- a/compiler/generator/rust/rust_instructions.hh
+++ b/compiler/generator/rust/rust_instructions.hh
@@ -343,16 +343,6 @@ class RustInstVisitor : public TextInstVisitor {
         }
         *fOut << named->getName();
         if (named->isStaticStruct()) {
-            std::cout << "usage of: " << named->getName() <<
-                " kStack=" << (named->getAccess() & Address::kStack) <<
-                " kGlobal=" << (named->getAccess() & Address::kGlobal) <<
-                " kLink=" << (named->getAccess() & Address::kLink) <<
-                " kLoop=" << (named->getAccess() & Address::kLoop) <<
-                " kVolatile=" << (named->getAccess() & Address::kVolatile) <<
-                " kConst=" << (named->getAccess() & Address::kConst) <<
-                " kReference=" << (named->getAccess() & Address::kReference) <<
-                " kMutable=" << (named->getAccess() & Address::kMutable) <<
-                "\n";
             if (fVarsRequiringGuards.find(named->getName()) != fVarsRequiringGuards.end()) {
                 *fOut << "_guard";
             }


### PR DESCRIPTION
This would be my proposal after thinking about #1005 and #1150 a bit more.

I did some comparison of safe solutions based on `thread_local`, `Mutex`, and `RwLock`. `RwLock` feels like it is semantically the best fit for our use case, because we need to write to these static mut tables (essentially) once, and the `compute` function only needs read access. Coincidentally, `RwLock` had the best performance in my benchmarks, which a basically negligible performance overhead. Note that it is impossible the have exactly zero overhead, because fixing the unsoundness needs at least a tiny boolean check internally for correctness proofing. But this boolean check is barely measurable even in an isolated experiment, and even more so in real life, and the resulting Rust examples have even better performance than their C++ counterparts, so all good.

This solution gets fully rid of `unsafe` usages around static mut, i.e., everything gets solved entirely in "Safe Rust" land.

To illustrate the changes. My running example for the codegen was:

```faust
import("stdfaust.lib");

envelope(gate) = gate : en.adsr(0.01, 0.01, 0.3, 0.1);
synth(gate, freq) = envelope(gate) * os.osc(freq);

process = synth;
```

The key ideas of the codegen in this example are (left is old codegen, right is after this change):

* Replace the plain `static mut` arrays with `static RwLock` instances:
![image](https://github.com/user-attachments/assets/926bcf6f-1dbf-4ce2-979d-b1bfb3ad4935)
* In the `class_init` obtain writable guards on these statics. The pattern is always to use `<static-var-name>_guard` for these instances. In the "visit" of these vars, the `_guard` suffix gets appended:
![image](https://github.com/user-attachments/assets/376960e8-1aee-4306-97f9-3b38161149e7)
* In `compute` we do the read equivalent of that, otherwise same idea:
![image](https://github.com/user-attachments/assets/ff7e816a-1d96-4fd8-80be-548798deb22d)

I assume that not all tests will pass at first, and the implementation may need a bit polishing. In particular the way I'm obtaining these static var names feels pretty hacky currently. Would love to get some hints how to solve that more elegantly.

CC @crop2000 
