### PR TITLE
Fix typo in Makefile for LIBDAISY_DIR value

### DIFF
--- a/architecture/hothouse/Makefile
+++ b/architecture/hothouse/Makefile
@@ -4,7 +4,7 @@ USE_DAISYSP_LGPL=1
 
 # Library Locations
 HOTHOUSE_DIR ?= ../../HothouseExamples
-LIBDAISY_DIR ?= $(HOTHOUSE_DIR)/libdaisy
+LIBDAISY_DIR ?= $(HOTHOUSE_DIR)/libDaisy
 DAISYSP_DIR ?= $(HOTHOUSE_DIR)/DaisySP
 
 # Sources


### PR DESCRIPTION
In the HothouseExamples repo, the libDaisy submodule directory name is camelCase (rather than all lowercase):

* libdaisy (incorrect)
* libDaisy (correct)

With the current incorrect value, faust2hothouse throws a path not found exception.