### PR TITLE
JSFX fixes (param name matching & slider initialization)

### DIFF
--- a/compiler/generator/jsfx/jsfx_code_container.cpp
+++ b/compiler/generator/jsfx/jsfx_code_container.cpp
@@ -130,6 +130,8 @@ void JSFXCodeContainer::produceClass()
     // Generate utility functions
     *fOut << "@init" << endl;
 
+    gGlobal->gJSFXVisitor->generateInit();
+
     *fOut << "\n"
           << "// GLOBAL Functions \n"
           << "\n";
@@ -469,6 +471,14 @@ void JSFXScalarCodeContainer::generateCompute(int n)
     *fOut << "@slider";
     tab(n, *fOut);
     *fOut << "control();";
+    tab(n, *fOut);
+
+    // @serialize section is used to prevent init values (in @init section) to override the serialized value 
+    // It is here just to be non-empty, as described in JSFX documentation
+    tab(n, *fOut);
+    *fOut << "@serialize";
+    tab(n, *fOut);
+    *fOut << "(file_avail(0) < 0);";
     tab(n, *fOut);
 
     // @sample section is the audio loop.


### PR DESCRIPTION
1. Reserved MIDI polyphonic parameters (freq, gate, gain, vel, veloc) are now exactly matched : any other string like "my_special_gate" will not be considered a MIDI polyphonic gate anymore 
2. Initialization of visible sliders is now done manually, since JSFX engine does not do it by default. It involved adding initialization code in @init section, and add a dummy non-empty @serialize section 
