### PR TITLE
Update juce-midi.h for recent Juce compatibility

### DIFF
--- a/architecture/faust/midi/juce-midi.h
+++ b/architecture/faust/midi/juce-midi.h
@@ -191,12 +191,21 @@ class juce_midi : public juce_midi_handler, public juce::MidiInputCallback {
         
         bool startMidi()
         {
-            if ((fMidiIn = juce::MidiInput::openDevice(juce::MidiInput::getDefaultDevice().name, this)) == nullptr) {
+            auto defaultIn = juce::MidiInput::getDefaultDevice();
+            auto defaultOut = juce::MidiOutput::getDefaultDevice();
+
+            if (defaultIn.identifier.isEmpty()
+                || (fMidiIn = juce::MidiInput::openDevice(defaultIn.identifier, this)) == nullptr)
+            {
                 return false;
             }
-            if ((fMidiOut = juce::MidiOutput::openDevice(juce::MidiInput::getDefaultDevice().name)) == nullptr) {
+
+            if (defaultOut.identifier.isEmpty()
+                || (fMidiOut = juce::MidiOutput::openDevice(defaultOut.identifier)) == nullptr)
+            {
                 return false;
             }
+
             fMidiIn->start();
             return true;
         }


### PR DESCRIPTION
Salut ! 
Je voulais utilisé Faust2Juice pour créer des .VST3 mais j'ai remarqué que le startmidi() n'étais pas à jour pour les versions récentes de JUCE, donc je propose cette modification d'architecture midi, qui fonctionne à merveille sur ma machine Win 64 + VS22 et Ableton live 11 suite. Je pense que ce même problème peut-être sur d'autre plateforme, à voir.
Merci.

Hi!
I wanted to use Faust2Juice to create .VST3 plugins, but I noticed that the startmidi() function wasn't up-to-date for recent versions of JUCE. So, I'm proposing this MIDI architecture modification, which works perfectly on my 64-bit Windows machine with VS22 and Ableton Live 11 Suite. I think this same issue might occur on other platforms, so it's worth checking.
Thanks.