### PR TITLE
Expose Missing Box Constructors in Public API + Add Tests

### DIFF
--- a/architecture/faust/dsp/libfaust-box-c.h
+++ b/architecture/faust/dsp/libfaust-box-c.h
@@ -249,6 +249,50 @@ LIBFAUST_API Box CboxMerge(Box x, Box y);
 LIBFAUST_API Box CboxRec(Box x, Box y);
 
 /**
+ * Create an iterative par box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative par box.
+ */
+LIBFAUST_API Box CboxIPar(Box x, Box y, Box z);
+
+/**
+ * Create an iterative seq box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative seq box.
+ */
+LIBFAUST_API Box CboxISeq(Box x, Box y, Box z);
+
+/**
+ * Create an iterative sum box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative sum box.
+ */
+LIBFAUST_API Box CboxISum(Box x, Box y, Box z);
+
+/**
+ * Create an iterative prod box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative prod box.
+ */
+LIBFAUST_API Box CboxIProd(Box x, Box y, Box z);
+
+/**
  * The route primitive facilitates the routing of signals in Faust.
  * It has the following syntax: route(A,B,a,b,c,d,...) or route(A,B,(a,b),(c,d),...)
  *
@@ -277,6 +321,20 @@ LIBFAUST_API Box CboxDelay();
  * @return the delayed box.
  */
 LIBFAUST_API Box CboxDelayAux(Box b, Box del);
+
+/**
+ * Create a one-sample delay box.
+ *
+ * @return the one-sample delay box.
+ */
+LIBFAUST_API Box CboxDelay1();
+
+/**
+ * Create a prefix box.
+ *
+ * @return the prefix box.
+ */
+LIBFAUST_API Box CboxPrefix();
 
 /**
  * Create a casted box.
@@ -715,6 +773,94 @@ LIBFAUST_API Box CboxAttach();
  * @return the attach box.
  */
 LIBFAUST_API Box CboxAttachAux(Box b1, Box b2);
+
+/**
+ * Create an enable box.
+ *
+ * @return the enable box.
+ */
+LIBFAUST_API Box CboxEnable();
+
+/**
+ * Create a control box.
+ *
+ * @return the control box.
+ */
+LIBFAUST_API Box CboxControl();
+
+/**
+ * Create an assertbounds box.
+ *
+ * @return the assertbounds box.
+ */
+LIBFAUST_API Box CboxAssertBound();
+
+/**
+ * Create a lowest box.
+ *
+ * @return the lowest box.
+ */
+LIBFAUST_API Box CboxLowest();
+
+/**
+ * Create a highest box.
+ *
+ * @return the highest box.
+ */
+LIBFAUST_API Box CboxHighest();
+
+/**
+ * Create a box for the number of inputs of a box.
+ *
+ * @param x - the box
+ *
+ * @return the inputs box.
+ */
+LIBFAUST_API Box CboxInputs(Box x);
+
+/**
+ * Create a box for the number of outputs of a box.
+ *
+ * @param x - the box
+ *
+ * @return the outputs box.
+ */
+LIBFAUST_API Box CboxOutputs(Box x);
+
+/**
+ * Create an empty environment box.
+ *
+ * @return the environment box.
+ */
+LIBFAUST_API Box CboxEnvironment();
+
+/**
+ * Create a component box.
+ *
+ * @param filename - the file to be loaded
+ *
+ * @return the component box.
+ */
+LIBFAUST_API Box CboxComponent(const char* filename);
+
+/**
+ * Create a library box.
+ *
+ * @param filename - the file to be loaded
+ *
+ * @return the library box.
+ */
+LIBFAUST_API Box CboxLibrary(const char* filename);
+
+/**
+ * Create a metadata box.
+ *
+ * @param exp - the expression
+ * @param mdlist - the metadata list
+ *
+ * @return the metadata box.
+ */
+LIBFAUST_API Box CboxMetadata(Box exp, Box mdlist);
 
 LIBFAUST_API bool CisBoxAbstr(Box t, Box* x, Box* y);
 LIBFAUST_API bool CisBoxAccess(Box t, Box* exp, Box* id);

--- a/architecture/faust/dsp/libfaust-box.h
+++ b/architecture/faust/dsp/libfaust-box.h
@@ -295,6 +295,50 @@ LIBFAUST_API Box boxMerge(Box x, Box y);
 LIBFAUST_API Box boxRec(Box x, Box y);
 
 /**
+ * Create an iterative par box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative par box.
+ */
+LIBFAUST_API Box boxIPar(Box x, Box y, Box z);
+
+/**
+ * Create an iterative seq box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative seq box.
+ */
+LIBFAUST_API Box boxISeq(Box x, Box y, Box z);
+
+/**
+ * Create an iterative sum box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative sum box.
+ */
+LIBFAUST_API Box boxISum(Box x, Box y, Box z);
+
+/**
+ * Create an iterative prod box.
+ *
+ * @param x - the iterator variable
+ * @param y - the number of iterations
+ * @param z - the body expression
+ *
+ * @return the iterative prod box.
+ */
+LIBFAUST_API Box boxIProd(Box x, Box y, Box z);
+
+/**
  * The route primitive facilitates the routing of signals in Faust.
  * It has the following syntax: route(A,B,a,b,c,d,...) or route(A,B,(a,b),(c,d),...)
  *
@@ -323,6 +367,20 @@ LIBFAUST_API Box boxDelay();
  * @return the delayed box.
  */
 LIBFAUST_API Box boxDelay(Box b, Box del);
+
+/**
+ * Create a one-sample delay box.
+ *
+ * @return the one-sample delay box.
+ */
+LIBFAUST_API Box boxDelay1();
+
+/**
+ * Create a prefix box.
+ *
+ * @return the prefix box.
+ */
+LIBFAUST_API Box boxPrefix();
 
 /**
  * Create a casted box.
@@ -761,6 +819,94 @@ LIBFAUST_API Box boxAttach();
  * @return the attach box.
  */
 LIBFAUST_API Box boxAttach(Box b1, Box b2);
+
+/**
+ * Create an enable box.
+ *
+ * @return the enable box.
+ */
+LIBFAUST_API Box boxEnable();
+
+/**
+ * Create a control box.
+ *
+ * @return the control box.
+ */
+LIBFAUST_API Box boxControl();
+
+/**
+ * Create an assertbounds box.
+ *
+ * @return the assertbounds box.
+ */
+LIBFAUST_API Box boxAssertBound();
+
+/**
+ * Create a lowest box.
+ *
+ * @return the lowest box.
+ */
+LIBFAUST_API Box boxLowest();
+
+/**
+ * Create a highest box.
+ *
+ * @return the highest box.
+ */
+LIBFAUST_API Box boxHighest();
+
+/**
+ * Create a box for the number of inputs of a box.
+ *
+ * @param x - the box
+ *
+ * @return the inputs box.
+ */
+LIBFAUST_API Box boxInputs(Box x);
+
+/**
+ * Create a box for the number of outputs of a box.
+ *
+ * @param x - the box
+ *
+ * @return the outputs box.
+ */
+LIBFAUST_API Box boxOutputs(Box x);
+
+/**
+ * Create an empty environment box.
+ *
+ * @return the environment box.
+ */
+LIBFAUST_API Box boxEnvironment();
+
+/**
+ * Create a component box.
+ *
+ * @param filename - the file to be loaded
+ *
+ * @return the component box.
+ */
+LIBFAUST_API Box boxComponent(const std::string& filename);
+
+/**
+ * Create a library box.
+ *
+ * @param filename - the file to be loaded
+ *
+ * @return the library box.
+ */
+LIBFAUST_API Box boxLibrary(const std::string& filename);
+
+/**
+ * Create a metadata box.
+ *
+ * @param exp - the expression
+ * @param mdlist - the metadata list
+ *
+ * @return the metadata box.
+ */
+LIBFAUST_API Box boxMetadata(Box exp, Box mdlist);
 
 LIBFAUST_API Box boxPrim2(prim2 foo);
 

--- a/compiler/box_signal_api.cpp
+++ b/compiler/box_signal_api.cpp
@@ -1587,6 +1587,18 @@ LIBFAUST_API Tree boxControl()
     return boxPrim2(sigControl);
 }
 
+// Module system
+
+LIBFAUST_API Tree boxComponent(const string& filename)
+{
+    return boxComponent(tree(filename));
+}
+
+LIBFAUST_API Tree boxLibrary(const string& filename)
+{
+    return boxLibrary(tree(filename));
+}
+
 // Helpers
 
 LIBFAUST_API Tree boxPar3(Tree x, Tree y, Tree z)
@@ -2284,6 +2296,91 @@ LIBFAUST_API Tree CboxTGroup(const char* label, Tree group)
 LIBFAUST_API Tree CboxAttach()
 {
     return boxAttach();
+}
+
+LIBFAUST_API Tree CboxIPar(Tree x, Tree y, Tree z)
+{
+    return boxIPar(x, y, z);
+}
+
+LIBFAUST_API Tree CboxISeq(Tree x, Tree y, Tree z)
+{
+    return boxISeq(x, y, z);
+}
+
+LIBFAUST_API Tree CboxISum(Tree x, Tree y, Tree z)
+{
+    return boxISum(x, y, z);
+}
+
+LIBFAUST_API Tree CboxIProd(Tree x, Tree y, Tree z)
+{
+    return boxIProd(x, y, z);
+}
+
+LIBFAUST_API Tree CboxInputs(Tree x)
+{
+    return boxInputs(x);
+}
+
+LIBFAUST_API Tree CboxOutputs(Tree x)
+{
+    return boxOutputs(x);
+}
+
+LIBFAUST_API Tree CboxEnvironment()
+{
+    return boxEnvironment();
+}
+
+LIBFAUST_API Tree CboxComponent(const char* filename)
+{
+    return boxComponent(tree(filename));
+}
+
+LIBFAUST_API Tree CboxLibrary(const char* filename)
+{
+    return boxLibrary(tree(filename));
+}
+
+LIBFAUST_API Tree CboxMetadata(Tree exp, Tree mdlist)
+{
+    return boxMetadata(exp, mdlist);
+}
+
+LIBFAUST_API Tree CboxDelay1()
+{
+    return boxDelay1();
+}
+
+LIBFAUST_API Tree CboxPrefix()
+{
+    return boxPrefix();
+}
+
+LIBFAUST_API Tree CboxEnable()
+{
+    return boxEnable();
+}
+
+LIBFAUST_API Tree CboxControl()
+{
+    return boxControl();
+}
+
+LIBFAUST_API Tree CboxAssertBound()
+{
+    return boxAssertBound();
+}
+
+LIBFAUST_API Tree CboxLowest()
+{
+    return boxLowest();
+}
+
+LIBFAUST_API Tree CboxHighest()
+{
+    return boxHighest();
 }
 
 // Box test API

--- a/compiler/boxes/boxes.hh
+++ b/compiler/boxes/boxes.hh
@@ -136,10 +136,10 @@ LIBFAUST_API bool isBoxMerge(Tree t, Tree& x, Tree& y);
                         Algorithmic Composition of Boxes
 *****************************************************************************/
 
-Tree boxIPar(Tree x, Tree y, Tree z);
-Tree boxISeq(Tree x, Tree y, Tree z);
-Tree boxISum(Tree x, Tree y, Tree z);
-Tree boxIProd(Tree x, Tree y, Tree z);
+LIBFAUST_API Tree boxIPar(Tree x, Tree y, Tree z);
+LIBFAUST_API Tree boxISeq(Tree x, Tree y, Tree z);
+LIBFAUST_API Tree boxISum(Tree x, Tree y, Tree z);
+LIBFAUST_API Tree boxIProd(Tree x, Tree y, Tree z);
 
 LIBFAUST_API bool isBoxIPar(Tree t, Tree& x, Tree& y, Tree& z);
 LIBFAUST_API bool isBoxISeq(Tree t, Tree& x, Tree& y, Tree& z);
@@ -150,8 +150,8 @@ LIBFAUST_API bool isBoxIProd(Tree t, Tree& x, Tree& y, Tree& z);
                         Static information on Boxes
 *****************************************************************************/
 
-Tree boxInputs(Tree x);
-Tree boxOutputs(Tree x);
+LIBFAUST_API Tree boxInputs(Tree x);
+LIBFAUST_API Tree boxOutputs(Tree x);
 
 LIBFAUST_API bool isBoxInputs(Tree t, Tree& x);
 LIBFAUST_API bool isBoxOutputs(Tree t, Tree& x);
@@ -318,13 +318,13 @@ LIBFAUST_API bool isBoxFVar(Tree s, Tree& type, Tree& name, Tree& file);
                              Modules
 *****************************************************************************/
 
-Tree              boxEnvironment();
+LIBFAUST_API Tree boxEnvironment();
 LIBFAUST_API bool isBoxEnvironment(Tree s);
 
-Tree              boxComponent(Tree filename);
+LIBFAUST_API Tree boxComponent(Tree filename);
 LIBFAUST_API bool isBoxComponent(Tree s, Tree& filename);
 
-Tree              boxLibrary(Tree filename);
+LIBFAUST_API Tree boxLibrary(Tree filename);
 LIBFAUST_API bool isBoxLibrary(Tree s, Tree& filename);
 
 Tree importFile(Tree filename);
@@ -404,7 +404,7 @@ bool isBoxPatternVar(Tree s, Tree& id);
 /*****************************************************************************
                              Metadata (pattern matching)
 *****************************************************************************/
-Tree              boxMetadata(Tree exp, Tree mdlist);
+LIBFAUST_API Tree boxMetadata(Tree exp, Tree mdlist);
 LIBFAUST_API bool isBoxMetadata(Tree s, Tree& exp, Tree& mdlist);
 
 /*****************************************************************************

--- a/tools/benchmark/box-api-test.cpp
+++ b/tools/benchmark/box-api-test.cpp
@@ -1,0 +1,256 @@
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2024 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+
+ ************************************************************************/
+
+// Tests for newly exposed Box API constructors.
+// Validates that constructors produce valid boxes and that
+// isBox* destructors round-trip correctly.
+
+#include <iostream>
+#include <string>
+
+#include "faust/dsp/libfaust-box.h"
+
+using namespace std;
+
+static bool compile(const string& name_app, Box box)
+{
+    string error_msg;
+    string source = createSourceFromBoxes(name_app, box, "cpp", 0, nullptr, error_msg);
+    if (source != "") {
+        return true;
+    } else {
+        cerr << "  compile error: " << error_msg;
+        return false;
+    }
+}
+
+// Test boxIPar constructor and isBoxIPar destructor
+static bool test_iPar()
+{
+    createLibContext();
+    // Use boxWire() as placeholder for iterator variable (boxIdent is internal)
+    Box box = boxIPar(boxWire(), boxInt(4), boxWire());
+    Box x, y, z;
+    bool ok = isBoxIPar(box, x, y, z);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxISeq constructor and isBoxISeq destructor
+static bool test_iSeq()
+{
+    createLibContext();
+    Box box = boxISeq(boxWire(), boxInt(4), boxWire());
+    Box x, y, z;
+    bool ok = isBoxISeq(box, x, y, z);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxISum constructor and isBoxISum destructor
+static bool test_iSum()
+{
+    createLibContext();
+    Box box = boxISum(boxWire(), boxInt(4), boxMul());
+    Box x, y, z;
+    bool ok = isBoxISum(box, x, y, z);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxIProd constructor and isBoxIProd destructor
+static bool test_iProd()
+{
+    createLibContext();
+    Box box = boxIProd(boxWire(), boxInt(4), boxAdd());
+    Box x, y, z;
+    bool ok = isBoxIProd(box, x, y, z);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxInputs and boxOutputs constructors and destructors
+static bool test_inputs_outputs()
+{
+    createLibContext();
+    Box inp = boxInputs(boxWire());
+    Box out = boxOutputs(boxWire());
+    Box x;
+    bool ok1 = isBoxInputs(inp, x);
+    bool ok2 = isBoxOutputs(out, x);
+    destroyLibContext();
+    return ok1 && ok2;
+}
+
+// Test boxDelay1 produces a valid box that compiles
+static bool test_delay1()
+{
+    createLibContext();
+    // delay1 is a 1-input, 1-output primitive: _ : mem
+    Box box = boxSeq(boxWire(), boxDelay1());
+    bool ok = compile("test_delay1", box);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxPrefix produces a valid box that compiles
+static bool test_prefix()
+{
+    createLibContext();
+    // prefix takes 3 inputs: prefix(init, x, y) -> y with init value
+    // Use as: 0, _, _ : prefix
+    Box box = boxSeq(boxPar3(boxInt(0), boxWire(), boxWire()), boxPrefix());
+    bool ok = compile("test_prefix", box);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxEnable and boxControl produce valid boxes that compile
+static bool test_enable_control()
+{
+    bool ok1, ok2;
+    createLibContext();
+    {
+        // enable takes 2 inputs: signal, enable_flag
+        Box enable_box = boxSeq(boxPar(boxWire(), boxInt(1)), boxEnable());
+        ok1 = compile("test_enable", enable_box);
+    }
+    destroyLibContext();
+
+    createLibContext();
+    {
+        // control takes 2 inputs: signal, control_flag
+        Box control_box = boxSeq(boxPar(boxWire(), boxInt(1)), boxControl());
+        ok2 = compile("test_control", control_box);
+    }
+    destroyLibContext();
+
+    return ok1 && ok2;
+}
+
+// Test boxAssertBound, boxLowest, boxHighest produce valid boxes
+static bool test_bounds()
+{
+    bool ok1, ok2, ok3;
+    createLibContext();
+    {
+        // assertbounds takes 3 inputs: lo, hi, x
+        Box assert_box = boxSeq(boxPar3(boxReal(-1.0), boxReal(1.0), boxWire()), boxAssertBound());
+        ok1 = compile("test_assertbound", assert_box);
+    }
+    destroyLibContext();
+
+    createLibContext();
+    {
+        // lowest takes 1 input
+        Box lowest_box = boxSeq(boxWire(), boxLowest());
+        ok2 = compile("test_lowest", lowest_box);
+    }
+    destroyLibContext();
+
+    createLibContext();
+    {
+        // highest takes 1 input
+        Box highest_box = boxSeq(boxWire(), boxHighest());
+        ok3 = compile("test_highest", highest_box);
+    }
+    destroyLibContext();
+
+    return ok1 && ok2 && ok3;
+}
+
+// Test boxEnvironment constructor and isBoxEnvironment destructor
+static bool test_environment()
+{
+    createLibContext();
+    Box box = boxEnvironment();
+    bool ok = isBoxEnvironment(box);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxMetadata constructor and isBoxMetadata destructor
+static bool test_metadata()
+{
+    createLibContext();
+    // Use boxPar of two ints as a dummy metadata list
+    Box box = boxMetadata(boxWire(), boxPar(boxInt(0), boxInt(0)));
+    Box exp, mdlist;
+    bool ok = isBoxMetadata(box, exp, mdlist);
+    destroyLibContext();
+    return ok;
+}
+
+// Test boxComponent and boxLibrary constructors and destructors
+// (box construction only, not compilation since files don't exist)
+static bool test_component_library()
+{
+    createLibContext();
+    Box comp = boxComponent("foo.dsp");
+    Box filename;
+    bool ok1 = isBoxComponent(comp, filename);
+
+    Box lib = boxLibrary("bar.dsp");
+    bool ok2 = isBoxLibrary(lib, filename);
+    destroyLibContext();
+    return ok1 && ok2;
+}
+
+int main()
+{
+    int failures = 0;
+
+    struct {
+        const char* name;
+        bool (*func)();
+    } tests[] = {
+        { "test_iPar",              test_iPar },
+        { "test_iSeq",              test_iSeq },
+        { "test_iSum",              test_iSum },
+        { "test_iProd",             test_iProd },
+        { "test_inputs_outputs",    test_inputs_outputs },
+        { "test_delay1",            test_delay1 },
+        { "test_prefix",            test_prefix },
+        { "test_enable_control",    test_enable_control },
+        { "test_bounds",            test_bounds },
+        { "test_environment",       test_environment },
+        { "test_metadata",          test_metadata },
+        { "test_component_library", test_component_library },
+    };
+
+    for (const auto& t : tests) {
+        bool pass = t.func();
+        cout << (pass ? "PASS" : "FAIL") << ": " << t.name << endl;
+        if (!pass) failures++;
+    }
+
+    cout << endl;
+    if (failures == 0) {
+        cout << "All tests passed." << endl;
+    } else {
+        cout << failures << " test(s) failed." << endl;
+    }
+
+    return failures;
+}


### PR DESCRIPTION
## Summary

While working with the Box API, I noticed that 17 constructors were implemented internally but were not exposed through the public headers (`libfaust-box.h` and `libfaust-box-c.h`).

In this PR, I expose those constructors to the public C++ and C APIs and add a small standalone test file to validate them.

I haven’t introduced any new logic — I’ve only exposed existing functionality and added basic coverage for it.

---

## What I Changed

* Added the missing constructor declarations to the public C++ and C headers.
* Added thin C wrapper implementations in `box_signal_api.cpp`.
* Added missing internal declarations in `boxes.hh`.
* Added a lightweight test file covering all exposed constructors.

Example (C++ API):

```cpp id="a1k29x"
LIBFAUST_API Box boxIPar(Box x, Box y, Box z);
LIBFAUST_API Box boxDelay1();
LIBFAUST_API Box boxEnvironment();
```

Example (C wrapper):

```cpp id="m82xpl"
LIBFAUST_API Tree CboxIPar(Tree x, Tree y, Tree z) {
    return boxIPar(x, y, z);
}
```

Each wrapper simply forwards to the already existing internal implementation.

---

## Tests

I added a standalone test file:

```
tools/benchmark/box-api-test.cpp
```

The tests use two simple patterns:

**Round-trip validation:**

```cpp id="t6z1rp"
static bool test_iPar() {
    createLibContext();
    Box box = boxIPar(boxWire(), boxInt(4), boxWire());
    Box x, y, z;
    bool ok = isBoxIPar(box, x, y, z);
    destroyLibContext();
    return ok;
}
```

**Compilation validation:**

```cpp id="k3pd9v"
static bool test_delay1() {
    createLibContext();
    Box box = boxSeq(boxWire(), boxDelay1());
    bool ok = compile("test_delay1", box);
    destroyLibContext();
    return ok;
}
```

All tests passed locally during my build.

<img width="1181" height="570" alt="image" src="https://github.com/user-attachments/assets/8572f798-9950-4774-8341-1b0a7ae4bb65" />
---

## Impact

This change should not affect existing behavior since I did not modify any internal logic — I only exposed functions that were already implemented.

My intention was to make the public API more complete and consistent with the internal implementation. If there are concerns about API surface, test placement, or naming, I’m happy to revise accordingly.