### PR TITLE
Fix missing double-precision conversion in JuceReader

### DIFF
--- a/architecture/faust/gui/JuceReader.h
+++ b/architecture/faust/gui/JuceReader.h
@@ -80,7 +80,12 @@ struct JuceReader : public SoundfileReader {
             if (!formatReader->usesFloatingPointData) {
                 for (int chan = 0; chan < int(formatReader->numChannels); ++chan) {
                     if (soundfile->fIsDouble) {
-                        // TODO
+                        double* buffer = &(static_cast<double**>(soundfile->fBuffers))[chan][soundfile->fOffset[part]];
+                        const int* intBuffer = reinterpret_cast<const int*>(buffer);
+                        // Iterate backwards: double (8 bytes) > int (4 bytes), same underlying buffer
+                        for (int i = int(formatReader->lengthInSamples) - 1; i >= 0; --i) {
+                            buffer[i] = double(intBuffer[i]) / double(0x7fffffff);
+                        }
                     } else {
                         float* buffer = &(static_cast<float**>(soundfile->fBuffers))[chan][soundfile->fOffset[part]];
                         juce::FloatVectorOperations::convertFixedToFloat(buffer, reinterpret_cast<const int*>(buffer),


### PR DESCRIPTION
In JuceReader::readFile, when the soundfile uses double precision and the audio format is fixed-point integer, the conversion step was left as a TODO. The float path already handles this using FloatVectorOperations::convertFixedToFloat, but the double path was just skipped silently.

This means double-precision users would get unconverted int data in their audio buffers without any warning.

Added a manual conversion loop for the double case. It iterates backwards because double (8 bytes) and int (4 bytes) share the same underlying buffer memory, so forward iteration would overwrite unread int samples.

File changed: architecture/faust/gui/JuceReader.h (line 82-88)