### PR TITLE
Fix FUNC_GPIO0_CLK_OUT1 issue

### DIFF
--- a/architecture/faust/audio/esp32-dsp.h
+++ b/architecture/faust/audio/esp32-dsp.h
@@ -220,7 +220,9 @@ class esp32audio : public audio {
         #endif
             i2s_driver_install((i2s_port_t)0, &i2s_config, 0, nullptr);
             i2s_set_pin((i2s_port_t)0, &pin_config);
-            PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+            #if CONFIG_IDF_TARGET_ESP32
+                PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+            #endif
             REG_WRITE(PIN_CTRL, 0xFFFFFFF0);
         }
     


### PR DESCRIPTION
This PR puts `FUNC_GPIO0_CLK_OUT1` (soc/esp32/register/soc/io_mux_reg.h) behind a flag: Without this change _faust2esp32_ output can only be compiled for `ESP32` target chip (the name is confusing so just to be clear, this is not referring to the family but the original ESP32). For example, my target `ESP32S3` doesn't compile because this define doesn't exist in [soc/esp32s3/register/soc/io_mux_reg.h](https://github.com/espressif/esp-idf/blob/130fdc7ce755207811740f1163e6f394e0e86c0b/components/soc/esp32s3/register/soc/io_mux_reg.h). Maybe this could be configurable but I don't believe it's strictly necessary.

Extracted from https://github.com/grame-cncm/faust/pull/1187