### PR TITLE
fbc: fix build error with clang 20 on windows

### DIFF
--- a/compiler/generator/interpreter/fbc_compiler.hh
+++ b/compiler/generator/interpreter/fbc_compiler.hh
@@ -78,7 +78,7 @@ class FBCCompiler : public FBCInterpreter<REAL, 0> {
 #endif
 #else
 #ifdef WIN32
-#pragma message("warning pure Interpreter mode");
+#pragma message("warning pure Interpreter mode")
 #else
 #warning pure Interpreter mode
 #endif


### PR DESCRIPTION
```
faust/compiler/generator/interpreter/fbc_compiler.hh:81:49: error: pragma message requires parenthesized string
   81 | #pragma message("warning pure Interpreter mode");
      |                                                 ^
```