### PR TITLE
Fix division by zero in uiNumEntry when step is 0 (#1266)

### DIFF
--- a/architecture/faust/gui/QTUI.h
+++ b/architecture/faust/gui/QTUI.h
@@ -1135,7 +1135,7 @@ public:
     uiNumEntry(GUI* ui, FAUSTFLOAT* zone, QDoubleSpinBox* numEntry, FAUSTFLOAT cur, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step)
     : uiItem(ui, zone), fNumEntry(numEntry), fCur(cur), fMin(lo), fMax(hi), fStep(step)
     {
-        int decimals = (fStep >= 1.0) ? 0 : int(0.5+log10(1.0/fStep));
+        int decimals = (fStep >= 1.0 || fStep <= 0.0) ? 0 : int(0.5+log10(1.0/fStep));
         fNumEntry->setMinimum(fMin);
         fNumEntry->setMaximum(fMax);
         fNumEntry->setSingleStep(fStep);


### PR DESCRIPTION
This Pull Request fixes a division by zero (and subsequent undefined behavior during the float-to-int cast) in the `uiNumEntry` constructor when `fStep` is set to `0.0`. 

It ensures that `decimals` is safely set to `0` if `fStep <= 0.0`.

Closes #1266