### PR TITLE
Add cstdint include to Schedule.hh

### DIFF
--- a/compiler/DirectedGraph/Schedule.hh
+++ b/compiler/DirectedGraph/Schedule.hh
@@ -14,6 +14,7 @@
 #pragma once
 #include <algorithm>  // for std::find
 #include <cassert>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <list>


### PR DESCRIPTION
Otherwise:

```
/run/build/faust/compiler/DirectedGraph/Schedule.hh:153:10: error: unknown type name 'uint64_t'
  153 |     for (uint64_t i = 0; i < P.size(); i++) {
      |          ^
```