### PR TITLE
Avoid clean-build failure when libncurses.a is missing

### DIFF
--- a/build/Make.llvm.static
+++ b/build/Make.llvm.static
@@ -36,7 +36,13 @@ AR = ar
 ARFLAGS = rcs
 endif
 
-FOLDERS := $(INPUT:%.a=$(TMP)/%.dir) $(TMP)/libfaust.dir $(TMP)/libncurses.dir
+ifneq ($(strip $(LIBNCURSES_PATH)),)
+NCURSES_FOLDER := $(TMP)/libncurses.dir
+else
+NCURSES_FOLDER :=
+endif
+
+FOLDERS := $(INPUT:%.a=$(TMP)/%.dir) $(TMP)/libfaust.dir $(NCURSES_FOLDER)
 CONFIG  := ../tools/faust-config
 
 MAKEFILE := $(lastword $(MAKEFILE_LIST))
@@ -74,7 +80,9 @@ $(TMP)/libfaust.dir: lib/libfaust.a
 	@-[ -d $@ ] && rm -rf $@ 
 	mkdir -p $@ && cd $@ && ar -x ../../$<
 
-# Add a new rule for extracting libncurses.a
+ifneq ($(strip $(LIBNCURSES_PATH)),)
+# Add a new rule for extracting libncurses.a when available.
 $(TMP)/libncurses.dir: $(LIBNCURSES_PATH)
 	@-[ -d $@ ] && rm -rf $@
 	mkdir -p $@ && cd $@ && ar -x $(LIBNCURSES_PATH)
+endif


### PR DESCRIPTION
This has been an issue for me for awhile, but I've been just dealing with it and I decided to do some housekeeping and threw claude at it 😅 The issue is that on my machine, when building faust as a static lib, a clean build fails every time, but I just have to build again to get past it. Claude's summary:

`build/Make.llvm.static` unconditionally required `__tmp_llvm_lib__/libncurses.dir` and always defined an extraction rule for `$(LIBNCURSES_PATH)`. On systems where that path resolves empty, clean builds fail on the first run when `ar -x` is invoked with no archive.

Make ncurses extraction conditional:
- only include `$(TMP)/libncurses.dir` in `FOLDERS` when `LIBNCURSES_PATH` is set
- only define the `libncurses.dir` extraction rule in that case

This makes single-run builds work without changing behavior when static ncurses is available.