### PR TITLE
Fix C compatibility: add missing 'enum' keyword in function prototypes in libfaust-box-c.h

### DIFF
--- a/architecture/faust/dsp/libfaust-box-c.h
+++ b/architecture/faust/dsp/libfaust-box-c.h
@@ -462,9 +462,9 @@ LIBFAUST_API Box CboxFVar(enum SType type, const char* name, const char* incfile
  *
  * @return the result box of op(x,y).
  */
-LIBFAUST_API Box CboxBinOp(SOperator op);
+LIBFAUST_API Box CboxBinOp(enum SOperator op);
 
-LIBFAUST_API Box CboxBinOpAux(SOperator op, Box b1, Box b2);
+LIBFAUST_API Box CboxBinOpAux(enum SOperator op, Box b1, Box b2);
 
 /**
  * Specific binary mathematical functions.


### PR DESCRIPTION
This PR adds the missing `enum` keyword to `SOperator` in the function prototypes for `CboxBinOp` and `CboxBinOpAux`.

When including `libfaust-box-c.h` in a pure C project, the compiler fails with the following errors:

```text
error: must use 'enum' tag to refer to type 'SOperator'
465 | LIBFAUST_API Box CboxBinOp(SOperator op);
    |                            ^
    |                            enum
```
    
This is because SOperator is an enum and requires the enum keyword in standard C.
Verified the fix by compiling and running interp-test-c on macOS (Apple Silicon, M4) using gcc.