### PR TITLE
Fix Dockerfile: replace ncurses5 with libncurses-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable-slim
-MAINTAINER Vincent Giersch <vincent@flat.io>
+LABEL maintainer="Vincent Giersch <vincent@flat.io>"
 
 RUN mkdir /faust
 WORKDIR /faust
@@ -7,12 +7,12 @@ COPY . /faust
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm libncurses5-dev libncurses5 libmicrohttpd-dev git cmake pkg-config && \
+  apt-get install -y build-essential llvm libncurses-dev libncursesw6 libmicrohttpd-dev git cmake pkg-config && \
   rm -rf /var/lib/apt/lists/*
 
 RUN \
   make && make install && \
   make clean && \
-  apt-get purge -y build-essential llvm libncurses5-dev && apt-get autoremove -y
+  apt-get purge -y build-essential llvm libncurses-dev && apt-get autoremove -y
 
 ENTRYPOINT ["/usr/local/bin/faust"]


### PR DESCRIPTION
This PR updates the Dockerfile to replace the deprecated `libncurses5`
package with `libncurses-dev`, which fixes the build failure on
`debian:stable-slim`.