### PR TITLE
feat: improve rust codegen for wasm target

### DIFF
--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -295,6 +295,8 @@ void RustCodeContainer::produceClass()
     // Missing math functions
     // See: https://users.rust-lang.org/t/analog-of-c-std-remainder/59670
     if (gGlobal->gFloatSize == 1 && !gGlobal->gRustNoLibm) {
+        *fOut << "#[cfg(not(target_arch = \"wasm32\"))] // Compile ffi bindings only on non-wasm targets";
+        tab(n, *fOut);
         *fOut << "mod ffi {";
         tab(n + 1, *fOut);
         *fOut << "use std::os::raw::c_float;";
@@ -315,13 +317,25 @@ void RustCodeContainer::produceClass()
         tab(n, *fOut);
         *fOut << "fn remainder_f32(from: f32, to: f32) -> f32 {";
         tab(n + 1, *fOut);
+        *fOut << "#[cfg(not(target_arch = \"wasm32\"))] // non-wasm targets use ffi bindings";
+        tab(n + 1, *fOut);
         *fOut << "unsafe { ffi::remainderf(from, to) }";
+        tab(n + 1, *fOut);
+        *fOut << "#[cfg(target_arch = \"wasm32\")] // wasm relies on libm";
+        tab(n + 1, *fOut);
+        *fOut << "libm::remainderf(from, to)";
         tab(n, *fOut);
         *fOut << "}";
         tab(n, *fOut);
         *fOut << "fn rint_f32(val: f32) -> f32 {";
         tab(n + 1, *fOut);
+        *fOut << "#[cfg(not(target_arch = \"wasm32\"))] // non-wasm targets use ffi bindings";
+        tab(n + 1, *fOut);
         *fOut << "unsafe { ffi::rintf(val) }";
+        tab(n + 1, *fOut);
+        *fOut << "#[cfg(target_arch = \"wasm32\")] // wasm relies on libm";
+        tab(n + 1, *fOut);
+        *fOut << "libm::rintf(val)";
         tab(n, *fOut);
         *fOut << "}";
         tab(n, *fOut);
@@ -332,6 +346,8 @@ void RustCodeContainer::produceClass()
         tab(n, *fOut);
         */
     } else if (gGlobal->gFloatSize == 2 && !gGlobal->gRustNoLibm) {
+        *fOut << "#[cfg(not(target_arch = \"wasm32\"))] // Compile ffi bindings only on non-wasm targets";
+        tab(n + 1, *fOut);
         *fOut << "mod ffi {";
         tab(n + 1, *fOut);
         *fOut << "use std::os::raw::c_double;";
@@ -352,13 +368,25 @@ void RustCodeContainer::produceClass()
         tab(n, *fOut);
         *fOut << "fn remainder_f64(from: f64, to: f64) -> f64 {";
         tab(n + 1, *fOut);
+        *fOut << "#[cfg(not(target_arch = \"wasm32\"))] // non-wasm targets use ffi bindings";
+        tab(n + 1, *fOut);
         *fOut << "unsafe { ffi::remainder(from, to) }";
+        tab(n + 1, *fOut);
+        *fOut << "#[cfg(target_arch = \"wasm32\")] // wasm relies on libm";
+        tab(n + 1, *fOut);
+        *fOut << "libm::remainder(from, to)";
         tab(n, *fOut);
         *fOut << "}";
         tab(n, *fOut);
         *fOut << "fn rint_f64(val: f64) -> f64 {";
         tab(n + 1, *fOut);
+        *fOut << "#[cfg(not(target_arch = \"wasm32\"))] // non-wasm targets use ffi bindings";
+        tab(n + 1, *fOut);
         *fOut << "unsafe { ffi::rint(val) }";
+        tab(n + 1, *fOut);
+        *fOut << "#[cfg(target_arch = \"wasm32\")] // wasm relies on libm";
+        tab(n + 1, *fOut);
+        *fOut << "libm::rint(val)";
         tab(n, *fOut);
         *fOut << "}";
         tab(n, *fOut);


### PR DESCRIPTION
This PR improves the Rust codegen for targeting wasm, following up on ideas from #1118.

Basically now the generated code works for both non-wasm and wasm compilation. (My requirement was to have the _same_ generated code work under both.)

To demonstrate, the generated code now looks like this:

```rust
#[cfg(not(target_arch = "wasm32"))] // Compile ffi bindings only on non-wasm targets
mod ffi {
    use std::os::raw::c_float;
    // Conditionally compile the link attribute only on non-Windows platforms
    #[cfg_attr(not(target_os = "windows"), link(name = "m"))]
    unsafe extern "C" {
        pub fn remainderf(from: c_float, to: c_float) -> c_float;
        pub fn rintf(val: c_float) -> c_float;
    }
}
fn remainder_f32(from: f32, to: f32) -> f32 {
    #[cfg(not(target_arch = "wasm32"))] // non-wasm targets use ffi bindings
    unsafe { ffi::remainderf(from, to) }
    #[cfg(target_arch = "wasm32")] // wasm relies on libm
    libm::remainderf(from, to)
}
fn rint_f32(val: f32) -> f32 {
    #[cfg(not(target_arch = "wasm32"))] // non-wasm targets use ffi bindings
    unsafe { ffi::rintf(val) }
    #[cfg(target_arch = "wasm32")] // wasm relies on libm
    libm::rintf(val)
}
```

This follows @mitchmindtree's idea in https://github.com/grame-cncm/faust/issues/1118#issuecomment-2816626272 and works for both use cases:

- native targets: They use the `ffi` and linking to `lm` as before.
- wasm target: They delegate to [`libm`](https://docs.rs/libm/latest/libm/index.html), a pure Rust crate offering the same functionality. Of course, wasm users need to add `libm` as a dependency.

---

Note that this makes the `-rnlm`/`--rust-no-libm` command line args (and `gRustNoLibm` internally) more or less obsolete. Removing it would be a breaking change though for someone expecting these command line arguments to exist. I didn't remove it yet, but if the breaking change is considered minor enough, we could do so in a follow-up. This would be more or less the inverse of https://github.com/grame-cncm/faust/commit/ad2e1566fa9fd3423e8a1ee7773f701b512c6a79.
