### PR TITLE
Embed the AssemblyScript backend in the wasm libfaust

### DIFF
--- a/build/backends/regular.cmake
+++ b/build/backends/regular.cmake
@@ -19,7 +19,7 @@ set ( FIR_BACKEND                        OFF      CACHE STRING  "Include FIR bac
 set ( INTERP_BACKEND                     OFF      CACHE STRING  "Include Interpreter backend" FORCE )
 set ( JAVA_BACKEND   COMPILER STATIC DYNAMIC      CACHE STRING  "Include JAVA backend" FORCE )
 set ( JAX_BACKEND    COMPILER STATIC DYNAMIC      CACHE STRING  "Include JAX backend"  FORCE )
-set ( AS_BACKEND     COMPILER STATIC DYNAMIC      CACHE STRING  "Include AssemblyScript backend" FORCE )
+set ( AS_BACKEND     COMPILER STATIC DYNAMIC WASM CACHE STRING  "Include AssemblyScript backend" FORCE )
 set ( JULIA_BACKEND  COMPILER STATIC DYNAMIC      CACHE STRING  "Include Julia backend" FORCE )
 set ( JSFX_BACKEND  COMPILER STATIC DYNAMIC CACHE STRING  "Include JSFX backend" FORCE )
 set ( LLVM_BACKEND                       OFF      CACHE STRING  "Include LLVM backend" FORCE )


### PR DESCRIPTION
The AssemblyScript backend (`compiler/generator/assemblyscript/`, `-lang asc`) exists in the compiler but isn't embedded in the wasm `libfaust`: in `build/backends/regular.cmake`, `AS_BACKEND` is `COMPILER STATIC DYNAMIC` — it lacks the `WASM` keyword that `WASM_BACKEND` has. So a `libfaust-wasm` built via `make wasmlib` can't generate AssemblyScript; `generateAuxFiles(..., "-lang asc ...")` returns *"cannot find backend for 'asc'"*.

This adds `WASM` to `AS_BACKEND` so the backend is compiled into `libfaust-wasm`, matching `WASM_BACKEND`.

Verified in a clean CI build (no other patches): a `libfaust-wasm` built from this branch reports the asc backend present and generates valid `-lang asc` output for a range of real DSPs (DX7 algorithms etc.). One-line change.

Companion: grame-cncm/faustwasm#40 (a standalone ESM-loader fix needed when libfaust-wasm is rebuilt with a newer emscripten).