### PR TITLE
modify gGlobal, add per-instance garbage collection

### DIFF
--- a/architecture/faust/dsp/libfaust-box.h
+++ b/architecture/faust/dsp/libfaust-box.h
@@ -174,6 +174,22 @@ extern "C" LIBFAUST_API void createLibContext();
 extern "C" LIBFAUST_API void destroyLibContext();
 
 /**
+ * Get the current reference count of the library context.
+ * Useful for debugging and to check if context is still alive.
+ *
+ * @return The number of active references to the context
+ */
+extern "C" LIBFAUST_API int getLibContextRefCount();
+
+/**
+ * Prepare for shutdown.
+ *
+ * Note: This will cause a one-time memory leak of the global context, which is
+ * acceptable for single-process applications that are exiting anyway.
+ */
+extern "C" LIBFAUST_API void prepareForShutdown();
+
+/**
  * Check if a box is nil.
  *
  * @param b - the box

--- a/architecture/faust/dsp/libfaust-signal.h
+++ b/architecture/faust/dsp/libfaust-signal.h
@@ -176,6 +176,22 @@ extern "C" LIBFAUST_API void createLibContext();
 extern "C" LIBFAUST_API void destroyLibContext();
 
 /**
+ * Get the current reference count of the library context.
+ * Useful for debugging and to check if context is still alive.
+ *
+ * @return The number of active references to the context
+ */
+extern "C" LIBFAUST_API int getLibContextRefCount();
+
+/**
+ * Prepare for shutdown.
+ *
+ * Note: This will cause a one-time memory leak of the global context, which is
+ * acceptable for single-process applications that are exiting anyway.
+ */
+extern "C" LIBFAUST_API void prepareForShutdown();
+
+/**
  * Get the signal interval.
  *
  * @param s - the signal

--- a/compiler/global.hh
+++ b/compiler/global.hh
@@ -624,9 +624,9 @@ struct global {
     int gTimeout;  // Time out to abort compiler (in seconds)
 
     // Garbage collection
-    static std::list<Garbageable*> gRawObjectTable;
-    static std::list<Garbageable*> gArrayObjectTable;
-    static bool                    gHeapCleanup;
+    std::list<Garbageable*> gRawObjectTable;
+    std::list<Garbageable*> gArrayObjectTable;
+    bool                    gHeapCleanup;
 
     ZoneArray* gIntZone;   // array of 'int32' intermediate zone values
     ZoneArray* gRealZone;  // array of 'real' intermediate zone values


### PR DESCRIPTION
I was trying to use nanobind instead of pybind11 with DawDreamer. Claude identified`gGlobal` as a potential reason that Python was exiting with a 134 error code once a program had finished. This PR is a potential fix. I haven't done the full loop of creating libfaust, building DawDreamer etc, but I thought I'd just share it first.