### PR TITLE
Remove std::less<CTree*> specialization

### DIFF
--- a/compiler/tlib/tree.hh
+++ b/compiler/tlib/tree.hh
@@ -105,17 +105,6 @@ typedef CTree* Tree;
 
 typedef std::vector<Tree> tvec;
 
-namespace std {
-
-// The std::less <CTree*>comparison function is redefined to provide an unique and stable ordering
-// for all CTree instances and so maintain determinism.
-template <>
-struct less<CTree*> {
-    bool operator()(const CTree* lhs, const CTree* rhs) const;
-};
-
-}  // namespace std
-
 /**
  * A CTree = (Node x [CTree]) is the association of a content Node and a list of subtrees
  * called branches. In order to maximize the sharing of trees, hashconsing techniques are used.
@@ -228,15 +217,6 @@ class LIBFAUST_API CTree : public virtual Garbageable {
         return (i == fProperties.end()) ? nullptr : i->second;
     }
 };
-
-// The comparison function relies on lhs->serial() which provides an unique and stable ordering
-// for all CTree instances and so maintain determinism.
-namespace std {
-inline bool less<CTree*>::operator()(const CTree* lhs, const CTree* rhs) const
-{
-    return lhs->serial() < rhs->serial();
-}
-};  // namespace std
 
 //---------------------------------API---------------------------------------
 // To build trees


### PR DESCRIPTION
I was hitting infinite recursion nondeterministically - turns out, these `CTree` pointers were inconsistent between comparisons somehow. I could hit this during a single compile sometimes, but on teardown/recompile I hit it always in my case. Can't really explain what was changing CTree values in a way that would change the `serial` of what it references during a single compile. Never really got to the bottom of it.

This was causing set ordering invariants to break, causing infinite recursion in `symlistVisit` - it uses a `set<Tree>` to detect cycles during signal tree traversal. With the corrupted set, already-visited nodes couldn't be found, so it cycled until the stack overflowed.

Using default pointer comparison fixes since it only compares addresses and avoids derefs that can return inconsistent values if what they point to changes. This is safe because hashconsing guarantees unique pointers per logical tree.

However, I think this would technically break compiler determinism, so maybe it's not the right fix, but it completely solved the crashes I was seeing - I could provide more context if needed.
