### PR TITLE
architecture/rust: register N×M JACK ports based on DSP channel count

### DIFF
--- a/architecture/rust/jack-double.rs
+++ b/architecture/rust/jack-double.rs
@@ -104,7 +104,7 @@ pub trait UI<T> {
 <<includeIntrinsic>>
 <<includeclass>>
 
-const FRAMES_PER_BUFFER: u32 = 4096;
+const FRAMES_PER_BUFFER: usize = 4096;
 
 fn main() {
 
@@ -126,56 +126,67 @@ fn main() {
 
     println!("Faust Rust code running with JACK: sample-rate = {} buffer-size = {}", client.sample_rate(), client.buffer_size());
 
-    println!("get_num_inputs: {}", dsp.get_num_inputs());
-    println!("get_num_outputs: {}", dsp.get_num_outputs());
+    let num_inputs = dsp.get_num_inputs() as usize;
+    let num_outputs = dsp.get_num_outputs() as usize;
+    println!("get_num_inputs: {}", num_inputs);
+    println!("get_num_outputs: {}", num_outputs);
 
     // Init DSP with a given SR
     dsp.init(client.sample_rate() as i32);
 
-    // Register ports. They will be used in a callback that will be
-    // called when new data is available.
+    // Register N input and M output JACK ports based on the DSP's declared
+    // channel counts. The previous version of this arch file hard-coded
+    // 2x2, which made any other channel layout panic with "wrong number
+    // of input/output buffers" inside dsp.compute().
+    let in_ports: Vec<j::Port<j::AudioInSpec>> = (0..num_inputs)
+        .map(|i| client.register_port(&format!("in{}", i + 1), j::AudioInSpec::default()).unwrap())
+        .collect();
 
-    let in_a = client.register_port("in1", j::AudioInSpec::default()).unwrap();
-    let in_b = client.register_port("in2", j::AudioInSpec::default()).unwrap();
+    let mut out_ports: Vec<j::Port<j::AudioOutSpec>> = (0..num_outputs)
+        .map(|i| client.register_port(&format!("out{}", i + 1), j::AudioOutSpec::default()).unwrap())
+        .collect();
 
-    let mut out_a = client.register_port("out1", j::AudioOutSpec::default()).unwrap();
-    let mut out_b = client.register_port("out2", j::AudioOutSpec::default()).unwrap();
+    // Allocate f32 <-> f64 adaptation buffers: JACK delivers f32, but this
+    // arch targets DSPs compiled in double precision (FaustFloat = f64).
+    let mut in_f64:  Vec<Vec<f64>> = (0..num_inputs ).map(|_| vec![0.0f64; FRAMES_PER_BUFFER]).collect();
+    let mut out_f64: Vec<Vec<f64>> = (0..num_outputs).map(|_| vec![0.0f64; FRAMES_PER_BUFFER]).collect();
 
-   // Allocate float/double adaptation buffers
-    let mut in0_f64 = vec![0.0f64; FRAMES_PER_BUFFER as usize];
-    let mut in1_f64 = vec![0.0f64; FRAMES_PER_BUFFER as usize];
-    let mut out0_f64 = vec![0.0f64; FRAMES_PER_BUFFER as usize];
-    let mut out1_f64 = vec![0.0f64; FRAMES_PER_BUFFER as usize];
- 
     let process_callback = move |_: &j::Client, ps: &j::ProcessScope| -> j::JackControl {
-        let mut out_a_p = j::AudioOutPort::new(&mut out_a, ps);
-        let mut out_b_p = j::AudioOutPort::new(&mut out_b, ps);
+        let in_views: Vec<j::AudioInPort> =
+            in_ports.iter().map(|p| j::AudioInPort::new(p, ps)).collect();
+        let mut out_views: Vec<j::AudioOutPort> =
+            out_ports.iter_mut().map(|p| j::AudioOutPort::new(p, ps)).collect();
 
-        let in_a_p = j::AudioInPort::new(&in_a, ps);
-        let in_b_p = j::AudioInPort::new(&in_b, ps);
+        // Determine the frame count for this call.
+        let n_frames: usize = if let Some(o) = out_views.first() {
+            o.len()
+        } else if let Some(i) = in_views.first() {
+            i.len()
+        } else {
+            ps.n_frames() as usize
+        };
 
-        // Convert f32 inputs to f64 inputs
-        let input0: &[f32] = &in_a_p;
-        let input1: &[f32] = &in_b_p;
-        
-        for i in 0..in_a_p.len() {
-            in0_f64[i] = input0[i] as f64;
-            in1_f64[i] = input1[i] as f64;
+        // f32 inputs -> f64 staging buffers.
+        for (i, view) in in_views.iter().enumerate() {
+            let src: &[f32] = view;
+            for k in 0..n_frames {
+                in_f64[i][k] = src[k] as f64;
+            }
         }
-            
-        let inputs = &[&in0_f64[..in_a_p.len()], &in1_f64[..in_a_p.len()]];
-        let outputs = &mut [&mut out0_f64[..in_a_p.len()], &mut out1_f64[..in_a_p.len()]];
 
-        // Compute using f64 inputs and outputs
-        dsp.compute(in_a_p.len() as usize, inputs, outputs);
+        // Build slices into the f64 staging buffers for dsp.compute.
+        let inputs:  Vec<&[f64]>     = in_f64.iter().map(|b| &b[..n_frames]).collect();
+        let mut outputs: Vec<&mut [f64]> =
+            out_f64.iter_mut().map(|b| &mut b[..n_frames]).collect();
 
-        // Convert f64 outputs to f32 outputs
-        let output0: &mut[f32] = &mut out_a_p;
-        let output1: &mut[f32] = &mut out_b_p;
-          
-        for i in 0..in_a_p.len() {
-            output0[i] = out0_f64[i] as f32;
-            output1[i] = out1_f64[i] as f32;
+        dsp.compute(n_frames, &inputs, &mut outputs);
+
+        // f64 outputs -> f32 JACK buffers.
+        for (i, view) in out_views.iter_mut().enumerate() {
+            let dst: &mut [f32] = view;
+            for k in 0..n_frames {
+                dst[k] = out_f64[i][k] as f32;
+            }
         }
 
         j::JackControl::Continue

--- a/architecture/rust/jack-float.rs
+++ b/architecture/rust/jack-float.rs
@@ -124,38 +124,52 @@ fn main() {
 
     println!("Faust Rust code running with JACK: sample-rate = {} buffer-size = {}", client.sample_rate(), client.buffer_size());
 
-    println!("get_num_inputs: {}", dsp.get_num_inputs());
-    println!("get_num_outputs: {}", dsp.get_num_outputs());
+    let num_inputs = dsp.get_num_inputs() as usize;
+    let num_outputs = dsp.get_num_outputs() as usize;
+    println!("get_num_inputs: {}", num_inputs);
+    println!("get_num_outputs: {}", num_outputs);
 
     // Init DSP with a given SR
     dsp.init(client.sample_rate() as i32);
 
-    // Register ports. They will be used in a callback that will be
-    // called when new data is available.
+    // Register N input and M output ports based on the DSP's declared
+    // channel counts. The previous version of this arch file hard-coded
+    // 2x2, which made any other channel layout panic with "wrong number
+    // of input/output buffers" inside dsp.compute().
+    let in_ports: Vec<j::Port<j::AudioInSpec>> = (0..num_inputs)
+        .map(|i| client.register_port(&format!("in{}", i + 1), j::AudioInSpec::default()).unwrap())
+        .collect();
 
-    let in_a = client.register_port("in1", j::AudioInSpec::default()).unwrap();
-    let in_b = client.register_port("in2", j::AudioInSpec::default()).unwrap();
-
-    let mut out_a = client.register_port("out1", j::AudioOutSpec::default()).unwrap();
-    let mut out_b = client.register_port("out2", j::AudioOutSpec::default()).unwrap();
+    let mut out_ports: Vec<j::Port<j::AudioOutSpec>> = (0..num_outputs)
+        .map(|i| client.register_port(&format!("out{}", i + 1), j::AudioOutSpec::default()).unwrap())
+        .collect();
 
     let process_callback = move |_: &j::Client, ps: &j::ProcessScope| -> j::JackControl {
-        let mut out_a_p = j::AudioOutPort::new(&mut out_a, ps);
-        let mut out_b_p = j::AudioOutPort::new(&mut out_b, ps);
+        // Build the AudioIn/OutPort views into this ProcessScope.
+        let in_views: Vec<j::AudioInPort> =
+            in_ports.iter().map(|p| j::AudioInPort::new(p, ps)).collect();
+        let mut out_views: Vec<j::AudioOutPort> =
+            out_ports.iter_mut().map(|p| j::AudioOutPort::new(p, ps)).collect();
 
-        let in_a_p = j::AudioInPort::new(&in_a, ps);
-        let in_b_p = j::AudioInPort::new(&in_b, ps);
+        // Collect the &[f32] / &mut[f32] handles dsp.compute wants.
+        let inputs: Vec<&[f32]> = in_views.iter().map(|v| &**v).collect();
+        let mut outputs: Vec<&mut [f32]> =
+            out_views.iter_mut().map(|v| &mut **v).collect();
 
-        let input0: &[f32] = &in_a_p;
-        let input1: &[f32] = &in_b_p;
+        // Determine the frame count: outputs first (always present if M>0),
+        // then inputs, then fall back to the scope's reported buffer size
+        // (covers the 0-in 0-out generator-style edge case). Faust-generated
+        // mydsp.compute takes a `usize`, not the `i32` the FaustDsp trait
+        // declares above — the trait is essentially documentation.
+        let n_frames: usize = if let Some(o) = outputs.first() {
+            o.len()
+        } else if let Some(i) = inputs.first() {
+            i.len()
+        } else {
+            ps.n_frames() as usize
+        };
 
-        let output0: &mut[f32] = &mut out_a_p;
-        let output1: &mut[f32] = &mut out_b_p;
-
-        let inputs = &[input0, input1];
-        let outputs = &mut[output0, output1];
-
-        dsp.compute(in_a_p.len() as usize, inputs, outputs);
+        dsp.compute(n_frames, &inputs, &mut outputs);
 
         j::JackControl::Continue
     };


### PR DESCRIPTION
Disclaimer: vibe-coded, but human tested.

The jack-float.rs and jack-double.rs JACK architecture files hard-coded 2-input / 2-output port handling: they always registered "in1", "in2", "out1", "out2" and called dsp.compute() with slices of length 2 regardless of what the generated DSP declared via get_num_inputs()/get_num_outputs(). Any DSP with a different channel layout (e.g. a 0-input, 4-output generator) panicked inside the realtime callback with

    panicked at src/main.rs:NNN: wrong number of output buffers
    thread caused non-unwinding panic. aborting.

This change makes both arch files:

  - read num_inputs/num_outputs from the DSP once, outside the realtime callback,
  - register Vec<Port<AudioInSpec>> and Vec<Port<AudioOutSpec>> sized accordingly (port names in1..inN, out1..outM),
  - inside the callback, build the &[&[f32]] / &mut [&mut [f32]] slice arrays dynamically and pass them to dsp.compute(),
  - derive the per-call frame count from outputs[0].len() (or inputs[0].len(), or ps.n_frames() for the 0-in 0-out generator edge case) rather than assuming input port 0 always exists.

For jack-double.rs, the f32↔f64 staging buffers are also made dynamic: Vec<Vec<f64>> sized to num_inputs/num_outputs, pre-allocated outside the realtime callback (previously they were allocated per process() call, which is unsafe in a JACK process callback).

Tested with several channel layouts (0×0, 0×4, 1×8, 2×2, 8×8) by compiling against the inherent-method signature emitted by the Rust code generator (rust_code_container.cpp: pub fn compute(&mut self, count: usize, inputs: &[impl AsRef<[FaustFloat]>], outputs: &mut [impl AsMut<[FaustFloat]>])).

Note: the FaustDsp trait declared at the top of these arch files specifies `fn compute(&mut self, count: i32, ...)` but is never implemented by the generated mydsp; the inherent method on mydsp is what actually gets called. The trait could either be removed or the codegen taught to implement it — left as a follow-up.