### PR TITLE
EXtending pattern matching for route operator

### DIFF
--- a/compiler/boxes/boxes.cpp
+++ b/compiler/boxes/boxes.cpp
@@ -1021,6 +1021,8 @@ static Tree preparePattern(Tree box)
         return boxPar(preparePattern(t1), preparePattern(t2));
     } else if (isBoxRec(box, t1, t2)) {
         return boxRec(preparePattern(t1), preparePattern(t2));
+    } else if (isBoxRoute(box, t1, t2, t3)) {
+        return boxRoute(preparePattern(t1), preparePattern(t2), preparePattern(t3));
     }
 
     // Iterative block diagram construction

--- a/compiler/evaluate/eval.cpp
+++ b/compiler/evaluate/eval.cpp
@@ -69,6 +69,33 @@ static int    eval2int(Tree exp, Tree visited, Tree localValEnv);
 static double eval2double(Tree exp, Tree visited, Tree localValEnv);
 static string evalLabel(const char* l, Tree visited, Tree localValEnv);
 
+// Helper to normalize route pattern (flatten Par structure)
+static void collectParElements(Tree box, vector<Tree>& elements)
+{
+    Tree l, r;
+    if (isBoxPar(box, l, r)) {
+        collectParElements(l, elements);
+        collectParElements(r, elements);
+    } else {
+        elements.push_back(box);
+    }
+}
+
+static Tree normalizeRoutePattern(Tree routes)
+{
+    vector<Tree> elements;
+    collectParElements(routes, elements);
+    
+    if (elements.empty()) return routes;
+    
+    // Rebuild as right-associative list (a, (b, (c, ...)))
+    Tree res = elements.back();
+    for (int i = elements.size() - 2; i >= 0; i--) {
+        res = boxPar(elements[i], res);
+    }
+    return res;
+}
+
 static Tree evalIdDef(Tree id, Tree visited, Tree env);
 
 static Tree evalCase(Tree rules, Tree env);
@@ -663,8 +690,10 @@ static Tree realeval(Tree exp, Tree visited, Tree localValEnv)
                 if (isBoxPatternVar(v1, p) || isBoxPatternVar(v2, p) || isBoxPatternVar(vr, p) ||
                     isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) ||
                     isBoxSlot(v1) || isBoxSlot(v2) || isBoxSlot(vr)) {
-                    return boxRoute(v1, v2, vr);
+                    return boxRoute(v1, v2, normalizeRoutePattern(vr));
                 }
+
+
                 evalerror(getDefFileProp(exp), getDefLineProp(exp),
                           "invalid route expression, parameters should be numbers", exp);
             }
@@ -674,8 +703,10 @@ static Tree realeval(Tree exp, Tree visited, Tree localValEnv)
             if (isBoxPatternVar(v1, p) || isBoxPatternVar(v2, p) || isBoxPatternVar(vr, p) ||
                 isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) ||
                 isBoxSlot(v1) || isBoxSlot(v2) || isBoxSlot(vr)) {
-                return boxRoute(v1, v2, vr);
+                return boxRoute(v1, v2, normalizeRoutePattern(vr));
             }
+
+
             evalerror(getDefFileProp(exp), getDefLineProp(exp),
                       "invalid route expression, first two parameters should be blocks producing a "
                       "value, third "

--- a/compiler/evaluate/eval.cpp
+++ b/compiler/evaluate/eval.cpp
@@ -85,9 +85,11 @@ static Tree normalizeRoutePattern(Tree routes)
 {
     vector<Tree> elements;
     collectParElements(routes, elements);
-    
-    if (elements.empty()) return routes;
-    
+
+    if (elements.empty()) {
+        return routes;
+    }
+
     // Rebuild as right-associative list (a, (b, (c, ...)))
     Tree res = elements.back();
     for (int i = elements.size() - 2; i >= 0; i--) {
@@ -688,11 +690,10 @@ static Tree realeval(Tree exp, Tree visited, Tree localValEnv)
                 Tree p;
                 // Allow pattern variables and wildcards in route patterns
                 if (isBoxPatternVar(v1, p) || isBoxPatternVar(v2, p) || isBoxPatternVar(vr, p) ||
-                    isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) ||
-                    isBoxSlot(v1) || isBoxSlot(v2) || isBoxSlot(vr)) {
+                    isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) || isBoxSlot(v1) ||
+                    isBoxSlot(v2) || isBoxSlot(vr)) {
                     return boxRoute(v1, v2, normalizeRoutePattern(vr));
                 }
-
 
                 evalerror(getDefFileProp(exp), getDefLineProp(exp),
                           "invalid route expression, parameters should be numbers", exp);
@@ -701,11 +702,10 @@ static Tree realeval(Tree exp, Tree visited, Tree localValEnv)
             Tree p;
             // Allow pattern variables and wildcards in route patterns
             if (isBoxPatternVar(v1, p) || isBoxPatternVar(v2, p) || isBoxPatternVar(vr, p) ||
-                isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) ||
-                isBoxSlot(v1) || isBoxSlot(v2) || isBoxSlot(vr)) {
+                isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) || isBoxSlot(v1) || isBoxSlot(v2) ||
+                isBoxSlot(vr)) {
                 return boxRoute(v1, v2, normalizeRoutePattern(vr));
             }
-
 
             evalerror(getDefFileProp(exp), getDefLineProp(exp),
                       "invalid route expression, first two parameters should be blocks producing a "
@@ -861,7 +861,8 @@ static Tree patternSimplification(Tree pattern)
     if (isBoxNumeric(pattern, v)) {
         return v;
     } else if (isBoxPatternOpTernary(pattern, n, t1, t2, t3)) {
-        return tree(n, patternSimplification(t1), patternSimplification(t2), patternSimplification(t3));
+        return tree(n, patternSimplification(t1), patternSimplification(t2),
+                    patternSimplification(t3));
     } else if (isBoxPatternOp(pattern, n, t1, t2)) {
         return tree(n, patternSimplification(t1), patternSimplification(t2));
     } else {

--- a/compiler/evaluate/eval.cpp
+++ b/compiler/evaluate/eval.cpp
@@ -658,10 +658,24 @@ static Tree realeval(Tree exp, Tree visited, Tree localValEnv)
                 }
                 return boxRoute(boxInt(w1[0]), boxInt(w2[0]), b);
             } else {
+                Tree p;
+                // Allow pattern variables and wildcards in route patterns
+                if (isBoxPatternVar(v1, p) || isBoxPatternVar(v2, p) || isBoxPatternVar(vr, p) ||
+                    isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) ||
+                    isBoxSlot(v1) || isBoxSlot(v2) || isBoxSlot(vr)) {
+                    return boxRoute(v1, v2, vr);
+                }
                 evalerror(getDefFileProp(exp), getDefLineProp(exp),
                           "invalid route expression, parameters should be numbers", exp);
             }
         } else {
+            Tree p;
+            // Allow pattern variables and wildcards in route patterns
+            if (isBoxPatternVar(v1, p) || isBoxPatternVar(v2, p) || isBoxPatternVar(vr, p) ||
+                isBoxWire(v1) || isBoxWire(v2) || isBoxWire(vr) ||
+                isBoxSlot(v1) || isBoxSlot(v2) || isBoxSlot(vr)) {
+                return boxRoute(v1, v2, vr);
+            }
             evalerror(getDefFileProp(exp), getDefLineProp(exp),
                       "invalid route expression, first two parameters should be blocks producing a "
                       "value, third "
@@ -745,6 +759,16 @@ static Tree realeval(Tree exp, Tree visited, Tree localValEnv)
     return nullptr;
 }
 
+/* Deconstruct a ternary op pattern (route). */
+static inline bool isBoxPatternOpTernary(Tree box, Node& n, Tree& t1, Tree& t2, Tree& t3)
+{
+    if (isBoxRoute(box, t1, t2, t3)) {
+        n = box->node();
+        return true;
+    }
+    return false;
+}
+
 /* Deconstruct a (BDA) op pattern */
 static inline bool isBoxPatternOp(Tree box, Node& n, Tree& t1, Tree& t2)
 {
@@ -801,10 +825,12 @@ static bool isBoxNumeric(Tree in, Tree& out)
 static Tree patternSimplification(Tree pattern)
 {
     Node n(0);
-    Tree v, t1, t2;
+    Tree v, t1, t2, t3;
 
     if (isBoxNumeric(pattern, v)) {
         return v;
+    } else if (isBoxPatternOpTernary(pattern, n, t1, t2, t3)) {
+        return tree(n, patternSimplification(t1), patternSimplification(t2), patternSimplification(t3));
     } else if (isBoxPatternOp(pattern, n, t1, t2)) {
         return tree(n, patternSimplification(t1), patternSimplification(t2));
     } else {

--- a/compiler/patternmatcher/patternmatcher.cpp
+++ b/compiler/patternmatcher/patternmatcher.cpp
@@ -84,8 +84,6 @@ static inline bool isBoxPatternOpTernary(Tree box, Node& n, Tree& t1, Tree& t2, 
     return false;
 }
 
-
-
 /* TA data structures. */
 
 /* subterm paths */
@@ -102,9 +100,12 @@ static Tree subtree(Tree X, int i, const Path& p)
     if (i < n && isBoxPatternOpTernary(X, op, x0, x1, x2)) {
         /* ternary operator */
         switch (p[i]) {
-            case 0: return subtree(x0, i + 1, p);
-            case 1: return subtree(x1, i + 1, p);
-            default: return subtree(x2, i + 1, p);
+            case 0:
+                return subtree(x0, i + 1, p);
+            case 1:
+                return subtree(x1, i + 1, p);
+            default:
+                return subtree(x2, i + 1, p);
         }
     } else if (i < n && isBoxPatternOp(X, op, x0, x1)) {
         return subtree((p[i] == 0) ? x0 : x1, i + 1, p);

--- a/compiler/patternmatcher/patternmatcher.cpp
+++ b/compiler/patternmatcher/patternmatcher.cpp
@@ -74,6 +74,18 @@ static inline bool isBoxPatternOp(Tree box, Node& n, Tree& t1, Tree& t2)
     }
 }
 
+/* Deconstruct a ternary op pattern (route). */
+static inline bool isBoxPatternOpTernary(Tree box, Node& n, Tree& t1, Tree& t2, Tree& t3)
+{
+    if (isBoxRoute(box, t1, t2, t3)) {
+        n = box->node();
+        return true;
+    }
+    return false;
+}
+
+
+
 /* TA data structures. */
 
 /* subterm paths */
@@ -86,8 +98,15 @@ static Tree subtree(Tree X, int i, const Path& p)
 {
     int  n = (int)p.size();
     Node op(0);
-    Tree x0, x1;
-    if (i < n && isBoxPatternOp(X, op, x0, x1)) {
+    Tree x0, x1, x2;
+    if (i < n && isBoxPatternOpTernary(X, op, x0, x1, x2)) {
+        /* ternary operator */
+        switch (p[i]) {
+            case 0: return subtree(x0, i + 1, p);
+            case 1: return subtree(x1, i + 1, p);
+            default: return subtree(x2, i + 1, p);
+        }
+    } else if (i < n && isBoxPatternOp(X, op, x0, x1)) {
         return subtree((p[i] == 0) ? x0 : x1, i + 1, p);
     } else {
         return X;
@@ -353,7 +372,7 @@ ostream& Automaton::print(ostream& fout) const
 
 static State* make_state(State* state, int r, Tree x, Path& p)
 {
-    Tree id, x0, x1;
+    Tree id, x0, x1, x2;
     Node op(0);
     if (isBoxPatternVar(x, id)) {
         /* variable */
@@ -362,6 +381,23 @@ static State* make_state(State* state, int r, Tree x, Path& p)
         Trans trans(nullptr);
         state->trans.push_back(trans);
         return state->trans.begin()->state;
+    } else if (isBoxPatternOpTernary(x, op, x0, x1, x2)) {
+        /* ternary composite pattern (Route) */
+        Rule rule(r, nullptr);
+        state->rules.push_back(rule);
+        Trans trans(op, 3);
+        state->trans.push_back(trans);
+        State* next = state->trans.begin()->state;
+        p.push_back(0);
+        next = make_state(next, r, x0, p);
+        p.pop_back();
+        p.push_back(1);
+        next = make_state(next, r, x1, p);
+        p.pop_back();
+        p.push_back(2);
+        next = make_state(next, r, x2, p);
+        p.pop_back();
+        return next;
     } else if (isBoxPatternOp(x, op, x0, x1)) {
         /* composite pattern */
         Rule rule(r, nullptr);
@@ -685,7 +721,26 @@ static int apply_pattern_matcher_internal(Automaton* A, int s, Tree X, vector<Su
                     return s;
                 }
             } else if (t->is_op_trans(op)) {
-                Tree x0, x1;
+                Tree x0, x1, x2;
+                Node op1(0);
+                if (isBoxPatternOpTernary(X, op1, x0, x1, x2) && op == op1) {
+                    /* transition on ternary operation symbol */
+#ifdef DEBUG
+                    cerr << "state " << s << ", " << op << ": goto state " << t->state->s << endl;
+#endif
+                    add_subst(subst, A, s);
+                    s = t->state->s;
+                    if (s >= 0) {
+                        s = apply_pattern_matcher_internal(A, s, x0, subst);
+                    }
+                    if (s >= 0) {
+                        s = apply_pattern_matcher_internal(A, s, x1, subst);
+                    }
+                    if (s >= 0) {
+                        s = apply_pattern_matcher_internal(A, s, x2, subst);
+                    }
+                    return s;
+                }
                 if (isBoxPatternOp(X, op1, x0, x1) && op == op1) {
                     /* transition on operation symbol */
 #ifdef DEBUG

--- a/tests/pass-tests/PM-route1.dsp
+++ b/tests/pass-tests/PM-route1.dsp
@@ -1,0 +1,35 @@
+// PM-route1.dsp - Basic route pattern matching tests
+// Tests exact matching and pattern variables with route primitive
+
+import("stdfaust.lib");
+
+// Test 1: Exact match on complete route expression
+test_exact = case {
+    (route(2,2,1,2,2,1)) => 100;
+    (_) => 0;
+};
+
+// Test 2: Pattern variables bind input/output counts only
+test_vars_io = case {
+    (route(n,m,1,2,2,1)) => n * 10 + m;
+    (_) => -1;
+};
+
+// Test 3: Different exact routes
+test_exact2 = case {
+    (route(3,3,1,2,3,1,2,3)) => 200;
+    (_) => 0;
+};
+
+// Test 4: Sequential matching - first match wins
+test_priority = case {
+    (route(2,2,1,2,2,1)) => 300;   // Specific pattern
+    (route(n,m,1,2,2,1)) => 400;   // More general pattern
+    (_) => 0;
+};
+
+process = 
+    test_exact(route(2,2,1,2,2,1)),       // Expected: 100 (exact match)
+    test_vars_io(route(2,3,1,2,2,1)),     // Expected: 23 (2*10 + 3)
+    test_exact2(route(3,3,1,2,3,1,2,3)),  // Expected: 200 (exact match) 
+    test_priority(route(2,2,1,2,2,1));    // Expected: 300 (first match)

--- a/tests/pass-tests/PM-route1.dsp
+++ b/tests/pass-tests/PM-route1.dsp
@@ -1,35 +1,22 @@
-// PM-route1.dsp - Basic route pattern matching tests
-// Tests exact matching and pattern variables with route primitive
 
-import("stdfaust.lib");
+// Basic route pattern matching tests
 
-// Test 1: Exact match on complete route expression
 test_exact = case {
     (route(2,2,1,2,2,1)) => 100;
     (_) => 0;
 };
 
-// Test 2: Pattern variables bind input/output counts only
-test_vars_io = case {
+test_vars = case {
     (route(n,m,1,2,2,1)) => n * 10 + m;
-    (_) => -1;
-};
-
-// Test 3: Different exact routes
-test_exact2 = case {
-    (route(3,3,1,2,3,1,2,3)) => 200;
     (_) => 0;
 };
 
-// Test 4: Sequential matching - first match wins
 test_priority = case {
-    (route(2,2,1,2,2,1)) => 300;   // Specific pattern
-    (route(n,m,1,2,2,1)) => 400;   // More general pattern
+    (route(2,2,1,2,2,1)) => 300;
+    (route(n,m,1,2,2,1)) => 400;
     (_) => 0;
 };
 
-process = 
-    test_exact(route(2,2,1,2,2,1)),       // Expected: 100 (exact match)
-    test_vars_io(route(2,3,1,2,2,1)),     // Expected: 23 (2*10 + 3)
-    test_exact2(route(3,3,1,2,3,1,2,3)),  // Expected: 200 (exact match) 
-    test_priority(route(2,2,1,2,2,1));    // Expected: 300 (first match)
+process = test_exact(route(2,2,1,2,2,1)), 
+          test_vars(route(2,3,1,2,2,1)),
+          test_priority(route(2,2,1,2,2,1));

--- a/tests/pass-tests/PM-route2.dsp
+++ b/tests/pass-tests/PM-route2.dsp
@@ -1,0 +1,31 @@
+
+// Route pattern nesting and canonicalization verification
+
+// Flat pattern
+test_nest1 = case {
+    (route(n,m,(1,2,3,4))) => 10;
+    (_) => 0;
+};
+
+// Right-associative pattern (Standard internal form)
+test_nest2 = case {
+    (route(n,m,(1,(2,(3,4))))) => 20;
+    (_) => 0;
+};
+
+// Left-associative pattern
+test_nest3 = case {
+    (route(n,m,((1,2),(3,4)))) => 30;
+    (_) => 0;
+};
+
+// Mixed grouping
+test_nest4 = case {
+    (route(n,m,(1,(2,(3,(4)))))) => 40;
+    (_) => 0;
+};
+
+process = test_nest1(route(1,1,1,2,3,4)), 
+          test_nest2(route(1,1,1,2,3,4)), 
+          test_nest3(route(1,1,1,2,3,4)), 
+          test_nest4(route(1,1,1,2,3,4));

--- a/tests/pass-tests/PM-route3.dsp
+++ b/tests/pass-tests/PM-route3.dsp
@@ -1,0 +1,31 @@
+
+// Route pattern edge cases
+
+// Mixed variables and constants with grouping
+test_mixed = case {
+    (route(n,m, a, (b,c), d)) => a + b + c + d;
+    (_) => 0;
+};
+
+// Tail variable capture
+test_tail = case {
+    (route(n,m, 10, x)) => 1;
+    (_) => 0;
+};
+
+// Single pair
+test_single = case {
+    (route(n,m, x, y)) => x + y;
+    (_) => 0;
+};
+
+// Long list
+test_long = case {
+    (route(n,m, 1,2,3,4,5,6)) => 999;
+    (_) => 0;
+};
+
+process = test_mixed(route(1,1,10,20,30,40)), 
+          test_tail(route(1,1,10,20,30,40)), 
+          test_single(route(1,1,5,6)),
+          test_long(route(1,1,1,2,3,4,5,6));


### PR DESCRIPTION
fixes #1153 
The implementation follows the existing pattern for binary operators but extends it to support route operator.

## Changes
- ### in `boxes.cpp`
  - added `route` case to `preparePattern()`
- ### in `patternmatcher.cpp` :
  - introduced `isBoxPatternOpTernary()` helper function for ternary operator detection
  - extended automaton construction to handle three-argument patterns
  - added ternary transition support in `make_state()` and implemented ternary operator matching in `apply_pattern_matcher_internal()`

- ### in `eval.cpp`
  - extended `patternSimplification()` to recursively simplify ternary operators 
  - added support for pattern variables and wildcards `(_)` in route expressions

- ### Testing
  - added testfile `PM-route1.dsp` that validates exact matching on complete route expressions, 
    which currently gives

     >ERROR : preparePattern() : BoxRoute[2,2,BoxPar[1,BoxPar[2,BoxPar[2,1]]]] is not a valid box
     
     but with the changes in this PR the test(s) will pass and the code will compile successfully



## Steps to Reproduce
Trying to compile this code currently will cause error 
```
import("stdfaust.lib");
// Match specific route configuration
matcher = case {
    (route(2,2,1,2,2,1)) => 100;  // Crossover route
    (route(2,2,1,1,2,2)) => 200;  // Parallel route
    (_) => 0;
};
// Pattern variables for input/output counts
flexible = case {
    (route(n,m,connections)) => n * 10 + m;
    (_) => -1;
};
process = 
    matcher(route(2,2,1,2,2,1)),      // Returns 100
    flexible(route(3,4,1,1,2,2,3,3)); // Returns 34
```

but after this PR these pattern matching will work!
