### PR TITLE
Add .gradle and CMakeFiles to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ tests/impulse-tests/ir
 .idea/
 ### Pyenv
 .python-version
+### Gradle (Android builds)
+.gradle/
+### CMake
+CMakeFiles/


### PR DESCRIPTION
## Summary
- Add `.gradle/` directories (Android build cache) to gitignore
- Add `CMakeFiles/` directories (CMake build artifacts) to gitignore

These were showing up as untracked files in git status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)