### PR TITLE
Extend support for ESP32 targets

### DIFF
--- a/architecture/esp32/esp32.cpp
+++ b/architecture/esp32/esp32.cpp
@@ -89,7 +89,7 @@ list<GUI*> GUI::fGuiList;
 ztimedmap GUI::gTimedZoneMap;
 #endif
 
-AudioFaust::AudioFaust(int sample_rate, int buffer_size)
+AudioFaust::AudioFaust(int sample_rate, int buffer_size, i2s_pin_config_t pin_config)
 {
 #ifdef NVOICES
     int nvoices = NVOICES;
@@ -101,7 +101,7 @@ AudioFaust::AudioFaust(int sample_rate, int buffer_size)
     fUI = new MapUI();
     fDSP->buildUserInterface(fUI);
     
-    fAudio = new esp32audio(sample_rate, buffer_size);
+    fAudio = new esp32audio(sample_rate, buffer_size, pin_config);
     fAudio->init("esp32", fDSP);
     
 #ifdef SOUNDFILE

--- a/architecture/esp32/esp32.h
+++ b/architecture/esp32/esp32.h
@@ -42,6 +42,14 @@ class esp32_midi;
 class SoundUI;
 #endif
 
+#define DEFAULT_I2S_PIN_CONFIG { \
+    .mck_io_num = I2S_PIN_NO_CHANGE, \
+    .bck_io_num = I2S_PIN_NO_CHANGE, \
+    .ws_io_num = I2S_PIN_NO_CHANGE, \
+    .data_out_num = I2S_PIN_NO_CHANGE, \
+    .data_in_num = I2S_PIN_NO_CHANGE \
+}
+
 class AudioFaust
 {
     private:
@@ -59,7 +67,7 @@ class AudioFaust
 
     public:
     
-        AudioFaust(int sample_rate, int buffer_size);
+        AudioFaust(int sample_rate, int buffer_size, i2s_pin_config_t pin_config = DEFAULT_I2S_PIN_CONFIG);
         ~AudioFaust();
     
         bool start();

--- a/architecture/faust/audio/esp32-dsp.h
+++ b/architecture/faust/audio/esp32-dsp.h
@@ -143,7 +143,7 @@ class esp32audio : public audio {
     
     public:
     
-        esp32audio(int srate, int bsize):
+        esp32audio(int srate, int bsize, i2s_pin_config_t pin_config):
         fSampleRate(srate),
         fBufferSize(bsize),
         fNumInputs(0),
@@ -154,7 +154,6 @@ class esp32audio : public audio {
         fDSP(nullptr),
         fRunning(false)
         {
-            i2s_pin_config_t pin_config;
         #if TTGO_TAUDIO
             pin_config = {
                 .mck_io_num = I2S_PIN_NO_CHANGE,
@@ -178,14 +177,6 @@ class esp32audio : public audio {
                 .ws_io_num = 25,
                 .data_out_num = 26,
                 .data_in_num = 35
-            };
-        #else // Default
-            pin_config = {
-                .mck_io_num = I2S_PIN_NO_CHANGE,
-                .bck_io_num = 33,
-                .ws_io_num = 25,
-                .data_out_num = 26,
-                .data_in_num = 27
             };
         #endif
             
@@ -220,7 +211,9 @@ class esp32audio : public audio {
         #endif
             i2s_driver_install((i2s_port_t)0, &i2s_config, 0, nullptr);
             i2s_set_pin((i2s_port_t)0, &pin_config);
-            PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+            #if CONFIG_IDF_TARGET_ESP32
+                PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+            #endif
             REG_WRITE(PIN_CTRL, 0xFFFFFFF0);
         }
     

--- a/tools/faust2appls/faust2esp32
+++ b/tools/faust2appls/faust2esp32
@@ -46,7 +46,7 @@ echoHelp()
     options -midi -soundfile
     option -main "add a 'main' entry point"
     option "-nvoices <num>"
-    option "-wm8978, -es8388 or -ac101" "to choose codec driver"
+    option "-wm8978, -es8388, -ac101 or -driverless" "to choose codec driver"
     option "Faust options"
     exit
 }
@@ -92,6 +92,9 @@ do
     # -soundfile
     elif [ $p = "-soundfile" ]; then
         SOUNDFILE=1
+    # -driverless (e.g. PCM510x)
+    elif [ $p = "-driverless" ] || [ $p = "-DRIVERLESS" ]; then
+        DRIVER="driverless"
     # -wm8978 (ttgo t-audio)
     elif [ $p = "-wm8978" ] || [ $p = "-WM8978" ]; then
         DRIVER="wm8978"
@@ -176,6 +179,8 @@ if [[ "$LIB" == "1" || "$GRAMOPHONE" == "1" ]]; then
         cp $FAUSTARCH/esp32/drivers/es8388/es8388.cpp $MODULENAME
         cp $FAUSTARCH/esp32/drivers/es8388/es8388.h $MODULENAME
         cp $FAUSTARCH/esp32/drivers/es8388/adf_structs.h $MODULENAME
+    elif [[ $DRIVER = "driverless" ]]; then
+        : # do nothing
     else
         cp $FAUSTARCH/esp32/drivers/wm8978/WM8978.cpp $MODULENAME
         cp $FAUSTARCH/esp32/drivers/wm8978/WM8978.h $MODULENAME
@@ -275,6 +280,8 @@ if [[ "$LIB" == "0" && "$GRAMOPHONE" == "0" ]]; then
         cp $FAUSTARCH/esp32/drivers/es8388/es8388.cpp $MODULENAME/es8388
         cp $FAUSTARCH/esp32/drivers/es8388/es8388.h $MODULENAME/es8388/include
         cp $FAUSTARCH/esp32/drivers/es8388/adf_structs.h $MODULENAME/es8388/include
+    elif [[ $DRIVER = "driverless" ]]; then
+        : # do nothing
     else
         mkdir -p $MODULENAME/WM8978/include
         cp $FAUSTARCH/esp32/drivers/wm8978/CMakeLists.txt $MODULENAME/WM8978


### PR DESCRIPTION
This PR extends the current support for other ESP32 targets (e.g. ESP32-S3), allows for custom I2S pin configurations and also simplifies integration with DACs that don't require a codec driver (e.g. PCM5100).