### PR TITLE
Changed types on inputs and outputs to compute! from overly constrain…

### DIFF
--- a/compiler/generator/julia/julia_code_container.cpp
+++ b/compiler/generator/julia/julia_code_container.cpp
@@ -297,9 +297,7 @@ void JuliaCodeContainer::produceMetadata(int tabs)
                     *fOut << "declare!(m, \"" << *(i.first) << "\", " << **j << ");";
                 } else {
                     tab(tabs + 1, *fOut);
-                    *fOut << "declare!(m, \""
-                          << "contributor"
-                          << "\", " << **j << ");";
+                    *fOut << "declare!(m, \"" << "contributor" << "\", " << **j << ");";
                 }
             }
         }
@@ -323,7 +321,8 @@ void JuliaScalarCodeContainer::generateCompute(int n)
     // Generates declaration
     tab(n, *fOut);
     *fOut << "@inbounds function compute!(dsp::" << fKlassName << "{T}, " << fFullCount
-          << subst("::Int32, inputs::Matrix{$0}, outputs::Matrix{$0}) where {T}", xfloat());
+          << subst("::Int32, inputs::AbstractMatrix{$0}, outputs::AbstractMatrix{$0}) where {T}",
+                   xfloat());
     tab(n + 1, *fOut);
     gGlobal->gJuliaVisitor->Tab(n + 1);
 
@@ -362,7 +361,8 @@ void JuliaVectorCodeContainer::generateCompute(int n)
     // Generates declaration
     tab(n + 1, *fOut);
     *fOut << "@inbounds function compute!(dsp::" << fKlassName << "{T}, " << fFullCount
-          << subst("::Int32, inputs::Matrix{$0}, outputs::Matrix{$0}) where {T}", xfloat());
+          << subst("::Int32, inputs::AbstractMatrix{$0}, outputs::AbstractMatrix{$0}) where {T}",
+                   xfloat());
     tab(n + 2, *fOut);
     gGlobal->gJuliaVisitor->Tab(n + 2);
 


### PR DESCRIPTION
The types set on the inputs and outputs to compute! where set to the overly restrictive Matrix. This means that vectors that had been reshaped into a Matrix could not be used with compute!  By using AbstractMatrix, we fix this problem.