### PR TITLE
faust2daisy improvements & bugs fixed. Support for Patch, PatchSM, hardward PWM, soundfile, and serial communication

### DIFF
--- a/architecture/daisy/Makefile
+++ b/architecture/daisy/Makefile
@@ -20,3 +20,8 @@ OPT ?= -Os
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile
+
+# Soundfile support: when a DSP uses soundfiles, the audio samples are inlined
+# as 'const' into daisy_soundfile.hpp. Build with -qspi so they are placed in
+# QSPI flash (they do not fit in the 128 KB internal flash). No extra build
+# step is needed: the samples are part of the single program image.

--- a/architecture/daisy/Makefile.sd_uploader
+++ b/architecture/daisy/Makefile.sd_uploader
@@ -1,0 +1,22 @@
+# Makefile for the faust2daisy SD card soundfile uploader firmware.
+# Built and flashed temporarily by `faust2daisy -upload-sd`.
+
+TARGET = sd_uploader
+
+CPP_SOURCES = sd_uploader.cpp
+
+# Required to link the FatFS middleware (adds ff.c + the codepage source that
+# provides ff_convert / ff_wtoupper for long filename support).
+USE_FATFS = 1
+
+# Library Locations (overridden by the LIBDAISY_DIR / DAISYSP_DIR env vars)
+LIBDAISY_DIR ?= ../../../libdaisy
+DAISYSP_DIR ?= ../../../DaisySP
+
+# Runs from internal flash: small firmware, no bootloader required.
+APP_TYPE ?= BOOT_NONE
+
+OPT ?= -Os
+
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/architecture/daisy/README.md
+++ b/architecture/daisy/README.md
@@ -1,10 +1,7 @@
 # faust2daisy
 
-The **faust2daisy** tool compiles a Faust DSP program in a folder containing the C++ source code and a Makefile to compile it.  
-This new version is a partial refactor of the previous tool, aiming to : 
-- improve memory footprint
-- provide compile time memory footprint
-- target Daisy boards (while still providing a way to target platforms)
+The **faust2daisy** tool compiles a Faust DSP program into a C++ program targetting Electrosmith Daisy boards.
+It can target both Daisy Seed and Daisy Patch Submodule, as well as used defined platforms built upon (such as Pod, Patch, Patch.Init() etc). 
 
 `faust2daisy [-faust2daisy_options...] [additional Faust options (-vec -vs 8...)] <file.dsp>`
 
@@ -13,7 +10,7 @@ Here are the available options:
 - `-seed`: target Daisy seed chip
 - `-patchsm`: target Daisy patchsm chip
 - `-pod`: use Pod configuration file 
-- `-patch`: use Patch configuration file (not full feature yet) 
+- `-patch`: use Patch configuration file, as well as Patch audio codec & OLED display
 - `-sram`: program will stand on SRAM (512kB)
 - `-qspi`: program will stand on QSPIFLASH (8MB)
 - `-sdram`: enable SDRAM for large buffers (slow, but big)
@@ -25,9 +22,39 @@ Here are the available options:
 - `-tx-pin <Pin>`: TX Pin for MIDI UART
 - `-nvoices <num>`: number of voices, enables polyphony 
 - `-poly-mode`: mode for voice management in polyphonic context. Options <stealing> or <blocking> (defaults to stealing)
-- `sr <num>`: sample rate of DSP : only 8000, 16000, 32000, 48000, 96000 are allowed
-- `bs <num>`: buffer size
+- `-sr <num>`: sample rate of DSP : only 8000, 16000, 32000, 48000, 96000 are allowed
+- `-bs <num>`: buffer size
+- `-sd` to load soundfiles from the SD card at runtime instead of inlining to QSPI
+- `-sd-debug` to print loaded soundfile info over USB serial at startup
+-  `-upload-sd` to upload soundfiles to the SD card (does not build the DSP, just the uploader)
 - Any other option will be passed to Faust compiler
+
+
+## Features 
+
+This tool tries to provide the most exhaustive control one can give over Daisy boards with Faust DSP programs. 
+
+It features : 
+- Audio : High quality, up to 96KHz sample rate, low latency, 2 inputs, 2 outputs
+- Audio : Soundfile, either stored in QSPI flash (small files) or in SD card (bigger files)  
+- Control : ADC's (up to 12 inputs, 16 bits each) and DAC's (up to 2, 12 bits outputs). 
+  - ADC example : `hslider("amp[adc:A0]", 0, 0, 1, 0.001)`
+  - DAC example : `vbargraph("ampout[DAC:A7]", 0, 1)`
+- Control : MIDI input, either through default USB or serial UART
+  - MIDI example : `hslider("freq[midi:ctrl 14]", 50, 20, 1000, 0.1)`
+  - Polyphonic example with `-nvoices` option : `hslider("gain", 0, 0, 1, 0.001)`
+- Control : Digital GPIOs (a large set of on/off switches, or software PWM at ~1000Hz)
+  - GPIO option : `button("gate[gpio:D8])`
+  - Software PWM mode (output only) : `vbargraph("led_control[gpio:D8][mode:softpwm]", 0, 1)`
+- Control : Serial communication through UART pins
+  - Input example : `hslider("freq[rx:D1]", 50, 20, 1000, 0.01)`
+  - Output example : `vbargraph("outctrl[tx:D2]", 0, 1)`
+- Control : hardware PWM output (~29KHz by default)
+  - Example : `vbargraph("dim[pwm:D3], 0, 1)` 
+- Memory : Almost constant, compile-time awareness of memory footprint 
+- Memory : control location where program is stored and executed (Flash, SRAM, QSPI flash)
+- Memory : control threshold above which memory blocks (delay lines for example) are stored in SDRAM (64MB) 
+- Development : configuration file system, allowing to rename some pins (for example : `knob:1 = adc:A0`)
 
 ## Setup 
 
@@ -42,21 +69,24 @@ export LIBDAISY_DIR=~/GitHub/DaisyExamples/libdaisy
 export DAISYSP_DIR=~/GitHub/DaisyExamples/DaisySP
 ```
 
-If on macOS, consider putting the above text in `~/.zshrc` so that it's always set in Terminal.
+If on macOS, consider putting the above text in `~/.zshrc` so that it's always set in Terminal. On linux, put it to `~/.bashrc`. 
 
-The default optimization is for file size: `OPT=-Os`. You can optimize for speed by setting `OPT=-O2` or the even more aggressive setting `OPT=-O3`. This can be set in the Makefile in "faust/architecture/daisy".
+The default optimization is for file size: `OPT=-Os`. You can optimize for speed by setting `OPT=-O2` or the even more aggressive setting `OPT=-O3`. The drawback is that more aggressive optimization will result in larger binary. This can be set in the Makefile in "faust/architecture/daisy".
 
 ## Targetting boards 
 
 This tool is intended to target Daisy boards : 
 - Seed 
-- PatchSM - currently unimplemented 
+- PatchSM 
 
-The idea is to provide access to all of the Pins that can be useful in an audio context : 
+ It provide access to all of the Pins and features that can be useful in an audio context : 
 - Audio inputs & outputs (24 bits)
-- Control ADCs (16 bits)
-- Control DACs (12 bits)
-- GPIO (in either on/off mode, or as software PWM for output)
+- Control ADCs (CV in for Patch SM) (16 bits) 
+- Control DACs (CV out for Patch SM) (12 bits)
+- GPIO & Gates (either on/off mode, or software PWM for output)
+- Serial through UART pins
+- MIDI via USB or UART 
+- Hardware PWM 
 
 Example : 
 ``` faust
@@ -65,7 +95,7 @@ import("stdfaust.lib");
 freq = hslider("freq[adc::A0]", 50, 50, 1000, 0.1) : si.smoo;
 
 // Controls accept scale parameter : either lin (default), log or exp 
-amp = hslider("freq[adc:A1][scale:exp]", 0, 0, 1, 0.01) : si.smoo;
+amp = hslider("amp[adc:A1][scale:exp]", 0, 0, 1, 0.01) : si.smoo;
 
 // Digital GPIO (1 or 0 only)
 gate = button("gate[gpio:D27]); 
@@ -78,7 +108,7 @@ process = os.sawtooth(freq) * amp * 0.5 * env <: _,_;
 
 Then compile with `faust2daisy -seed my.dsp`. 
 
-In order to embrace more fully the potential of Daisy boards, there gpio outputs can be configured as PWM controls, providing more high frequency outputs
+In order to embrace more fully the potential of Daisy boards, there gpio outputs can be configured as PWM controls, running at ~1000Hz.
 
 ``` faust
 import("stdfaust.lib");
@@ -93,9 +123,124 @@ process = os.osc(100) * duty * 0.3;
 ### MIDI 
 
 Midi is implemented for both monophonic controls (control change, keyon, keyoff, key) & polyphonic controls (freq, key, gain, vel, gate). 
-Of course, you need to set "nvoices" either as a command line option, or in your DSP metadata. 
+For monophonic midi, parser will automatically detect that there are some MIDI controls in your DSP. You might specify (command line option, or config file) the MIDI mode : UART pin, or USB (default). 
+For polyphonic MIDI, you need to set "nvoices" either as a command line option, or in your DSP global metadata. 
 
-MIDI can be passed through the power supply/flash USB interface. This is the MIDI USB mode (default when setting `-midi`) or through serial ports (UART) with `midi-uart` option. In this case, you need to specify which pins are used.
+MIDI can be passed through the power supply/flash USB interface. This is the MIDI USB mode (default when setting `-midi`) or through serial ports (UART) with `-midi-uart` option. In this case, you need to specify which pins are used (or use a configuration file). 
+
+## Pin reference
+
+These tables list every pin faust2daisy can address on each board, and which
+metadata each one accepts. They are generated from the tool's own resolution
+tables (`daisy_pins.py`, `daisy_uart_pins.py`, `daisy_pwm_pin.py`) cross-checked
+against libDaisy (`daisy_seed.h`, `daisy_patch_sm.h`), so they match exactly what
+the parser will accept.
+
+**Legend**
+
+| Column | Metadata | Meaning |
+|--------|----------|---------|
+| ADC  | `[adc:PIN]`               | Analog input (16-bit). |
+| DAC  | `[dac:PIN]`               | Analog output (12-bit). |
+| GPIO | `[gpio:PIN]` (+ optional `[mode:softpwm]`) | Digital in (`button`/`checkbox`) or out; `in`/`out` noted where the board wires it one way. |
+| PWM  | `[pwm:PIN]`               | Hardware PWM output. The cell shows `timer·channel` — **pins on the same timer share one frequency**, and one `timer·channel` drives only one pin. |
+| UART | `[rx:PIN]` / `[tx:PIN]`   | Serial. `Rx`/`Tx` shown with the USART peripheral; an `Rx` and a `Tx` on the **same peripheral** form one bidirectional link. |
+
+Every physical pin may be claimed by **one** feature only (the conflict guard
+rejects re-use) — the exception is serial, where a pin may appear on several
+controls. Aliases resolve to the same silicon (Seed `A0` == `D15`), so they
+conflict too. `Shared` names the pin's other on-board function; reusing it there
+(SPI/I²C/SDMMC/USB/CV) is your responsibility.
+
+### Daisy Seed
+
+Seed exposes `D0`–`D32`; the analog pins also carry an `A`-alias. **Every pin is
+usable as digital GPIO.** The 12 documented ADC inputs are `A0`–`A11`; `A12`/`A13`
+(`D31`/`D32`) are ADC-capable underside pads. `A7`/`A8` (`D22`/`D23`) double as
+the two DAC outputs — used as a DAC, that pin is no longer free for ADC.
+
+| Pin | MCU | ADC | DAC | GPIO | PWM | UART | Shared |
+|-----|-----|:---:|:---:|:----:|:---:|------|--------|
+| D0        | PB12 |   |   | ✓ |      |             | |
+| D1        | PC11 |   |   | ✓ |      | Rx · USART3 | |
+| D2        | PC10 |   |   | ✓ |      | Tx · USART3 | |
+| D3        | PC9  |   |   | ✓ | T3·4 |             | |
+| D4        | PC8  |   |   | ✓ | T3·3 |             | |
+| D5        | PD2  |   |   | ✓ |      | Rx · UART5  | |
+| D6        | PC12 |   |   | ✓ |      | Tx · UART5  | |
+| D7        | PG10 |   |   | ✓ |      |             | |
+| D8        | PG11 |   |   | ✓ |      |             | |
+| D9        | PB4  |   |   | ✓ | T3·1 |             | SPI1 MISO |
+| D10       | PB5  |   |   | ✓ | T3·2 |             | SPI1 MOSI |
+| D11       | PB8  |   |   | ✓ | T4·3 | Rx · UART4  | I²C1 SCL |
+| D12       | PB9  |   |   | ✓ | T4·4 | Tx · UART4  | I²C1 SDA |
+| D13       | PB6  |   |   | ✓ | T4·1 | Tx · USART1 | default UART Tx |
+| D14       | PB7  |   |   | ✓ | T4·2 | Rx · USART1 | default UART Rx |
+| D15 · A0  | PC0  | ✓ |   | ✓ |      |             | |
+| D16 · A1  | PA3  | ✓ |   | ✓ | T5·4 | Rx · USART2 | |
+| D17 · A2  | PB1  | ✓ |   | ✓ | T3·4 |             | |
+| D18 · A3  | PA7  | ✓ |   | ✓ | T3·2 |             | SPI1 MOSI |
+| D19 · A4  | PA6  | ✓ |   | ✓ | T3·1 |             | SPI1 MISO |
+| D20 · A5  | PC1  | ✓ |   | ✓ |      |             | |
+| D21 · A6  | PC4  | ✓ |   | ✓ |      |             | |
+| D22 · A7  | PA5  | ✓ | ✓ | ✓ |      |             | DAC out 2 |
+| D23 · A8  | PA4  | ✓ | ✓ | ✓ |      |             | DAC out 1 |
+| D24 · A9  | PA1  | ✓ |   | ✓ | T5·2 |             | underside pad |
+| D25 · A10 | PA0  | ✓ |   | ✓ | T5·1 |             | underside pad |
+| D26       | PD11 |   |   | ✓ |      |             | |
+| D27       | PG9  |   |   | ✓ |      |             | |
+| D28 · A11 | PA2  | ✓ |   | ✓ | T5·3 |             | underside pad |
+| D29       | PB14 |   |   | ✓ |      | Tx · USART1 | USB D− (AF4) |
+| D30       | PB15 |   |   | ✓ |      | Rx · USART1 | USB D+ (AF4) |
+| D31 · A12 | PC2  | ✓ |   | ✓ |      |             | underside pad |
+| D32 · A13 | PC3  | ✓ |   | ✓ |      |             | underside pad |
+
+**UART pairs (Seed):** USART1 `Rx D14 / Tx D13` (or `Rx D30 / Tx D29` on the USB
+pins) · USART3 `Rx D1 / Tx D2` · UART4 `Rx D11 / Tx D12` · UART5 `Rx D5 / Tx D6`
+· USART2 `Rx D16` (no documented Tx).
+
+### Daisy Patch SM
+
+Patch SM routes most pins through on-board analog circuitry, so their role is
+fixed: `CV In n` are ADC inputs, `CV Out n` are DAC outputs, and the gates are
+one-directional GPIO. Power/audio pins (`A1`, `A4`–`A7`, `A10`, `B1`–`B4`) and the
+USB pins (`A8`/`A9`) are not addressable and are omitted. The `D2`–`D7` pins are
+the SDMMC bus — do not reuse them when building with `-sd`.
+
+| Pin | MCU | ADC | DAC | GPIO | PWM | UART | Function / shared |
+|-----|-----|:---:|:---:|:----:|:---:|------|-------------------|
+| A2  | PA1  | ✓ |   |         | T5·2 | Rx · UART4  | default UART Rx |
+| A3  | PA0  | ✓ |   |         | T5·1 | Tx · UART4  | default UART Tx |
+| B5  | PC14 |   |   | ✓ (out) |      |             | Gate Out 1 |
+| B6  | PC13 |   |   | ✓ (out) |      |             | Gate Out 2 |
+| B7  | PB8  |   |   | ✓       | T4·3 | Rx · UART4  | I²C1 SCL |
+| B8  | PB9  |   |   | ✓       | T4·4 | Tx · UART4  | I²C1 SDA |
+| B9  | PG14 |   |   | ✓ (in)  |      |             | Gate In 2 |
+| B10 | PG13 |   |   | ✓ (in)  |      |             | Gate In 1 |
+| C1  | PA5  |   | ✓ |         |      |             | CV Out 2 |
+| C2  | PA7  | ✓ |   |         | T3·2 |             | CV In 4 |
+| C3  | PA2  | ✓ |   |         | T5·3 |             | CV In 3 |
+| C4  | PA6  | ✓ |   |         | T3·1 |             | CV In 2 |
+| C5  | PA3  | ✓ |   |         | T5·4 |             | CV In 1 |
+| C6  | PB1  | ✓ |   |         | T3·4 |             | CV In 5 |
+| C7  | PC4  | ✓ |   |         |      |             | CV In 6 |
+| C8  | PC0  | ✓ |   |         |      |             | CV In 7 |
+| C9  | PC1  | ✓ |   |         |      |             | CV In 8 |
+| C10 | PA4  |   | ✓ |         |      |             | CV Out 1 |
+| D1  | PB4  |   |   | ✓       | T3·1 |             | SPI2 CS |
+| D2  | PC11 |   |   | ✓       |      | Rx · USART3 | SDMMC D3 |
+| D3  | PC10 |   |   | ✓       |      | Tx · USART3 | SDMMC D2 |
+| D4  | PC9  |   |   | ✓       | T3·4 |             | SDMMC D1 |
+| D5  | PC8  |   |   | ✓       | T3·3 |             | SDMMC D0 |
+| D6  | PC12 |   |   | ✓       |      | Tx · UART5  | SDMMC CK |
+| D7  | PD2  |   |   | ✓       |      | Rx · UART5  | SDMMC CMD |
+| D8  | PC2  | ✓ |   | ✓       |      |             | SPI2 MISO |
+| D9  | PC3  | ✓ |   | ✓       |      |             | SPI2 MOSI |
+| D10 | PD3  |   |   | ✓       |      |             | SPI2 SCK |
+
+The 12 ADC channels are the eight `CV In` pins plus `A2`/`A3` and `D8`/`D9`; the
+two DACs are `C1` / `C10`. **UART pairs (Patch SM):** UART4 `Rx A2 / Tx A3` (or
+`Rx B7 / Tx B8`) · USART3 `Rx D2 / Tx D3` · UART5 `Rx D7 / Tx D6`.
 
 ## Targetting platforms 
 
@@ -126,43 +271,91 @@ You can then choose a more appropriate location (SRAM, QSPI), or put large buffe
 Flash and SRAM are fast, though SRAM option forces you to put buffers to SDRAM (which is slower).
 QSPIFLASH is slower than Flash and SRAM. 
 
-## Architecture files
-
-Specific architecture files have been developed:
-
-- [faust/gui/DaisyControlUI.h](https://github.com/grame-cncm/faust/blob/master-dev/architecture/faust/gui/DaisyControlUI.h): to be used with the DSP `buildUserInterface` method to implement `button`, `checkbox`, `hslider`, `vslider`, `hbargraph`, `vbargraph` controllers, and interpret the specific metadata previously described
-- [faust/midi/daisy-midi.h](https://github.com/grame-cncm/faust/blob/master-dev/architecture/faust/midi/daisy-midi.h): implements a [midi_handler](https://github.com/grame-cncm/faust/blob/master-dev/architecture/faust/midi/midi.h) subclass to decode incoming MIDI events.
-- [faust/midi/daisy-poly.h](https://github.com/grame-cncm/faust/blob/master-dev/architecture/faust/dsp/daisy-poly.h): implements a lightweight polyphonic DSP encapsulation
-
 ## Python parsing 
 
-This tool uses a combination of interactions between the bash script and two python scripts (generate_config.py & faust_daisy_parser.py). 
-The latter is the most important, and will parse JSON representation of you Faust DSP to generate some C++ code to map all UI and metadata informations from Daisy to Faust C++ DSP. 
+This tool uses a combination of interactions between the bash script and a set of python scripts, designed to parse and interpret metadata of your Faust DSP program. 
+The scripts are used to interpret your metadata, set some preprocessor macros to the generated C++ code (in order to enable or disable some parts of the codebase), 
+and generate some code to instanciate controls as static objects (no dynamic allocation). 
 
-## New features (08/03/2026)
+## Soundfiles
 
-Daisy support is being refactored to provide a more efficient and memory deterministic support. The idea is to stick as close as possible to Daisy SDK.
-It was developed with libDaisy version 8.1.0.
-This new development allows the following new features : 
-- Near constant memory footprint (almost no dynamic allocation) 
-- Chip support (Seed, PatchSM) instead of platforms (Pod, Patch, Patch.Init)
-- JSON Configuration files for platforms support (see architecture/daisy/pod.json for example)
-- Access to all analog ADCs and DACs of chips (for controls like knobs, sliders, CV etc)
-- Access to all GPIO for digital control (useful for buttons, leds) 
-- GPIO outputs can be configured with software PWM (dimming led, or additional DAC's)
-- MIDI can be passed through internal chip USB, or through UART pins (pod for example).
-- MIDI monophonic support for CC, Keyon, Keyoff, Key
-- MIDI polyphonic support (algorithms for voice stealing and voice blocking)
-- Program can stand on Flash memory (128kB), SRAM (512kB) or QSPIFLASH (8MB)
-- Large buffers can be placed on SDRAM with `-sdram`. 
-- `-mem-thresh` determines size threshold in bytes above which data is stored on SDRAM  
+The Faust `soundfile` primitive is supported. WAV files referenced by the DSP are
+parsed **at build time** and inlined into a generated `daisy_soundfile.hpp`, so
+there is no runtime file system and no dynamic allocation. Supported formats are
+WAV PCM 16/24/32 bit and IEEE float 32 bit; all data is decoded to `float`.
+
+```faust
+import("stdfaust.lib");
+// 'kick.wav' must sit next to the .dsp file
+sample = soundfile("kick[url:{'kick.wav'}]", 2);
+process = 0,0 : sample : !,_,_;
+```
+
+Multi-part lists are supported too: `soundfile("s[url:{'a.wav';'b.wav'}]", 2)`.
+If a referenced file cannot be found, the build stops with an error.
+
+There are two ways to provide the samples, selected by a CLI option:
+
+### QSPI inlining (default)
+
+The samples are inlined as `const` data. **Build with `-qspi`** so they are placed
+in QSPI flash and read memory-mapped (never copied to RAM); the program and the
+samples are flashed together as a single image, exactly like any other `-qspi`
+program. This is required because audio data does not fit in the 128 KB internal
+flash, and QSPI can only be programmed through the Daisy bootloader (which `-qspi`
+already uses). A very small soundfile may still fit when built in the default
+FLASH mode, but anything sizeable needs `-qspi`.
+
+### SD card at runtime (`-sd`)
+
+With `-sd`, the samples are **not** inlined: the DSP loads `/soundfiles/*.wav`
+from the SD card into SDRAM at startup. This keeps the program small (it can run
+from internal flash) and supports large/long sounds, but requires an SD card
+(see *SD card pins*: only boards exposing the Seed SDMMC pins, e.g. Patch). The
+SDRAM arena defaults to 32 MB (override with `-DFAUST_SD_SOUNDFILE_BYTES`).
+
+> The card **must be formatted FAT32** — libDaisy's FatFS has exFAT disabled, so
+> exFAT cards (the default for ≥ 32 GB cards) will fail to mount. The uploader
+> reports the FatFS error code on failure, e.g. `ERR nomount=13` means
+> `FR_NO_FILESYSTEM` (wrong format), `=3` means `FR_NOT_READY` (card not detected).
+
+Upload the WAV files referenced by a DSP to the card with:
+
+```
+faust2daisy -upload-sd my.dsp
+```
+
+This temporarily flashes a small uploader firmware, then streams the files over
+USB-serial into a `/soundfiles` folder (clearing that folder first; nothing else
+on the card is touched). Then build and flash the DSP itself with `-sd`:
+
+```
+faust2daisy -sd my.dsp
+```
+
+> Note: the architecture files and tools must be **installed** (so faust2daisy
+> picks them up) — building from the repo alone is not enough, faust2daisy reads
+> the installed copies under `faust --archdir`.
+
+## PWM 
+
+This tool allows to output bargraph values to hardware PWM outputs. 
+To do so, simply add the metadata `vbargraph("outvalue[pwm:D1]", 0, 1)`. All PWM available pins are referenced inside *daisy_pwm_pin.py*, inside Faust daisy architecture folder.
+The PWM output is clocked around 29Khz, with a resolution of 13 bits (8192 steps). This is a compromise between the exigence to stay above audible frequencies (prevent mechanical noise in some specific hardware) and keep a high precision.
+
+## Serial 
+
+Serial communication is available in the same way as other controls. It can be used to receive or to transmit control data. 
+- Receive : `hslider("freq[rx:D1], 100, 20, 1000, 0.1)`  
+- Transmit : `vbargraph("outvalue[tx:D2], 0, 1)`
+
+Messages are formatted like this : `[freq <value>]` where *<value>* is a 4 bytes float, passed as binary representation. 
+Squared brackets are used to indicate start and end of a control message. 
 
 ## Possible future developments 
 
-- Daisy Patch full support (external Audio codec)
-- Daisy Patch SM support 
-- MIDI external USB peripheral support (Seed)
+- MIDI custom USB peripheral support (Seed)
 - OLED screens (Patch, custom platforms)
 - DMA for DACs / ADCs : Could provide extended audio inputs & outputs (16 bit for ADC, 12 bits for DAC) or higher time precision for controls 
 - Multiplexer for ADCs / DACs (to use with 4051's for example)
-- I2C communication (audio and/or control)
+- Serial communication for control

--- a/architecture/daisy/changelog.md
+++ b/architecture/daisy/changelog.md
@@ -1,0 +1,37 @@
+# 03/07/2026 
+
+## Features 
+* Soundfile primitive support: WAV files (PCM 16/24/32 bit, float 32 bit). Two modes:
+  * default (`-qspi`): parsed at build time and inlined into QSPI flash, no runtime
+    file I/O or dynamic allocation.
+  * `-sd`: loaded from the SD card (`/soundfiles`) into SDRAM at startup. Files are
+    uploaded with `faust2daisy -upload-sd` (temporary CDC uploader firmware).
+  * Daisy Patch supported 
+  * Daisy PatchSM supported 
+ * Serial control through UART pins (both RX and TX are implemented), passing messages in the format "amp 0.72551" 
+ * Hardware PWM output (defaults to 29Khz) wiht `pwm:D1`. 
+ * PIN conflict checking on parser side (for example using `[adc:A0]` and `[gpio:D15]` on daisy seed won't work, since it would conflict, same pin)
+
+## Fix 
+* Midi input was not initialized 
+* Python parser script DAC interpretation was wrong 
+* MIDI CC was not working properly for checkboxes and buttons. Now it is working as Faust documentation says : returns 1 if CC is 127, returns 0 if CC is 0
+* Python parser crashed on a DSP with UI controls when no configuration file was provided
+* Fixed Patch screen bar ordering 
+
+# 08/03/2026
+
+Daisy support is being refactored to provide a more efficient and memory deterministic support. The idea is to stick as close as possible to Daisy SDK. It was developed with libDaisy version 8.1.0. This new development allows the following new features :
+
+* Near constant memory footprint (almost no dynamic allocation)
+* Chip support (Seed, PatchSM) instead of platforms (Pod, Patch, Patch.Init)
+* JSON Configuration files for platforms support (see architecture/daisy/pod.json for example)
+* Access to all analog ADCs and DACs of chips (for controls like knobs, sliders, CV etc)
+* Access to all GPIO for digital control (useful for buttons, leds)
+* GPIO outputs can be configured with software PWM (dimming led, or additional DAC's)
+* MIDI can be passed through internal chip USB, or through UART pins (pod for example).
+* MIDI monophonic support for CC, Keyon, Keyoff, Key
+* MIDI polyphonic support (algorithms for voice stealing and voice blocking)
+* Program can stand on Flash memory (128kB), SRAM (512kB) or QSPIFLASH (8MB)
+* Large buffers can be placed on SDRAM with -sdram.
+* -mem-thresh determines size threshold in bytes above which data is stored on SDRAM

--- a/architecture/daisy/daisy_pins.py
+++ b/architecture/daisy/daisy_pins.py
@@ -1,0 +1,45 @@
+# daisy_pins.py
+#
+# Daisy pin label -> physical STM32 pin, for cross-feature pin-conflict checking.
+#
+# The point is to resolve ALIASES to the same physical pin so a conflict guard
+# catches e.g. Seed [adc:A0] vs [pwm:D15] (both PC0), or Seed [dac:A7] vs
+# [adc:D22] (both PA5). Verified against libDaisy/src/daisy_seed.h and
+# daisy_patch_sm.h. Physical pins use a "P<port><idx>" string (e.g. "PB12").
+#
+# Patch SM PORTX pins (power / GND / audio, all Pin(PORTX,0)) are omitted: they
+# are not usable GPIO and share a placeholder address that would false-collide.
+
+# Daisy Seed: D0..D32 physical, plus the A0..A13 analog aliases (A0 == D15, ...).
+_SEED = {
+    "D0": "PB12",  "D1": "PC11", "D2": "PC10", "D3": "PC9",  "D4": "PC8",
+    "D5": "PD2",   "D6": "PC12", "D7": "PG10", "D8": "PG11", "D9": "PB4",
+    "D10": "PB5",  "D11": "PB8", "D12": "PB9", "D13": "PB6", "D14": "PB7",
+    "D15": "PC0",  "D16": "PA3", "D17": "PB1", "D18": "PA7", "D19": "PA6",
+    "D20": "PC1",  "D21": "PC4", "D22": "PA5", "D23": "PA4", "D24": "PA1",
+    "D25": "PA0",  "D26": "PD11","D27": "PG9", "D28": "PA2", "D29": "PB14",
+    "D30": "PB15", "D31": "PC2", "D32": "PC3",
+    # Analog aliases (same physical pin as the D-name)
+    "A0": "PC0",  "A1": "PA3",  "A2": "PB1",  "A3": "PA7",  "A4": "PA6",
+    "A5": "PC1",  "A6": "PC4",  "A7": "PA5",  "A8": "PA4",  "A9": "PA1",
+    "A10": "PA0", "A11": "PA2", "A12": "PC2", "A13": "PC3",
+}
+
+# Daisy Patch SM (PORTX power/audio pins omitted).
+_PATCHSM = {
+    "A2": "PA1",  "A3": "PA0",  "A8": "PB14", "A9": "PB15",
+    "B5": "PC14", "B6": "PC13", "B7": "PB8",  "B8": "PB9",
+    "B9": "PG14", "B10": "PG13",
+    "C1": "PA5",  "C2": "PA7",  "C3": "PA2",  "C4": "PA6",  "C5": "PA3",
+    "C6": "PB1",  "C7": "PC4",  "C8": "PC0",  "C9": "PC1",  "C10": "PA4",
+    "D1": "PB4",  "D2": "PC11", "D3": "PC10", "D4": "PC9",  "D5": "PC8",
+    "D6": "PC12", "D7": "PD2",  "D8": "PC2",  "D9": "PC3",  "D10": "PD3",
+}
+
+_TABLES = {"seed": _SEED, "patchsm": _PATCHSM}
+
+
+def physical(chip, label):
+    """Canonical physical pin ('PB12'...) for a board pin label, or None if the
+    label is unknown (the caller can then fall back to comparing the label)."""
+    return _TABLES.get(chip, {}).get(str(label))

--- a/architecture/daisy/daisy_pwm_pin.py
+++ b/architecture/daisy/daisy_pwm_pin.py
@@ -1,0 +1,116 @@
+# daisy_pwm_pin.py
+#
+# Daisy pin -> hardware-PWM (timer channel) resolution for faust2daisy.
+#
+# Hardware PWM on the Daisy uses timers TIM3, TIM4, TIM5 (libDaisy PWMHandle),
+# 4 channels each. A pin is "PWM-capable" iff its AF2 alternate function is a
+# TIM3/4/5 channel -- fixed silicon, identical on Seed and Patch SM, only the
+# pin labels differ. The alternate function is ALWAYS AF2 and is applied by
+# libDaisy internally, so it is not stored here.
+#
+# Sources (not guessed):
+#   * Seed pin/timer/channel table : libDaisy/src/per/pwm.h  (documents the
+#     Daisy Seed D-names per channel) + STM32H7 AF2 table.
+#   * Patch SM physical pins        : libDaisy/src/daisy_patch_sm.h, cross-
+#     referenced with the same TIM3/4/5 AF2 channel pins.
+#
+# Usage: the parser resolves [pwm:<pin>] to {timer, channel} and emits a
+#   PWMHandle::Config with .periph = PWMHandle::Config::Peripheral::TIM_x and
+#   sets the matching channel's Channel::Config.pin to the Daisy pin constant.
+#
+# IMPORTANT constraints for the caller / parser:
+#   * One (timer, channel) drives ONE pin -- reject two PWM controls that land
+#     on the same timer+channel.
+#   * All channels of a timer SHARE its prescaler/period (=> same PWM frequency
+#     and resolution). Independent frequencies require different timers.
+#   * Every pin here is shared with another function (noted in 'note'); the
+#     parser should also reject a pin already used by ADC/DAC/serial/I2C/etc.
+#   * TIM2 (System us-timer) and TIM6 (DAC in DMA mode) are used elsewhere;
+#     TIM3/4/5 are otherwise free in faust2daisy.
+
+
+def _e(timer, channel, phys, note=""):
+    """One PWM resolution entry.
+
+    timer   : "TIM_3" | "TIM_4" | "TIM_5"  (PWMHandle::Config::Peripheral::TIM_x)
+    channel : 1..4                          (TIM channel on that timer)
+    phys    : physical MCU pin, for reference
+    note    : the pin's other (shared) function
+    """
+    return {"timer": timer, "channel": channel, "phys": phys, "note": note}
+
+
+# ----------------------------------------------------------------------------
+# Daisy Seed (daisy::seed::Dx). From pwm.h's documented channel pins.
+# Several channels expose two pins; pick whichever is free.
+#   TIM3: CH1 D19|D9   CH2 D18|D10   CH3 D4    CH4 D17|D3
+#   TIM4: CH1 D13      CH2 D14       CH3 D11   CH4 D12
+#   TIM5: CH1 D25      CH2 D24       CH3 D28   CH4 D16   (D16/D24/D25/D28 are the
+#         analog/SAI2 pins; D24/D25/D28 are underside pads)
+# ----------------------------------------------------------------------------
+SEED_PWM = {
+    "D3":  _e("TIM_3", 4, "PC9"),
+    "D4":  _e("TIM_3", 3, "PC8"),
+    "D9":  _e("TIM_3", 1, "PB4", "SPI1 MISO"),
+    "D10": _e("TIM_3", 2, "PB5", "SPI1 MOSI"),
+    "D11": _e("TIM_4", 3, "PB8", "I2C1 SCL"),
+    "D12": _e("TIM_4", 4, "PB9", "I2C1 SDA"),
+    "D13": _e("TIM_4", 1, "PB6", "USART1 TX"),
+    "D14": _e("TIM_4", 2, "PB7", "USART1 RX"),
+    "D16": _e("TIM_5", 4, "PA3", "ADC / USART2 RX"),
+    "D17": _e("TIM_3", 4, "PB1", "ADC"),
+    "D18": _e("TIM_3", 2, "PA7", "ADC / SPI1 MOSI"),
+    "D19": _e("TIM_3", 1, "PA6", "ADC / SPI1 MISO"),
+    "D24": _e("TIM_5", 2, "PA1", "underside pad (SAI2 / UART4)"),
+    "D25": _e("TIM_5", 1, "PA0", "underside pad (SAI2 / UART4)"),
+    "D28": _e("TIM_5", 3, "PA2", "underside pad (SAI2 / USART2)"),
+}
+
+# ----------------------------------------------------------------------------
+# Daisy Patch SM (daisy::patch_sm::Ax/Bx/Cx/Dx). Every pin is shared.
+#   TIM3: CH1 C4|D1   CH2 C2    CH3 D5    CH4 C6|D4
+#   TIM4: CH1 -       CH2 -     CH3 B7    CH4 B8     (PB6/PB7 not broken out)
+#   TIM5: CH1 A3      CH2 A2    CH3 C3    CH4 C5
+# ----------------------------------------------------------------------------
+PATCHSM_PWM = {
+    "A2": _e("TIM_5", 2, "PA1", "UART Rx"),
+    "A3": _e("TIM_5", 1, "PA0", "UART Tx"),
+    "B7": _e("TIM_4", 3, "PB8", "I2C1 SCL"),
+    "B8": _e("TIM_4", 4, "PB9", "I2C1 SDA"),
+    "C2": _e("TIM_3", 2, "PA7", "CV In 4"),
+    "C3": _e("TIM_5", 3, "PA2", "CV In 3"),
+    "C4": _e("TIM_3", 1, "PA6", "CV In 2"),
+    "C5": _e("TIM_5", 4, "PA3", "CV In 1"),
+    "C6": _e("TIM_3", 4, "PB1", "CV In 5"),
+    "D1": _e("TIM_3", 1, "PB4", "SPI2 CS"),
+    "D4": _e("TIM_3", 4, "PC9", "SDMMC D1"),
+    "D5": _e("TIM_3", 3, "PC8", "SDMMC D0"),
+}
+
+_TABLES = {
+    "seed":    SEED_PWM,
+    "patchsm": PATCHSM_PWM,
+}
+
+
+def resolve_pwm(chip, pin_label):
+    """Resolve (chip, pin_label) to a PWM entry {timer, channel, phys, note}.
+
+    Raises ValueError listing the valid pins on failure so the parser can
+    surface a clear message.
+    """
+    if chip not in _TABLES:
+        raise ValueError(
+            "PWM is only supported on 'seed' and 'patchsm' (got %r)" % chip)
+    table = _TABLES[chip]
+    if pin_label not in table:
+        valid = ", ".join(sorted(table.keys()))
+        raise ValueError(
+            "%s is not a hardware-PWM pin on %s. Valid PWM pins: %s"
+            % (pin_label, chip, valid))
+    return table[pin_label]
+
+
+def timer_channel(entry):
+    """(timer, channel) tuple -- handy for grouping/uniqueness checks."""
+    return (entry["timer"], entry["channel"])

--- a/architecture/daisy/daisy_sd_soundfile.hpp
+++ b/architecture/daisy/daisy_sd_soundfile.hpp
@@ -1,0 +1,459 @@
+/************************************************************************
+ FAUST Architecture File - Daisy runtime SD card soundfile loader
+ Copyright (C) 2020-2026 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+/*
+ * Runtime soundfile support reading WAV files from the SD card (folder
+ * "/soundfiles") into SDRAM at startup, used with `faust2daisy -sd`. This is
+ * the alternative to the compile-time QSPI inlining (daisy_soundfile.hpp) :
+ * the WAVs are uploaded once with `faust2daisy -upload-sd`, then loaded here.
+ *
+ * Samples are decoded to float and stored non-interleaved in a fixed SDRAM
+ * arena (bump-allocated, no heap). Supported WAV formats : PCM 16/24/32 bit
+ * and IEEE float 32 bit.
+ */
+
+#ifndef __daisy_sd_soundfile__
+#define __daisy_sd_soundfile__
+
+#include <cstdint>
+#include <cstring>
+#include <cstdio>
+
+#include "fatfs.h"
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif
+
+// Size of the SDRAM arena holding all decoded samples + metadata. Override
+// with -DFAUST_SD_SOUNDFILE_BYTES if you need more/less (SDRAM is 64 MB).
+#ifndef FAUST_SD_SOUNDFILE_BYTES
+#define FAUST_SD_SOUNDFILE_BYTES (32 * 1024 * 1024)
+#endif
+
+// These mirror the constants in architecture/faust/gui/Soundfile.h and only
+// describe the *empty/unloaded* parts of a Soundfile. They are NOT the audio
+// driver settings: the DSP sample rate and block size come from MY_SAMPLE_RATE
+// and MY_BUFFER_SIZE (set by faust2daisy -sr / -bs) and are used in main().
+#define MAX_SOUNDFILE_PARTS 256  // a Soundfile always has 256 part slots
+#define MAX_CHAN 64              // max channels addressable by the DSP
+#define BUFFER_SIZE 1024         // frame count reported for an empty/silent part
+#define SAMPLE_RATE 44100        // sample rate reported for an empty/silent part
+#define SD_MAX_SOUNDFILES 16  // distinct soundfile URLs cached
+#define SD_MAX_PARTS 8        // files per soundfile URL
+
+// Same field layout as architecture/faust/gui/Soundfile.h.
+struct Soundfile {
+    void* fBuffers;
+    int* fLength;
+    int* fSR;
+    int* fOffset;
+    int fChannels;
+    int fParts;
+    bool fIsDouble;
+} __attribute__((packed));
+
+// ─── SDRAM bump arena (no heap) ───────────────────────────────────────
+static uint8_t DSY_SDRAM_BSS faust_sd_arena[FAUST_SD_SOUNDFILE_BYTES];
+static size_t faust_sd_arena_off = 0;
+
+// Diagnostics : total frames successfully loaded across all soundfiles, and a
+// pointer to the most recently built soundfile (for the optional serial dump).
+static uint32_t  sd_total_frames = 0;
+static Soundfile* sd_debug_last  = nullptr;
+
+static void* sd_alloc(size_t bytes)
+{
+    faust_sd_arena_off = (faust_sd_arena_off + 3u) & ~size_t(3);
+    if (faust_sd_arena_off + bytes > sizeof(faust_sd_arena)) return nullptr;
+    void* p = faust_sd_arena + faust_sd_arena_off;
+    faust_sd_arena_off += bytes;
+    return p;
+}
+
+// ─── FatFS / SD state ─────────────────────────────────────────────────
+static daisy::SdmmcHandler   faust_sdmmc;
+static daisy::FatFSInterface faust_fsi;
+static bool                  faust_sd_mounted = false;
+
+// ─── default (silent) soundfile ───────────────────────────────────────
+static float     sd_empty_zero[BUFFER_SIZE];
+static float*    sd_empty_bufs[MAX_CHAN];
+static int       sd_empty_len[MAX_SOUNDFILE_PARTS];
+static int       sd_empty_sr[MAX_SOUNDFILE_PARTS];
+static int       sd_empty_off[MAX_SOUNDFILE_PARTS];
+static Soundfile sd_empty_soundfile;
+static Soundfile* defaultsound = nullptr;
+
+// SD read buffer. MUST be static (AXI SRAM), not on the stack: on the STM32H7
+// the stack is in DTCMRAM, which the SDMMC IDMA cannot access -> reads fail.
+// 32-byte aligned for the D-cache invalidate in sd_diskio.c.
+static uint8_t __attribute__((aligned(32))) sd_read_buf[4096];
+
+// File object. Also MUST be static (AXI SRAM): with _FS_TINY=0 each FIL holds
+// its own sector buffer, into which f_read DMAs partial-sector data; on the
+// stack (DTCMRAM) that DMA fails. Used sequentially (open/close one at a time).
+static FIL sd_fil;
+
+// ─── WAV parsing ──────────────────────────────────────────────────────
+struct sd_wav_info {
+    uint16_t fmt;
+    uint16_t channels;
+    uint32_t sr;
+    uint16_t bits;
+    uint32_t data_off;
+    uint32_t data_bytes;
+    uint32_t frames;
+};
+
+static inline uint32_t sd_u32(const uint8_t* p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+static inline uint16_t sd_u16(const uint8_t* p)
+{
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+static bool sd_parse_header(FIL* fil, sd_wav_info* w)
+{
+    uint8_t hdr[12];
+    UINT    br = 0;
+    if (f_read(fil, hdr, 12, &br) != FR_OK || br != 12) return false;
+    if (memcmp(hdr, "RIFF", 4) != 0 || memcmp(hdr + 8, "WAVE", 4) != 0) return false;
+
+    bool got_fmt = false, got_data = false;
+    while (!got_data) {
+        uint8_t chunk[8];
+        if (f_read(fil, chunk, 8, &br) != FR_OK || br != 8) break;
+        uint32_t csize = sd_u32(chunk + 4);
+
+        if (memcmp(chunk, "fmt ", 4) == 0) {
+            uint8_t fmt[40] = {0};
+            UINT    toread  = (csize < 40) ? csize : 40;
+            f_read(fil, fmt, toread, &br);
+            if (csize > toread) f_lseek(fil, f_tell(fil) + (csize - toread));
+            w->fmt      = sd_u16(fmt);
+            w->channels = sd_u16(fmt + 2);
+            w->sr       = sd_u32(fmt + 4);
+            w->bits     = sd_u16(fmt + 14);
+            if (w->fmt == 0xFFFE && csize >= 26) w->fmt = sd_u16(fmt + 24); // extensible subformat
+            got_fmt = true;
+        } else if (memcmp(chunk, "data", 4) == 0) {
+            if (!got_fmt) return false;
+            w->data_off   = f_tell(fil);
+            w->data_bytes = csize;
+            got_data      = true;
+        } else {
+            f_lseek(fil, f_tell(fil) + csize + (csize & 1)); // skip (word-aligned)
+        }
+    }
+    if (!got_data || w->channels == 0 || w->bits == 0) return false;
+    // Only PCM 16/24/32 and float32 are supported.
+    if (w->fmt == 0x0003) {
+        if (w->bits != 32) return false;
+    } else if (w->fmt == 0x0001) {
+        if (w->bits != 16 && w->bits != 24 && w->bits != 32) return false;
+    } else {
+        return false;
+    }
+    w->frames = w->data_bytes / (w->channels * (w->bits / 8u));
+    return true;
+}
+
+static float sd_decode(const uint8_t* p, uint16_t fmt, uint16_t bits)
+{
+    if (fmt == 0x0003) {
+        float v;
+        memcpy(&v, p, 4);
+        return v;
+    }
+    if (bits == 16) {
+        int16_t s;
+        memcpy(&s, p, 2);
+        return (float)s * (1.0f / 32768.0f);
+    }
+    if (bits == 24) {
+        int32_t s = (int32_t)p[0] | ((int32_t)p[1] << 8) | ((int32_t)p[2] << 16);
+        if (s & 0x00800000) s |= 0xFF000000;
+        return (float)s * (1.0f / 8388608.0f);
+    }
+    if (bits == 32) {
+        int32_t s;
+        memcpy(&s, p, 4);
+        return (float)s * (1.0f / 2147483648.0f);
+    }
+    return 0.0f;
+}
+
+// Return the file name without any directory part. The URL may hold an
+// absolute host path (e.g. "/home/me/sounds/son.wav"), but the uploader stores
+// files in /soundfiles by their base name only.
+static const char* sd_basename(const char* p)
+{
+    const char* base = p;
+    for (const char* c = p; *c; c++) {
+        if (*c == '/' || *c == '\\') base = c + 1;
+    }
+    return base;
+}
+
+// Extract file names from a Faust soundfile URL like "{'a.wav';'b.wav'}".
+static int sd_parse_url(const char* url, char names[][128], int maxn)
+{
+    int         count = 0;
+    const char* p     = url;
+    while (*p && count < maxn) {
+        if (*p == '\'') {
+            p++;
+            int k = 0;
+            while (*p && *p != '\'' && k < 127) names[count][k++] = *p++;
+            names[count][k] = 0;
+            if (*p == '\'') p++;
+            count++;
+        } else {
+            p++;
+        }
+    }
+    if (count == 0) {
+        // No quotes : split on ';' (the soundfile list separator), trimming
+        // any surrounding braces/spaces.
+        const char* s = url;
+        while (*s && count < maxn) {
+            while (*s == '{' || *s == '}' || *s == ' ') s++;
+            int k = 0;
+            while (*s && *s != ';' && *s != '}' && k < 127) names[count][k++] = *s++;
+            while (k > 0 && names[count][k - 1] == ' ') k--; // trim trailing spaces
+            names[count][k] = 0;
+            if (k > 0) count++;
+            while (*s && *s != ';') s++;
+            if (*s == ';') s++;
+        }
+    }
+    return count;
+}
+
+// Load all parts of a soundfile from /soundfiles into the SDRAM arena.
+static Soundfile* sd_build(char names[][128], int nfiles)
+{
+    sd_wav_info infos[SD_MAX_PARTS];
+    int         cur_chan   = 1;
+    uint32_t    total_real = 0;
+    int         nparts     = 0;
+
+    for (int i = 0; i < nfiles && i < SD_MAX_PARTS; i++) {
+        FIL& fil = sd_fil; // shared static FIL (AXI SRAM)
+        char path[160];
+        snprintf(path, sizeof(path), "soundfiles/%s", sd_basename(names[i]));
+        if (f_open(&fil, path, FA_READ) != FR_OK) return nullptr;
+        bool ok = sd_parse_header(&fil, &infos[i]);
+        f_close(&fil);
+        if (!ok) return nullptr;
+        if ((int)infos[i].channels > cur_chan) cur_chan = infos[i].channels;
+        total_real += infos[i].frames;
+        nparts++;
+    }
+    if (nparts == 0) return nullptr;
+    if (cur_chan > MAX_CHAN) cur_chan = MAX_CHAN;
+
+    // Concatenated per-channel buffers + one trailing silent block (for the
+    // empty parts). Zeroed so gaps / mono-in-stereo read as silence.
+    uint32_t total = total_real + BUFFER_SIZE;
+    float**  bufs  = (float**)sd_alloc(sizeof(float*) * MAX_CHAN);
+    if (!bufs) return nullptr;
+    for (int c = 0; c < cur_chan; c++) {
+        bufs[c] = (float*)sd_alloc(sizeof(float) * total);
+        if (!bufs[c]) return nullptr;
+        memset(bufs[c], 0, sizeof(float) * total);
+    }
+
+    int* length = (int*)sd_alloc(sizeof(int) * MAX_SOUNDFILE_PARTS);
+    int* sr     = (int*)sd_alloc(sizeof(int) * MAX_SOUNDFILE_PARTS);
+    int* offset = (int*)sd_alloc(sizeof(int) * MAX_SOUNDFILE_PARTS);
+    if (!length || !sr || !offset) return nullptr;
+
+    uint32_t off = 0;
+    for (int i = 0; i < nparts; i++) {
+        FIL& fil = sd_fil; // shared static FIL (AXI SRAM)
+        char path[160];
+        snprintf(path, sizeof(path), "soundfiles/%s", sd_basename(names[i]));
+        if (f_open(&fil, path, FA_READ) != FR_OK) return nullptr;
+        uint16_t fc          = infos[i].channels;
+        uint16_t bits        = infos[i].bits;
+        uint32_t bps         = bits / 8u;
+        uint32_t frame_bytes = bps * fc;
+
+        // Read SECTOR-ALIGNED full windows. The WAV data rarely starts on a
+        // sector boundary (header chunks before 'data'), and handing FatFS an
+        // unaligned file position makes it DMA into the read buffer at an
+        // unaligned offset -> libDaisy's 32-byte-rounded cache maintenance then
+        // corrupts samples. By seeking to the sector boundary and reading whole
+        // windows, the DMA target is always the 32-byte-aligned buffer start.
+        // 'skip' drops the head bytes of the first window; 'carry' rebuilds a
+        // frame split across two windows.
+        uint32_t fpos      = infos[i].data_off & ~((uint32_t)511);
+        uint32_t skip      = infos[i].data_off - fpos;
+        uint32_t data_left = infos[i].frames * frame_bytes;
+        f_lseek(&fil, fpos);
+
+        uint8_t  carry[256]; // one frame max (MAX_CHAN * 4 bytes)
+        uint32_t carry_n = 0;
+        uint32_t fidx    = 0;
+        while (data_left > 0) {
+            UINT br = 0;
+            f_read(&fil, sd_read_buf, sizeof(sd_read_buf), &br);
+            if (br == 0) break; // unexpected EOF
+            const uint8_t* p     = sd_read_buf + skip;
+            uint32_t       avail = (br > skip) ? (br - skip) : 0;
+            if (avail > data_left) avail = data_left; // ignore bytes past the data chunk
+            data_left -= avail;
+            skip = 0;
+
+            uint32_t pi = 0;
+            // Finish a frame carried over from the previous window.
+            if (carry_n > 0) {
+                while (carry_n < frame_bytes && pi < avail) carry[carry_n++] = p[pi++];
+                if (carry_n == frame_bytes) {
+                    for (uint16_t c = 0; c < fc && c < cur_chan; c++)
+                        bufs[c][off + fidx] = sd_decode(carry + c * bps, infos[i].fmt, bits);
+                    fidx++;
+                    carry_n = 0;
+                }
+            }
+            // Whole frames in this window.
+            uint32_t full = (avail - pi) / frame_bytes;
+            for (uint32_t f = 0; f < full; f++) {
+                const uint8_t* fp = p + pi + f * frame_bytes;
+                for (uint16_t c = 0; c < fc && c < cur_chan; c++)
+                    bufs[c][off + fidx + f] = sd_decode(fp + c * bps, infos[i].fmt, bits);
+            }
+            fidx += full;
+            pi += full * frame_bytes;
+            // Carry the trailing partial frame to the next window.
+            while (pi < avail && carry_n < frame_bytes) carry[carry_n++] = p[pi++];
+        }
+        f_close(&fil);
+
+        length[i] = (int)infos[i].frames;
+        sr[i]     = (int)infos[i].sr;
+        offset[i] = (int)off;
+        off += infos[i].frames;
+    }
+
+    // Empty parts all point to the shared trailing silent block.
+    for (int p = nparts; p < MAX_SOUNDFILE_PARTS; p++) {
+        length[p] = BUFFER_SIZE;
+        sr[p]     = SAMPLE_RATE;
+        offset[p] = (int)total_real;
+    }
+    // Alias channels up to MAX_CHAN (mirrors Soundfile::shareBuffers).
+    for (int c = cur_chan; c < MAX_CHAN; c++) bufs[c] = bufs[c % cur_chan];
+
+    Soundfile* sf = (Soundfile*)sd_alloc(sizeof(Soundfile));
+    if (!sf) return nullptr;
+    sf->fBuffers  = (void*)bufs;
+    sf->fLength   = length;
+    sf->fSR       = sr;
+    sf->fOffset   = offset;
+    sf->fChannels = cur_chan;
+    sf->fParts    = nparts;
+    sf->fIsDouble = false;
+    sd_total_frames += total_real;
+    sd_debug_last = sf;
+    return sf;
+}
+
+// ─── URL -> Soundfile cache ───────────────────────────────────────────
+struct sd_cache_entry {
+    char       url[160];
+    Soundfile* sf;
+};
+static sd_cache_entry sd_cache[SD_MAX_SOUNDFILES];
+static int            sd_cache_n = 0;
+
+// Called by DaisyControlUI::addSoundfile (once per soundfile widget).
+Soundfile* sd_load_soundfile(const char* url)
+{
+    if (!faust_sd_mounted) return defaultsound;
+    for (int i = 0; i < sd_cache_n; i++) {
+        if (strcmp(sd_cache[i].url, url) == 0) return sd_cache[i].sf;
+    }
+    char names[SD_MAX_PARTS][128];
+    int  n  = sd_parse_url(url, names, SD_MAX_PARTS);
+    Soundfile* sf = sd_build(names, n);
+    if (!sf) sf = defaultsound;
+    if (sd_cache_n < SD_MAX_SOUNDFILES) {
+        strncpy(sd_cache[sd_cache_n].url, url, 159);
+        sd_cache[sd_cache_n].url[159] = 0;
+        sd_cache[sd_cache_n].sf       = sf;
+        sd_cache_n++;
+    }
+    return sf;
+}
+
+// Mount the SD card and prepare the default soundfile. Call once from main()
+// before DSP.init()/buildUserInterface().
+void sd_soundfile_init()
+{
+    memset(sd_empty_zero, 0, sizeof(sd_empty_zero));
+    for (int c = 0; c < MAX_CHAN; c++) sd_empty_bufs[c] = sd_empty_zero;
+    for (int p = 0; p < MAX_SOUNDFILE_PARTS; p++) {
+        sd_empty_len[p] = BUFFER_SIZE;
+        sd_empty_sr[p]  = SAMPLE_RATE;
+        sd_empty_off[p] = 0;
+    }
+    sd_empty_soundfile.fBuffers  = (void*)sd_empty_bufs;
+    sd_empty_soundfile.fLength   = sd_empty_len;
+    sd_empty_soundfile.fSR       = sd_empty_sr;
+    sd_empty_soundfile.fOffset   = sd_empty_off;
+    sd_empty_soundfile.fChannels = 1;
+    sd_empty_soundfile.fParts    = 0;
+    sd_empty_soundfile.fIsDouble = false;
+    defaultsound                 = &sd_empty_soundfile;
+
+    faust_sd_arena_off = 0;
+
+    // Mount the SD card, trying a ladder of clock speeds and bus widths
+    // (fastest first). Boards with longer SD traces, e.g. the Daisy Patch, often
+    // need a slower clock and/or 1-bit mode (FR_DISK_ERR at 25 MHz). The card
+    // must be formatted FAT32 (libDaisy's FatFS has exFAT disabled).
+    daisy::FatFSInterface::Config fcfg;
+    fcfg.media = daisy::FatFSInterface::Config::MEDIA_SD;
+    const daisy::SdmmcHandler::Speed speeds[] = {
+        daisy::SdmmcHandler::Speed::STANDARD,
+        daisy::SdmmcHandler::Speed::MEDIUM_SLOW,
+        daisy::SdmmcHandler::Speed::SLOW};
+    const daisy::SdmmcHandler::BusWidth widths[] = {
+        daisy::SdmmcHandler::BusWidth::BITS_4,
+        daisy::SdmmcHandler::BusWidth::BITS_1};
+    FRESULT res = FR_NOT_READY;
+    bool done = false;
+    for (unsigned si = 0; si < 3 && !done; si++) {
+        for (unsigned wi = 0; wi < 2 && !done; wi++) {
+            daisy::SdmmcHandler::Config cfg;
+            cfg.Defaults();
+            cfg.speed           = speeds[si];
+            cfg.width           = widths[wi];
+            cfg.clock_powersave = false;
+            faust_sdmmc.Init(cfg);
+            faust_fsi.Init(fcfg);
+            res = f_mount(&faust_fsi.GetSDFileSystem(), "/", 1);
+            if (res == FR_OK) done = true;
+        }
+    }
+    faust_sd_mounted = (res == FR_OK);
+}
+
+#endif // __daisy_sd_soundfile__

--- a/architecture/daisy/daisy_soundfile_gen.py
+++ b/architecture/daisy/daisy_soundfile_gen.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+# ---------------------------------------------------------------------
+# faust2daisy : compile-time Soundfile support
+#
+# This module parses the WAV files referenced by a Faust DSP (through the
+# "soundfile" primitive) and generates a self-contained C++ header
+# (daisy_soundfile.hpp) in which all the audio data is inlined as
+# 'const float' arrays. No dependency on libsndfile, no runtime file I/O
+# and no dynamic allocation : everything is resolved at build time.
+#
+# The generated header provides :
+#   - a minimal 'Soundfile' struct (same field layout as
+#     architecture/faust/gui/Soundfile.h) ;
+#   - one prebuilt 'Soundfile' instance per distinct soundfile URL ;
+#   - a 'defaultsound' empty soundfile (used by the DSP before
+#     buildUserInterface, and as a fallback) ;
+#   - 'daisy_lookup_soundfile(url)' used by DaisyControlUI::addSoundfile.
+#
+# The big sample buffers are emitted as 'const' so that, in QSPI flash
+# mode (-qspi), they live in QSPI and are read directly (memory-mapped),
+# without being copied into RAM/SDRAM.
+#
+# Supported WAV formats : PCM 16/24/32 bit and IEEE float 32 bit.
+# ---------------------------------------------------------------------
+
+import os
+import re
+import sys
+import struct
+from array import array
+
+# Mirror of the constants used in architecture/faust/gui/Soundfile.h.
+# The Faust C++ backend clamps the (signal) "part" index to
+# [0, MAX_SOUNDFILE_PARTS-1], so these arrays must always have 256 slots.
+MAX_SOUNDFILE_PARTS = 256
+MAX_CHAN = 64
+BUFFER_SIZE = 1024      # length of an empty/silent part
+SAMPLE_RATE = 44100     # sample rate reported for empty parts
+
+# WAV format tags
+WAVE_FORMAT_PCM = 0x0001
+WAVE_FORMAT_FLOAT = 0x0003
+WAVE_FORMAT_EXTENSIBLE = 0xFFFE
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+# ---------------------------------------------------------------------
+# WAV parsing (no external dependency)
+# ---------------------------------------------------------------------
+
+class WavError(Exception):
+    pass
+
+
+def parse_wav(path):
+    """Parse a WAV file and return a dict :
+        { 'channels', 'sample_rate', 'bits', 'frames', 'data' }
+    where 'data' is a list of per-channel lists of floats in [-1, 1].
+    """
+    with open(path, 'rb') as f:
+        raw = f.read()
+
+    if len(raw) < 12 or raw[0:4] != b'RIFF' or raw[8:12] != b'WAVE':
+        raise WavError("'%s' is not a valid RIFF/WAVE file" % path)
+
+    fmt_tag = None
+    num_channels = None
+    sample_rate = None
+    bits = None
+    data_bytes = None
+
+    pos = 12
+    n = len(raw)
+    while pos + 8 <= n:
+        chunk_id = raw[pos:pos + 4]
+        chunk_size = struct.unpack_from('<I', raw, pos + 4)[0]
+        body = pos + 8
+
+        if chunk_id == b'fmt ':
+            fmt_tag, num_channels, sample_rate, _byte_rate, _block_align, bits = \
+                struct.unpack_from('<HHIIHH', raw, body)
+            # Extensible format : the real tag is the first 2 bytes of the
+            # SubFormat GUID, located 8 bytes into the extension block.
+            if fmt_tag == WAVE_FORMAT_EXTENSIBLE and chunk_size >= 26:
+                fmt_tag = struct.unpack_from('<H', raw, body + 24)[0]
+        elif chunk_id == b'data':
+            data_bytes = raw[body:body + chunk_size]
+
+        # Chunks are word-aligned : skip the padding byte for odd sizes.
+        pos = body + chunk_size + (chunk_size & 1)
+
+    if fmt_tag is None:
+        raise WavError("'%s' : missing 'fmt ' chunk" % path)
+    if data_bytes is None:
+        raise WavError("'%s' : missing 'data' chunk" % path)
+
+    if fmt_tag == WAVE_FORMAT_FLOAT:
+        if bits != 32:
+            raise WavError("'%s' : unsupported float format (%d bits, only 32 supported)" % (path, bits))
+    elif fmt_tag == WAVE_FORMAT_PCM:
+        if bits not in (16, 24, 32):
+            raise WavError("'%s' : unsupported PCM format (%d bits, only 16/24/32 supported)" % (path, bits))
+    else:
+        raise WavError("'%s' : unsupported WAV format tag 0x%04X" % (path, fmt_tag))
+
+    interleaved = _decode_samples(data_bytes, fmt_tag, bits)
+
+    # De-interleave into per-channel buffers.
+    channels = [interleaved[c::num_channels] for c in range(num_channels)]
+    frames = len(channels[0]) if num_channels > 0 else 0
+
+    return {
+        'channels': num_channels,
+        'sample_rate': sample_rate,
+        'bits': bits,
+        'frames': frames,
+        'data': channels,
+    }
+
+
+def _decode_samples(data, fmt_tag, bits):
+    """Decode the raw 'data' chunk into a flat list of floats in [-1, 1]."""
+    little_endian = (sys.byteorder == 'little')
+
+    if fmt_tag == WAVE_FORMAT_FLOAT:
+        arr = array('f')
+        arr.frombytes(data[:len(data) - (len(data) % 4)])
+        if not little_endian:
+            arr.byteswap()
+        return list(arr)
+
+    if bits == 16:
+        arr = array('h')
+        arr.frombytes(data[:len(data) - (len(data) % 2)])
+        if not little_endian:
+            arr.byteswap()
+        scale = 1.0 / 32768.0
+        return [s * scale for s in arr]
+
+    if bits == 32:
+        arr = array('i')
+        arr.frombytes(data[:len(data) - (len(data) % 4)])
+        if not little_endian:
+            arr.byteswap()
+        scale = 1.0 / 2147483648.0
+        return [s * scale for s in arr]
+
+    if bits == 24:
+        scale = 1.0 / 8388608.0
+        out = []
+        count = len(data) // 3
+        for i in range(count):
+            b = i * 3
+            v = data[b] | (data[b + 1] << 8) | (data[b + 2] << 16)
+            if v & 0x800000:
+                v -= 0x1000000
+            out.append(v * scale)
+        return out
+
+    raise WavError("unsupported sample format")
+
+
+# ---------------------------------------------------------------------
+# Soundfile detection in the Faust JSON UI
+# ---------------------------------------------------------------------
+
+def scan_soundfiles(dsp_layout):
+    """Return a de-duplicated list of (label, url) soundfile widgets found
+    in the DSP JSON UI, preserving first-seen order."""
+    found = []
+    seen = set()
+
+    def recurse(node):
+        if isinstance(node, dict):
+            if node.get('type') == 'soundfile':
+                url = node.get('url', '')
+                if url not in seen:
+                    seen.add(url)
+                    found.append((node.get('label', ''), url))
+            for item in node.get('items', []):
+                recurse(item)
+
+    for top in dsp_layout.get('ui', []):
+        recurse(top)
+    return found
+
+
+def parse_url(url):
+    """Extract the list of file names from a Faust soundfile URL.
+    Handles "{'a.wav';'b.wav'}" lists as well as a bare file name. The list
+    separator is ';' (semicolon)."""
+    names = re.findall(r"'([^']*)'", url)
+    if names:
+        return names
+    cleaned = url.strip().strip('{}').strip()
+    if not cleaned:
+        return []
+    return [part.strip() for part in cleaned.split(';') if part.strip()]
+
+
+def read_wav_info(path):
+    """Lightweight header-only parse: return (channels, frames) or None.
+    Does not decode the audio data (used to size the SD-mode SDRAM arena)."""
+    try:
+        with open(path, 'rb') as f:
+            hdr = f.read(12)
+            if len(hdr) < 12 or hdr[0:4] != b'RIFF' or hdr[8:12] != b'WAVE':
+                return None
+            channels = bits = frames = None
+            while True:
+                ch = f.read(8)
+                if len(ch) < 8:
+                    break
+                cid = ch[0:4]
+                csize = struct.unpack('<I', ch[4:8])[0]
+                if cid == b'fmt ':
+                    fmt_data = f.read(min(csize, 40))
+                    if csize > len(fmt_data):
+                        f.seek(csize - len(fmt_data), 1)
+                    channels = struct.unpack_from('<H', fmt_data, 2)[0]
+                    bits = struct.unpack_from('<H', fmt_data, 14)[0]
+                elif cid == b'data':
+                    if channels and bits:
+                        frames = csize // (channels * (bits // 8))
+                    break
+                else:
+                    f.seek(csize + (csize & 1), 1)
+            if channels and frames is not None:
+                return (channels, frames)
+    except Exception:
+        return None
+    return None
+
+
+def compute_sd_arena_bytes(soundfiles, search_dirs):
+    """Total SDRAM bytes needed to hold all soundfiles in -sd mode, or None if
+    a referenced WAV cannot be found/parsed at build time (then the runtime
+    default is used)."""
+    total = 0
+    for label, url in soundfiles:
+        cur_chan = 1
+        frames_sum = 0
+        for name in parse_url(url):
+            resolved = resolve_file(name, search_dirs)
+            if resolved is None:
+                return None
+            info = read_wav_info(resolved)
+            if info is None:
+                return None
+            cur_chan = max(cur_chan, info[0])
+            frames_sum += info[1]
+        if cur_chan > MAX_CHAN:
+            cur_chan = MAX_CHAN
+        total_frames = frames_sum + BUFFER_SIZE             # + trailing silent block
+        per = cur_chan * total_frames * 4                   # float channel buffers
+        per += MAX_CHAN * 4                                 # fBuffers pointer array
+        per += 3 * MAX_SOUNDFILE_PARTS * 4                  # length/sr/offset
+        per += 64                                           # Soundfile struct + slack
+        total += per
+    total = int(total * 1.10) + 8192                        # margin + base
+    return (total + 3) & ~3
+
+
+def resolve_file(name, search_dirs):
+    """Resolve 'name' against the search directories. Return the absolute
+    path or None if not found."""
+    if os.path.isabs(name) and os.path.isfile(name):
+        return name
+    for d in search_dirs:
+        candidate = os.path.join(d, name)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+# ---------------------------------------------------------------------
+# C++ header generation
+# ---------------------------------------------------------------------
+
+def _fmt_float(v):
+    """Format a float as a valid C++ 'float' literal (with 'f' suffix)."""
+    s = format(float(v), '.7g')
+    if 'e' not in s and 'E' not in s and '.' not in s and 'inf' not in s and 'nan' not in s:
+        s += '.0'
+    return s + 'f'
+
+
+def _emit_float_array(out, name, values):
+    out.append("static const float %s[%d] = {\n" % (name, len(values)))
+    chunk = []
+    line = []
+    for i, v in enumerate(values):
+        line.append(_fmt_float(v))
+        if len(line) == 12:
+            chunk.append("    " + ", ".join(line) + ",")
+            line = []
+    if line:
+        chunk.append("    " + ", ".join(line) + ",")
+    out.append("\n".join(chunk))
+    out.append("\n};\n")
+
+
+def _emit_int_array(out, name, values):
+    out.append("static int %s[%d] = {\n" % (name, len(values)))
+    line = []
+    chunk = []
+    for v in values:
+        line.append(str(int(v)))
+        if len(line) == 16:
+            chunk.append("    " + ", ".join(line) + ",")
+            line = []
+    if line:
+        chunk.append("    " + ", ".join(line) + ",")
+    out.append("\n".join(chunk))
+    out.append("\n};\n")
+
+
+def _build_soundfile(out, prefix, parts):
+    """Emit the C++ data for one soundfile made of 'parts' (each a parsed
+    WAV dict). Returns the C++ identifier of the generated Soundfile.
+
+    Arrays are sized to the actual number of parts (files in the URL), not the
+    generic MAX_SOUNDFILE_PARTS=256. The Faust soundfile part index is expected
+    to stay within [0, nparts-1] (the number of files actually loaded)."""
+    cur_chan = max((p['channels'] for p in parts), default=1)
+    cur_chan = max(cur_chan, 1)
+    nparts = len(parts)
+
+    # One concatenated buffer per channel (the QSPI data). No empty-part
+    # padding: every part is a real file, so reads (clamped by the DSP to
+    # [0, fLength[p]-1]) always stay inside the part's own region.
+    for c in range(cur_chan):
+        buf = []
+        for p in parts:
+            if c < p['channels']:
+                buf.extend(p['data'][c])
+            else:
+                buf.extend([0.0] * p['frames'])
+        _emit_float_array(out, "%s_ch%d" % (prefix, c), buf)
+
+    # fBuffers : cur_chan distinct pointers, then aliased up to MAX_CHAN so any
+    # requested channel index < MAX_CHAN resolves (mirrors Soundfile::shareBuffers).
+    out.append("static const float* const %s_buffers[%d] = {\n" % (prefix, MAX_CHAN))
+    line = []
+    chunk = []
+    for c in range(MAX_CHAN):
+        line.append("%s_ch%d" % (prefix, c % cur_chan))
+        if len(line) == 4:
+            chunk.append("    " + ", ".join(line) + ",")
+            line = []
+    if line:
+        chunk.append("    " + ", ".join(line) + ",")
+    out.append("\n".join(chunk))
+    out.append("\n};\n")
+
+    # fLength / fSR / fOffset : one entry per (real) part.
+    lengths = []
+    srs = []
+    offsets = []
+    offset = 0
+    for p in parts:
+        lengths.append(p['frames'])
+        srs.append(p['sample_rate'])
+        offsets.append(offset)
+        offset += p['frames']
+
+    _emit_int_array(out, "%s_length" % prefix, lengths)
+    _emit_int_array(out, "%s_sr" % prefix, srs)
+    _emit_int_array(out, "%s_offset" % prefix, offsets)
+
+    out.append(
+        "static Soundfile %s = { (void*)%s_buffers, %s_length, %s_sr, %s_offset, %d, %d, false };\n\n"
+        % (prefix, prefix, prefix, prefix, prefix, cur_chan, nparts)
+    )
+    return prefix
+
+
+def _emit_empty_soundfile(out, nparts):
+    """Emit the 'defaultsound' empty soundfile (1 channel, all parts silent).
+    'nparts' is sized to the max part count of the real soundfiles so the
+    fallback can stand in for any of them. All parts share one silent block."""
+    nparts = max(nparts, 1)
+    out.append("static const float sf_empty_zero[%d] = { 0.0f };\n" % BUFFER_SIZE)
+    out.append("static const float* const sf_empty_buffers[%d] = {\n" % MAX_CHAN)
+    out.append("    " + ", ".join(["sf_empty_zero"] * MAX_CHAN) + "\n};\n")
+    _emit_int_array(out, "sf_empty_length", [BUFFER_SIZE] * nparts)
+    _emit_int_array(out, "sf_empty_sr", [SAMPLE_RATE] * nparts)
+    _emit_int_array(out, "sf_empty_offset", [0] * nparts)
+    out.append(
+        "static Soundfile sf_empty = { (void*)sf_empty_buffers, "
+        "sf_empty_length, sf_empty_sr, sf_empty_offset, 1, 0, false };\n"
+    )
+    out.append("static Soundfile* defaultsound = &sf_empty;\n\n")
+
+
+def generate_header(soundfiles, search_dirs, out_path):
+    """Resolve, parse and inline all referenced WAV files into 'out_path'.
+    'soundfiles' is a list of (label, url). Returns True if at least one
+    soundfile was generated. Exits the process on a missing/invalid file."""
+    out = []
+    out.append("// Generated by faust2daisy (daisy_soundfile_gen.py) - do not edit.\n")
+    out.append("#ifndef __daisy_soundfile__\n#define __daisy_soundfile__\n\n")
+    out.append("#include <cstdint>\n#include <cstring>\n\n")
+    out.append("#ifndef FAUSTFLOAT\n#define FAUSTFLOAT float\n#endif\n\n")
+    out.append(
+        "// Sample data is emitted as 'const' (read-only .rodata). Built with\n"
+        "// faust2daisy -qspi, it is placed in QSPI flash and read memory-mapped,\n"
+        "// never copied to RAM. Soundfiles too large for the 128 KB internal\n"
+        "// flash therefore require the -qspi build mode.\n\n"
+    )
+    out.append("#define MAX_SOUNDFILE_PARTS %d\n" % MAX_SOUNDFILE_PARTS)
+    out.append("#define MAX_CHAN %d\n" % MAX_CHAN)
+    out.append("#define BUFFER_SIZE %d\n" % BUFFER_SIZE)
+    out.append("#define SAMPLE_RATE %d\n\n" % SAMPLE_RATE)
+    out.append(
+        "// Same field layout as architecture/faust/gui/Soundfile.h.\n"
+        "struct Soundfile {\n"
+        "    void* fBuffers;  // float** : MAX_CHAN non-interleaved buffers\n"
+        "    int* fLength;    // frames of each part\n"
+        "    int* fSR;        // sample rate of each part\n"
+        "    int* fOffset;    // frame offset of each part in the buffer\n"
+        "    int fChannels;   // max channels of all parts\n"
+        "    int fParts;      // number of loaded parts\n"
+        "    bool fIsDouble;  // sample format (always float here)\n"
+        "} __attribute__((packed));\n\n"
+    )
+
+    # Resolve and parse all files first, so the empty soundfile can be sized to
+    # the largest part count (and we fail fast before emitting anything).
+    parsed = []  # (index, url, parts)
+    for index, (label, url) in enumerate(soundfiles):
+        names = parse_url(url)
+        parts = []
+        for name in names:
+            resolved = resolve_file(name, search_dirs)
+            if resolved is None:
+                eprint("faust2daisy soundfile error : file '%s' (from soundfile '%s') "
+                       "not found in: %s" % (name, label, ", ".join(search_dirs)))
+                sys.exit(1)
+            try:
+                parts.append(parse_wav(resolved))
+            except WavError as e:
+                eprint("faust2daisy soundfile error : %s" % e)
+                sys.exit(1)
+        parsed.append((index, url, parts))
+
+    max_parts = max((len(p) for _, _, p in parsed), default=1)
+    _emit_empty_soundfile(out, max_parts)
+
+    entries = []  # (url, identifier)
+    for index, url, parts in parsed:
+        if not parts:
+            # Empty URL : map to the default (silent) soundfile.
+            entries.append((url, "sf_empty"))
+            continue
+        prefix = "sf%d" % index
+        ident = _build_soundfile(out, prefix, parts)
+        entries.append((url, ident))
+
+    # Lookup used by DaisyControlUI::addSoundfile.
+    out.append("Soundfile* daisy_lookup_soundfile(const char* url)\n{\n")
+    for url, ident in entries:
+        escaped = url.replace('\\', '\\\\').replace('"', '\\"')
+        out.append('    if (std::strcmp(url, "%s") == 0) return &%s;\n' % (escaped, ident))
+    out.append("    return defaultsound;\n}\n\n")
+
+    out.append("#endif // __daisy_soundfile__\n")
+
+    with open(out_path, 'w') as f:
+        f.write("".join(out))
+
+    return len(entries) > 0

--- a/architecture/daisy/daisy_uart_listener.hpp
+++ b/architecture/daisy/daisy_uart_listener.hpp
@@ -1,0 +1,277 @@
+#ifndef DAISY_UART_LISTENER_HPP
+#define DAISY_UART_LISTENER_HPP
+/************************** BEGIN daisy_uart_listener.hpp ****************
+FAUST Architecture File - faust2daisy
+Copyright (C) 2020-2024 GRAME, Centre National de Creation Musicale
+This is free software; see the FAUST architecture license.
+*************************************************************************/
+
+// =============================================================================
+// daisy_uart_listener.hpp
+//
+// Multi-channel, interrupt-free UART RX for Daisy, with fire-and-forget blocking
+// TX. Lets several UARTs receive *concurrently* -- something libDaisy's
+// UartHandler cannot do, because its DmaListenStart hardcodes DMA1_Stream5 and a
+// single global "dma_active" flag (so only one circular RX at a time, shared by
+// regular UART *and* UART-MIDI).
+//
+// HOW IT AVOIDS THAT, AND COEXISTS WITH libDaisy
+// ----------------------------------------------
+//   * Each channel runs its own circular DMA from the USART RDR into a ring
+//     buffer, on one of the DMA streams libDaisy never uses:
+//       DMA1_Stream7, DMA2_Stream5, DMA2_Stream6, DMA2_Stream7  (=> 4 channels)
+//   * It is driven by NO interrupts: we start the DMA with HAL_DMA_Start (not
+//     _IT) and set the USART DMAR bit by hand, then find new bytes by polling
+//     the DMA's remaining-count register (NDTR) in Poll(). So there is no DMA or
+//     USART NVIC use and no IRQ-handler symbols -> zero clash with libDaisy
+//     (which strongly defines USARTx_IRQHandler and the stream IRQs it uses),
+//     and the global dma_active_peripheral_ scheduler is never touched. libDaisy
+//     MIDI-UART RX (Stream5) and all other DMA users keep running.
+//
+// TX
+// --
+// Transmit() is blocking (HAL_UART_Transmit). UART TX is fire-and-forget and
+// bounded by byte-time, so blocking is safe and cannot stall on a missing
+// reader. Do NOT also drive a UART this class owns with a separate libDaisy
+// UartHandler -- two handles on one peripheral conflict. Use Transmit() here.
+//
+// RING BUFFER
+// -----------
+// Each channel's ring MUST live in DMA-accessible, non-cacheable memory
+// (DMA_BUFFER_MEM_SECTION). DMA writes it in the background; non-cacheable means
+// the CPU sees those writes without manual cache invalidation. Size the ring
+// larger than the most you could receive between two Poll() calls.
+//
+// CONFIG
+// ------
+// ChannelConfig carries raw HAL identifiers (USART instance, DMA request, GPIO
+// ports/pins/AF, baud). The faust2daisy generator already maps Faust pins to
+// peripherals/pins, so it fills these in; for hand use, see the STM32H7
+// datasheet / libDaisy's uart.cpp InitPins for the AF and DMA_REQUEST values.
+//
+// Requires the STM32 HAL in scope (include after daisy_seed.h) and C++17.
+// =============================================================================
+
+#include <cstddef>
+#include <cstdint>
+
+class DaisyUartListener
+{
+  public:
+    // One free DMA stream per channel; libDaisy leaves exactly these four.
+    static constexpr size_t kMaxChannels = 4;
+
+    // Called from Poll() (main-loop context) with bytes newly arrived on a
+    // channel. May be called twice in one Poll() when the ring wraps. Keep it
+    // light; copy/parse, do not block.
+    using RxCallback = void (*)(void* context, const uint8_t* data, size_t len);
+
+    struct ChannelConfig
+    {
+        USART_TypeDef* instance     = nullptr; // USART1 .. UART8
+        uint32_t       baud         = 115200;
+        uint32_t       dmaRxRequest = 0;       // DMA_REQUEST_USARTx_RX
+
+        // RX pin (required)
+        GPIO_TypeDef* rxPort    = nullptr;
+        uint16_t      rxPin     = 0; // GPIO_PIN_x
+        uint8_t       rxAltFunc = 0; // GPIO_AFy_USARTx
+
+        // TX pin (optional; leave txPort == nullptr for receive-only)
+        GPIO_TypeDef* txPort    = nullptr;
+        uint16_t      txPin     = 0;
+        uint8_t       txAltFunc = 0;
+
+        // Ring buffer in DMA_BUFFER_MEM_SECTION memory.
+        uint8_t* ring     = nullptr;
+        size_t   ringSize = 0;
+
+        RxCallback onReceive = nullptr;
+        void*      context   = nullptr;
+    };
+
+    // Configure a UART, start its circular RX DMA, and begin listening. Returns
+    // false if all channels are in use or the config is incomplete.
+    bool addChannel(const ChannelConfig& cfg)
+    {
+        if(channelCount_ >= kMaxChannels) return false;
+        if(!cfg.instance) return false;
+        const bool haveRx = (cfg.rxPort != nullptr) && (cfg.ring != nullptr)
+                            && (cfg.ringSize > 0);
+        if(!haveRx && cfg.txPort == nullptr) return false; // need RX and/or TX
+
+        Channel& ch = channels_[channelCount_];
+        ch.cfg      = cfg;
+        ch.lastPos  = 0;
+
+        if(haveRx) enableGpioClock(cfg.rxPort);
+        if(cfg.txPort) enableGpioClock(cfg.txPort);
+        enableUartClock(cfg.instance);
+
+        // --- GPIO (push-pull AF) ---
+        GPIO_InitTypeDef gpio = {};
+        gpio.Mode  = GPIO_MODE_AF_PP;
+        gpio.Pull  = GPIO_PULLUP;
+        gpio.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+
+        if(haveRx)
+        {
+            gpio.Pin       = cfg.rxPin;
+            gpio.Alternate = cfg.rxAltFunc;
+            HAL_GPIO_Init(cfg.rxPort, &gpio);
+        }
+        if(cfg.txPort)
+        {
+            gpio.Pin       = cfg.txPin;
+            gpio.Alternate = cfg.txAltFunc;
+            HAL_GPIO_Init(cfg.txPort, &gpio);
+        }
+
+        // --- USART (8N1) ---
+        ch.huart.Instance        = cfg.instance;
+        ch.huart.Init.BaudRate   = cfg.baud;
+        ch.huart.Init.WordLength = UART_WORDLENGTH_8B;
+        ch.huart.Init.StopBits   = UART_STOPBITS_1;
+        ch.huart.Init.Parity     = UART_PARITY_NONE;
+        if(haveRx && cfg.txPort) ch.huart.Init.Mode = UART_MODE_TX_RX;
+        else if(haveRx)          ch.huart.Init.Mode = UART_MODE_RX;
+        else                     ch.huart.Init.Mode = UART_MODE_TX;
+        ch.huart.Init.HwFlowCtl      = UART_HWCONTROL_NONE;
+        ch.huart.Init.OverSampling   = UART_OVERSAMPLING_16;
+        ch.huart.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+        ch.huart.Init.ClockPrescaler = UART_PRESCALER_DIV1;
+        if(HAL_UART_Init(&ch.huart) != HAL_OK) return false;
+
+        // --- RX: circular DMA, interrupt-free, on a libDaisy-unused stream ---
+        if(haveRx)
+        {
+            __HAL_RCC_DMA1_CLK_ENABLE();
+            __HAL_RCC_DMA2_CLK_ENABLE();
+            ch.hdma.Instance                 = freeStream(channelCount_);
+            ch.hdma.Init.Request             = cfg.dmaRxRequest;
+            ch.hdma.Init.Direction           = DMA_PERIPH_TO_MEMORY;
+            ch.hdma.Init.PeriphInc           = DMA_PINC_DISABLE;
+            ch.hdma.Init.MemInc              = DMA_MINC_ENABLE;
+            ch.hdma.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+            ch.hdma.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+            ch.hdma.Init.Mode                = DMA_CIRCULAR;
+            ch.hdma.Init.Priority            = DMA_PRIORITY_HIGH;
+            ch.hdma.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+            if(HAL_DMA_Init(&ch.hdma) != HAL_OK) return false;
+
+            // Start the stream WITHOUT interrupts (HAL_DMA_Start, not _IT) and
+            // turn on the USART's DMA-receive request by hand. From here the DMA
+            // fills the ring continuously; we never get (or need) an interrupt.
+            if(HAL_DMA_Start(&ch.hdma,
+                             (uint32_t)&cfg.instance->RDR,
+                             (uint32_t)cfg.ring,
+                             (uint32_t)cfg.ringSize)
+               != HAL_OK)
+                return false;
+            SET_BIT(cfg.instance->CR3, USART_CR3_DMAR);
+        }
+
+        ++channelCount_;
+        return true;
+    }
+
+    // Drain every channel: deliver any bytes the DMA has written since the last
+    // call. Call once per main-loop iteration. Cheap: one register read per
+    // channel when idle.
+    void poll()
+    {
+        for(size_t i = 0; i < channelCount_; ++i)
+        {
+            Channel& ch = channels_[i];
+            // DMA write index = ringSize - remaining(NDTR)
+            size_t pos = ch.cfg.ringSize - __HAL_DMA_GET_COUNTER(&ch.hdma);
+            if(pos == ch.lastPos) continue;
+
+            if(pos > ch.lastPos)
+            {
+                if(ch.cfg.onReceive)
+                    ch.cfg.onReceive(ch.cfg.context,
+                                     &ch.cfg.ring[ch.lastPos],
+                                     pos - ch.lastPos);
+            }
+            else // wrapped: tail then head
+            {
+                if(ch.cfg.onReceive)
+                {
+                    ch.cfg.onReceive(ch.cfg.context,
+                                     &ch.cfg.ring[ch.lastPos],
+                                     ch.cfg.ringSize - ch.lastPos);
+                    if(pos > 0)
+                        ch.cfg.onReceive(ch.cfg.context, &ch.cfg.ring[0], pos);
+                }
+            }
+            ch.lastPos = pos;
+        }
+    }
+
+    // Blocking, fire-and-forget transmit on a channel that has a TX pin.
+    bool transmit(size_t channel,
+                  const uint8_t* data,
+                  size_t         size,
+                  uint32_t       timeoutMs = 100)
+    {
+        if(channel >= channelCount_ || !channels_[channel].cfg.txPort)
+            return false;
+        return HAL_UART_Transmit(&channels_[channel].huart,
+                                 (uint8_t*)data,
+                                 (uint16_t)size,
+                                 timeoutMs)
+               == HAL_OK;
+    }
+
+    size_t channelCount() const { return channelCount_; }
+
+  private:
+    struct Channel
+    {
+        ChannelConfig     cfg;
+        UART_HandleTypeDef huart   = {};
+        DMA_HandleTypeDef  hdma    = {};
+        size_t             lastPos = 0;
+    };
+
+    Channel channels_[kMaxChannels];
+    size_t  channelCount_ = 0;
+
+    static DMA_Stream_TypeDef* freeStream(size_t idx)
+    {
+        switch(idx)
+        {
+            case 0: return DMA1_Stream7;
+            case 1: return DMA2_Stream5;
+            case 2: return DMA2_Stream6;
+            default: return DMA2_Stream7;
+        }
+    }
+
+    static void enableUartClock(USART_TypeDef* u)
+    {
+        if(u == USART1) __HAL_RCC_USART1_CLK_ENABLE();
+        else if(u == USART2) __HAL_RCC_USART2_CLK_ENABLE();
+        else if(u == USART3) __HAL_RCC_USART3_CLK_ENABLE();
+        else if(u == UART4) __HAL_RCC_UART4_CLK_ENABLE();
+        else if(u == UART5) __HAL_RCC_UART5_CLK_ENABLE();
+        else if(u == USART6) __HAL_RCC_USART6_CLK_ENABLE();
+        else if(u == UART7) __HAL_RCC_UART7_CLK_ENABLE();
+        else if(u == UART8) __HAL_RCC_UART8_CLK_ENABLE();
+    }
+
+    static void enableGpioClock(GPIO_TypeDef* p)
+    {
+        if(p == GPIOA) __HAL_RCC_GPIOA_CLK_ENABLE();
+        else if(p == GPIOB) __HAL_RCC_GPIOB_CLK_ENABLE();
+        else if(p == GPIOC) __HAL_RCC_GPIOC_CLK_ENABLE();
+        else if(p == GPIOD) __HAL_RCC_GPIOD_CLK_ENABLE();
+        else if(p == GPIOE) __HAL_RCC_GPIOE_CLK_ENABLE();
+        else if(p == GPIOG) __HAL_RCC_GPIOG_CLK_ENABLE();
+        else if(p == GPIOH) __HAL_RCC_GPIOH_CLK_ENABLE();
+    }
+};
+
+#endif // DAISY_UART_LISTENER_HPP
+/************************  END  daisy_uart_listener.hpp **********************/

--- a/architecture/daisy/daisy_uart_pins.py
+++ b/architecture/daisy/daisy_uart_pins.py
@@ -1,0 +1,137 @@
+# daisy_uart_pins.py
+#
+# Authoritative Daisy pin -> UART resolution for faust2daisy.
+#
+# A Faust control declares its UART pin by board label, e.g. hslider("amp[rx:D14]")
+# or "amp[tx:D13]" on the Seed, "amp[rx:A2]" on the Patch SM. The board silkscreen
+# naming is unreliable (the Seed names the USART index; the Patch SM just says
+# "UART RX/TX", and libDaisy even mislabels A2/A3 as "UART1" when they are really
+# UART4). So we resolve every pin the only reliable way: board label -> physical
+# MCU pin -> (USART peripheral, alternate-function, DMA request), using the
+# STM32H7 alternate-function table.
+#
+# The values below are extracted from libDaisy (not guessed):
+#   * physical pin per label : src/daisy_seed.h (daisy::seed::Dx),
+#                              src/daisy_patch_sm.h (daisy::patch_sm::Ax)
+#   * pin -> (peripheral, AF) : src/per/uart.cpp  (usartN_pins_tx/rx tables)
+#   * peripheral -> DMA req   : src/per/uart.cpp  (SetDmaPeripheral)
+#
+# These feed DaisyUartListener::ChannelConfig (daisy_uart_listener.hpp), which
+# takes raw HAL identifiers; the parser emits the strings below verbatim. The
+# listener stays board-agnostic -- all board difference lives here.
+#
+# NOTE on shared pins: a few physical pins expose more than one UART function
+# (e.g. Seed D2/PC10 = USART3_TX AF7 *or* UART4_TX AF8). We pick the canonical
+# one (the lower-numbered AF7 USART, matching the Seed pinout) and record the
+# alternate in 'alts'. If a DSP ever needs the alternate, the metadata would have
+# to name the peripheral explicitly; for the standard pinout this never arises.
+#
+# LPUART1 is intentionally excluded: it is driven by BDMA, not DMA1/DMA2, so it
+# is incompatible with DaisyUartListener's DMA1/DMA2 streams.
+
+
+def _e(periph, af, port, pin_idx, dma_req, alts=None):
+    """One resolution entry, holding the C++ identifiers the parser emits."""
+    return {
+        "periph":   periph,                  # human/diagnostic name
+        "instance": periph,                  # HAL USART_TypeDef* name (== periph)
+        "af":       af,                       # GPIO_AFx_xxx
+        "port":     port,                     # GPIO_TypeDef* name
+        "pin":      "GPIO_PIN_%d" % pin_idx,  # GPIO_PIN_n
+        "dma_req":  dma_req,                  # DMA_REQUEST_xxx_RX / _TX
+        "alts":     alts or [],
+    }
+
+
+# ----------------------------------------------------------------------------
+# Daisy Seed (daisy::seed::Dx). Only pins the official Daisy Seed pinout
+# documents as a UART function are listed (verified against
+# libDaisy/doc/Daisy_Seed_Rev4_Pinout.csv). Pins whose only UART role is a deep
+# alternate behind a non-UART primary (USB / SPI1 / SAI2 -> D0, D9, D10, D24,
+# D25, D27, D28) are intentionally excluded. [brackets] note a shared function.
+#
+# Usable bidirectional pairs:
+#   USART1: rx D14 / tx D13           (also rx D30 / tx D29 on the USB pins, AF4)
+#   USART3: rx D1  / tx D2
+#   UART4 : rx D11 / tx D12
+#   UART5 : rx D5  / tx D6
+#   USART2: rx D16                     (no tx pin documented)
+# ----------------------------------------------------------------------------
+SEED_UART_RX = {
+    "D1":  _e("USART3", "GPIO_AF7_USART3",  "GPIOC", 11, "DMA_REQUEST_USART3_RX",  # [SDMMC1_D3]
+              alts=["UART4_RX (AF8)"]),
+    "D5":  _e("UART5",  "GPIO_AF8_UART5",   "GPIOD",  2, "DMA_REQUEST_UART5_RX"),  # [SDMMC1_CMD]
+    "D11": _e("UART4",  "GPIO_AF8_UART4",   "GPIOB",  8, "DMA_REQUEST_UART4_RX"),  # [I2C1_SCL]
+    "D14": _e("USART1", "GPIO_AF7_USART1",  "GPIOB",  7, "DMA_REQUEST_USART1_RX"), # dedicated UART Rx
+    "D16": _e("USART2", "GPIO_AF7_USART2",  "GPIOA",  3, "DMA_REQUEST_USART2_RX"), # [ADC]
+    "D30": _e("USART1", "GPIO_AF4_USART1",  "GPIOB", 15, "DMA_REQUEST_USART1_RX"), # [USB D+]
+}
+
+SEED_UART_TX = {
+    "D2":  _e("USART3", "GPIO_AF7_USART3",  "GPIOC", 10, "DMA_REQUEST_USART3_TX",  # [SDMMC1_D2]
+              alts=["UART4_TX (AF8)"]),
+    "D6":  _e("UART5",  "GPIO_AF8_UART5",   "GPIOC", 12, "DMA_REQUEST_UART5_TX"),  # [SDMMC1_CK]
+    "D12": _e("UART4",  "GPIO_AF8_UART4",   "GPIOB",  9, "DMA_REQUEST_UART4_TX"),  # [I2C1_SDA]
+    "D13": _e("USART1", "GPIO_AF7_USART1",  "GPIOB",  6, "DMA_REQUEST_USART1_TX"), # dedicated UART Tx
+    "D29": _e("USART1", "GPIO_AF4_USART1",  "GPIOB", 14, "DMA_REQUEST_USART1_TX"), # [USB D-]
+}
+
+# ----------------------------------------------------------------------------
+# Daisy Patch SM (daisy::patch_sm::Ax/Bx/Dx). Only pins the official Patch SM
+# pinout documents as a UART function. A2/A3 are the dedicated UART pins; B7/B8
+# and D2/D3/D6/D7 expose UART alongside their primary function (noted in
+# [brackets]). C3/C5 (CV In, USART2) and D1 (SPI2 CS, UART7) are NOT shown as
+# UART on the official pinout and are excluded; so are A8/A9 (the USB D-/D+ pins).
+#
+# Usable bidirectional pairs:
+#   UART4 : rx A2|B7 / tx A3|B8        (also rx D2 / tx D3 via AF8)
+#   USART3: rx D2    / tx D3
+#   UART5 : rx D7    / tx D6
+# ----------------------------------------------------------------------------
+PATCHSM_UART_RX = {
+    "A2": _e("UART4",  "GPIO_AF8_UART4",  "GPIOA",  1, "DMA_REQUEST_UART4_RX"),   # dedicated UART Rx
+    "B7": _e("UART4",  "GPIO_AF8_UART4",  "GPIOB",  8, "DMA_REQUEST_UART4_RX"),   # [I2C1 SCL]
+    "D2": _e("USART3", "GPIO_AF7_USART3", "GPIOC", 11, "DMA_REQUEST_USART3_RX",   # [SDMMC D3]
+             alts=["UART4_RX (AF8)"]),
+    "D7": _e("UART5",  "GPIO_AF8_UART5",  "GPIOD",  2, "DMA_REQUEST_UART5_RX"),   # [SDMMC CMD]
+}
+
+PATCHSM_UART_TX = {
+    "A3": _e("UART4",  "GPIO_AF8_UART4",  "GPIOA",  0, "DMA_REQUEST_UART4_TX"),   # dedicated UART Tx
+    "B8": _e("UART4",  "GPIO_AF8_UART4",  "GPIOB",  9, "DMA_REQUEST_UART4_TX"),   # [I2C1 SDA]
+    "D3": _e("USART3", "GPIO_AF7_USART3", "GPIOC", 10, "DMA_REQUEST_USART3_TX",   # [SDMMC D2]
+             alts=["UART4_TX (AF8)"]),
+    "D6": _e("UART5",  "GPIO_AF8_UART5",  "GPIOC", 12, "DMA_REQUEST_UART5_TX"),   # [SDMMC CK]
+}
+
+_TABLES = {
+    "seed":    (SEED_UART_RX, SEED_UART_TX),
+    "patchsm": (PATCHSM_UART_RX, PATCHSM_UART_TX),
+}
+
+
+def resolve_uart(chip, pin_label, direction):
+    """Resolve (chip, pin_label, 'rx'|'tx') to a UART entry dict.
+
+    Raises ValueError with the list of valid pins on failure, so the parser can
+    surface a clear message instead of emitting a bad alternate-function.
+    """
+    if chip not in _TABLES:
+        raise ValueError(
+            "UART controls are only supported on 'seed' and 'patchsm' (got %r)"
+            % chip)
+    rx_tbl, tx_tbl = _TABLES[chip]
+    if direction not in ("rx", "tx"):
+        raise ValueError("UART direction must be 'rx' or 'tx' (got %r)" % direction)
+    table = rx_tbl if direction == "rx" else tx_tbl
+    if pin_label not in table:
+        valid = ", ".join(sorted(table.keys()))
+        raise ValueError(
+            "%s is not a UART %s pin on %s. Valid %s pins: %s"
+            % (pin_label, direction, chip, direction, valid))
+    return table[pin_label]
+
+
+def same_peripheral(rx_entry, tx_entry):
+    """True if an rx/tx pair belongs to one USART (required for one channel)."""
+    return rx_entry["instance"] == tx_entry["instance"]

--- a/architecture/daisy/ex_faust.cpp
+++ b/architecture/daisy/ex_faust.cpp
@@ -34,13 +34,23 @@
 
 //#include "daisysp.h"
 
-#ifdef SEED 
+#ifdef PATCH 
+
+#include "daisy_patch.h"
+
+using namespace daisy::seed;
+
+//static daisy::DaisyPatch platform;
+static daisy::DaisyPatch platform;
+static daisy::DaisySeed& hw = platform.seed; 
+#elif defined SEED 
 #include "daisy_seed.h"
 using namespace daisy::seed;
 static daisy::DaisySeed hw;
 #elif defined PATCHSM
 #include "daisy_patch_sm.h"
-static daisy::DaisyPatchSM hw;
+using namespace daisy::patch_sm;
+static daisy::patch_sm::DaisyPatchSM hw;
 #endif
 
 #include <functional>
@@ -163,7 +173,7 @@ struct control
     control::scale_t scale; // To implement in update methods
     const char *label; // Might be useless‘
 
-    float *value_ptr;
+    float *value_ptr = nullptr;
 
     scale::scale_t scale_type = scale::scale_t::lin;
     /*                           
@@ -187,7 +197,7 @@ struct control
 #ifdef SEED
     constexpr static const daisy::Pin DEFAULT_PIN = daisy::seed::A1;
 #elif defined PATCHSM 
-    constexpr static const daisy::Pin DEFAULT_PIN = daisy::patch_sm::A1;
+    constexpr static const daisy::Pin DEFAULT_PIN = daisy::patch_sm::DaisyPatchSM::C2;
 #endif
 
 /*
@@ -222,6 +232,19 @@ struct adc : public control
     {}
 
 
+    // Constructor for Patch SM which doesn't access adc directly, but uses the Analog Control interface 
+    adc(adc::type_t t, float init_, float min_, float max_, float step_, 
+        scale::scale_t scale_ = scale::scale_t::lin, uint8_t chn = 0)
+        : control::control(scale_)
+        , type(t)
+        , init(init_)
+        , min(min_)
+        , max(max_)
+        , step(step_)
+        , previous_state(init_)
+        , channel(chn)
+    {}
+
     /*
         For Buttons and checkboxes 0.05f we need a threshold to eliminate potential DC or noise 
     */
@@ -239,12 +262,12 @@ struct adc : public control
         *fZone = (value > noise_threshold) ? 1.0f : 0.0f;
     }
 
-    static void checkbox_method(float value, float *fZone, 
+    static void checkbox_method(float value, float *fzone, 
         float min, float max, float step, float &prev, scale::scale_t scale_type)
     {
         if(value > noise_threshold && value > prev && (value - prev) > noise_threshold)
         {
-            *fZone = 1.0f - (*fZone);
+            *fzone = 1.0f - (*fzone);
         }
         prev = value;
     }
@@ -266,11 +289,22 @@ struct adc : public control
         default:
             break;
         }
+        *value_ptr = init;
     }
 
     void update() override
     {
-        update_method(hw.adc.GetFloat(channel), value_ptr, 
+        #ifdef SEED
+            float val = hw.adc.GetFloat(channel);
+        #elif defined PATCHSM 
+            float val = hw.GetAdcValue(channel);
+        #endif 
+
+        #ifdef PATCH 
+            val = 1.0f - val; // Invert for Daisy Patch
+        #endif 
+
+        update_method(val, value_ptr, 
             min, max, step, previous_state, scale_type);
     }
 };
@@ -287,6 +321,12 @@ struct shared_adc : public adc
     shared_adc(adc::type_t t, float init_, float min_, float max_, float step_,
         scale::scale_t scale_ = scale::scale_t::lin, daisy::Pin pin_ = DEFAULT_PIN)
         : adc(t, init_, min_, max_, step_, scale_, pin_)
+        , val(init)
+    {}
+    
+    shared_adc(adc::type_t t, float init_, float min_, float max_, float step_,
+        scale::scale_t scale_ = scale::scale_t::lin, uint8_t chn)
+        : adc(t, init_, min_, max_, step_, scale_, chn)
         , val(init)
     {}
     // Called once per voice during buildUserInterface
@@ -307,8 +347,17 @@ struct shared_adc : public adc
     }
 
     void update() override {
-        if(counter == 0)
-            val = hw.adc.GetFloat(channel);
+        if(counter == 0) {
+        #ifdef SEED
+            float val = hw.adc.GetFloat(channel);
+        #elif defined PATCHSM 
+            float val = hw.GetAdcValue(channel);
+        #endif 
+
+        #ifdef PATCH 
+            val = 1.0f - val; // Invert for Daisy Patch
+        #endif 
+        }
         update_method(val, targets[counter], min, max, step, prev_states[counter], scale_type);
         counter = (counter + 1) % N;
     }
@@ -334,14 +383,14 @@ struct digi_input : public adc
         gpio.Init(pin, daisy::GPIO::Mode::INPUT, daisy::GPIO::Pull::PULLUP, 
             daisy::GPIO::Speed::VERY_HIGH);
         passed_samples =  0; 
-        *value_ptr = init;
+        //*value_ptr = init;
     }
 
     void update() override 
     {
         if(passed_samples == 0)
         {
-            update_method(!gpio.Read(), value_ptr, min, max, step, previous_state, scale_type);
+            update_method(gpio.Read(), value_ptr, min, max, step, previous_state, scale_type);
         }
         passed_samples += MY_BUFFER_SIZE;
         if(passed_samples >= time_threshold)
@@ -369,12 +418,14 @@ struct shared_digi_input : public digi_input
     void set_value_ptr(float * zone) override
     {
         if(counter < N)
+        {
             targets[counter] = zone;
+        }
     }
 
     void setup() override 
     {
-        counter, update_method);
+        // Initialize the shared digital input
         if(counter == 0)
         {
             adc::setup();
@@ -389,13 +440,13 @@ struct shared_digi_input : public digi_input
     void update() override 
     {
         if(counter == 0)
+        {
             val = !gpio.Read();
+        }
 
         update_method(val, targets[counter], min, max, step, prev_states[counter], scale_type);
         counter = (counter + 1) % N;
     }
-
-
 };
 #endif
 
@@ -408,9 +459,30 @@ struct midi_input : public adc
     midi_input() = default;
     midi_input(adc::type_t t, float init_, float min_, float max_, float step_, 
             scale::scale_t scale_ = scale::scale_t::lin, midi_t *midiptr = nullptr)
-        : adc::adc(t, init_, min_, max_, step_, scale_)
+        : adc::adc(t, init_, min_, max_, step_, scale_, DEFAULT_PIN)
         , m(midiptr)
-    {}
+    {
+        m->value = uint8_t(init);
+    }
+
+    static void midi_checkbox_method(float value, float *fzone, 
+        float min, float max, float step, float &prev, scale::scale_t scale_type)
+    {
+        if(value == 127) {
+            *fzone = 1.0f;
+        } else if (value == 0.0f) {
+            *fzone = 0.0f;
+        }
+    }
+
+    void setup() override 
+    {
+        adc::setup();
+        if(type == adc::type_t::checkbox || type == adc::type_t::button)
+        {
+            update_method = midi_checkbox_method;
+        }
+    }
 
     void update() override 
     {
@@ -527,8 +599,8 @@ struct dac : public control
     float min, max; 
     const char *label;
 
+    #ifdef SEED 
     daisy::DacHandle::Channel channel; // index in used ADC list 
-
     dac(daisy::DacHandle::Channel chn, float min_, float max_, 
             scale::scale_t scale_ = scale::scale_t::lin)
         : control::control(scale_)
@@ -536,13 +608,29 @@ struct dac : public control
         , max(max_)
         , channel(chn)
     {}
+    #elif defined PATCHSM
+    uint8_t channel;  // 0 for both, 1 for first, 2 for second channel
+    dac(uint8_t chn, float min_, float max_, 
+            scale::scale_t scale_ = scale::scale_t::lin)
+        : control::control(scale_)
+        , min(min_)
+        , max(max_)
+        , channel(chn)
+    {}
+    #endif
+
 
     void update() override
     {
+        #ifdef SEED 
         hw.dac.WriteValue(channel, uint16_t(scale::process(scale_type, 
             normalize(*value_ptr, min, max)) * 4095.0f));
+        #elif defined PATCHSM
+            hw.WriteCvOut(channel, scale::process(scale_type, normalize(*value_ptr, min, max)) * 5.0f);
+        #endif
     }
 };
+
 
 #ifdef POLY
 template<uint8_t N> 
@@ -551,10 +639,17 @@ struct shared_dac : public dac
     uint8_t counter = 0;
 
     shared_dac() = default; 
+    #ifdef SEED
     shared_dac(daisy::DacHandle::Channel chn, float min_, float max_, 
             scale::scale_t scale_ = scale::scale_t::lin)
         : dac::dac(chn, min_, max_, scale_)
     {}
+    #elif defined PATCHSM
+    shared_dac(uint8_t chn, float min_, float max_, 
+            scale::scale_t scale_ = scale::scale_t::lin)
+        : dac::dac(chn, min_, max_, scale_)
+    {}
+    #endif
 
     void set_value_ptr(float *zone)
     {
@@ -575,15 +670,8 @@ struct shared_dac : public dac
 };
 #endif
 
-struct digi_output : public control 
+struct digi_output : public control
 {
-    enum pwm_t 
-    {
-        off, 
-        on,
-        inv 
-    };
-
     daisy::Pin pin;
     float min, max;
     daisy::GPIO gpio;
@@ -594,50 +682,53 @@ struct digi_output : public control
 
     static void gpio_method(float *val, daisy::GPIO* gpio, daisy::Led* led)
     {
-        gpio->Write( (*val) < adc::noise_threshold );
+        (void*)led;
+        gpio->Write( (*val) > adc::noise_threshold );
     }
 
     static void led_method(float *val, daisy::GPIO* gpio, daisy::Led* led)
     {
+        (void*)gpio;
         led->Set(*val);
         led->Update();
     }
 
     digi_output() = default;
-    digi_output(daisy::Pin pin_, pwm_t pwm, float min_ = 0.0f, float max_ = 1.0f)
+    // softpwm == true -> software PWM brightness (daisy::Led), selected by
+    // [mode:softpwm]; otherwise a plain digital on/off output.
+    digi_output(daisy::Pin pin_, bool softpwm, float min_ = 0.0f, float max_ = 1.0f)
         : pin(pin_)
         , min(min_)
         , max(max_)
     {
-        if(pwm != pwm_t::off) 
+        if(softpwm)
         {
-            led.Init(pin, pwm == pwm_t::inv, 1000.0f /*MY_SAMPLE_RATE / MY_BUFFER_SIZE*/ );
-            digi_out_method = led_method;
-
-        } else 
-        {
-            gpio.Init(pin, daisy::GPIO::Mode::OUTPUT);
+            led.Init(pin, false /* no invert */, 1000.0f /*MY_SAMPLE_RATE / MY_BUFFER_SIZE*/ );
             digi_out_method = led_method;
         }
-        *value_ptr = min;
+        else
+        {
+            gpio.Init(pin, daisy::GPIO::Mode::OUTPUT);
+            digi_out_method = gpio_method;
+        }
     }
 
 
-    void update() override 
+    void update() override
     {
         digi_out_method(value_ptr, &gpio, &led);
     }
 };
 
 #ifdef POLY
-template<uint8_t N> 
+template<uint8_t N>
 struct shared_digi_output : public digi_output
 {
     uint8_t counter = 0;
 
-    shared_digi_output() = default; 
-    shared_digi_output(daisy::Pin pin_, float min_ = 0.0f, float max_ = 1.0f)
-        : digi_output::digi_output(pin_, min_, max_)
+    shared_digi_output() = default;
+    shared_digi_output(daisy::Pin pin_, bool softpwm, float min_ = 0.0f, float max_ = 1.0f)
+        : digi_output::digi_output(pin_, softpwm, min_, max_)
     {}
     
     void set_value_ptr(float *zone)
@@ -654,10 +745,315 @@ struct shared_digi_output : public digi_output
             digi_output::update();
         }
         counter = (counter + 1) % N;
-        
+
     }
 };
 #endif
+
+#ifdef PWM
+#include "per/pwm.h"
+
+#ifndef PWM_OUTPUTS
+#define PWM_OUTPUTS 0
+#endif
+
+// Hardware-PWM output control ([pwm:PIN] on a bargraph). One channel of a
+// TIM3/4/5 PWM peripheral; the DSP value is normalized to a 0..1 duty cycle.
+// update() is a single register write (Channel::Set), so it is safe in the
+// audio callback. The PWMHandle instances, channel Init and the 'channel'
+// pointer below are set up by pwm_setup() (parser-emitted).
+struct pwm_out : public control
+{
+    daisy::PWMHandle::Channel* channel = nullptr;
+    float                      min = 0.0f;
+    float                      max = 1.0f;
+
+    pwm_out() = default;
+    void update() override
+    {
+        if(channel && value_ptr)
+            channel->Set(normalize(*value_ptr, min, max));
+    }
+};
+
+#ifdef POLY
+// Polyphonic variant: drive the pin once from voice 0 (mirrors shared_dac).
+template <uint8_t N>
+struct shared_pwm_out : public pwm_out
+{
+    uint8_t counter = 0;
+    shared_pwm_out() = default;
+    void set_value_ptr(float* zone) override
+    {
+        if(counter == 0) value_ptr = zone;
+        counter = (counter + 1) % N;
+    }
+    void update() override
+    {
+        if(counter == 0) pwm_out::update();
+        counter = (counter + 1) % N;
+    }
+};
+using pwm_out_t = shared_pwm_out<NVOICES>;
+#else
+using pwm_out_t = pwm_out;
+#endif
+
+// Filled by pwm_setup() (parser-emitted): per-control [min,max] and channel.
+std::array<pwm_out_t, PWM_OUTPUTS> pwm_output_list;
+void pwm_setup(); // Init the PWM timers + channels, wire up pwm_output_list.
+#endif // PWM
+
+#ifdef SERIAL
+#include "daisy_uart_listener.hpp"
+#include <cstdlib> // atof / strtof
+#include <cstdio>  // snprintf
+#include <cstring> // memcmp
+#include <cmath>   // fabsf
+
+// faust2daisy defines these via the build; defaults keep the template
+// compilable and let a hand-written channel be tested before the parser is
+// wired (see the manual-test note in the README / discussion).
+#ifndef SERIAL_RX_INPUTS
+#define SERIAL_RX_INPUTS 1
+#endif
+#ifndef SERIAL_TX_OUTPUTS
+#define SERIAL_TX_OUTPUTS 0
+#endif
+#ifndef SERIAL_LINE_MAX
+#define SERIAL_LINE_MAX 32 // longest "label value" message, bytes
+#endif
+#ifndef SERIAL_RING_SIZE
+#define SERIAL_RING_SIZE 256 // per-channel circular-DMA ring (DMA memory)
+#endif
+#ifndef SERIAL_TX_INTERVAL_MS
+#define SERIAL_TX_INTERVAL_MS 20 // <= 50 Hz max outgoing rate per control
+#endif
+#ifndef SERIAL_TX_EPSILON
+#define SERIAL_TX_EPSILON 0.001f // send-on-change threshold
+#endif
+
+struct string_view
+{
+    const char* str;
+    uint8_t     size;
+};
+
+// Label -> value routing table. Filled by init_serial_input_labels() (emitted
+// by the parser, or hand-written for a manual test).
+void                                      init_serial_input_labels();
+std::array<string_view, SERIAL_RX_INPUTS> serial_input_labels;
+std::array<float, SERIAL_RX_INPUTS>       serial_input_values;
+
+// The single multi-channel listener (UART DMA RX + blocking TX). See
+// daisy_uart_listener.hpp.
+static DaisyUartListener serial_listener;
+
+// Parse one received frame body "label<space>value" (the bytes between the
+// framing brackets) and route the value (ASCII float) to the matching control.
+// Text framing -- not binary -- is used so a byte stream resyncs cleanly on the
+// '[' start marker and no value byte can ever be mistaken for a delimiter.
+// (Faust control labels contain no space, so the first space is the separator.)
+void serial_parse_line(const char* line, uint8_t len)
+{
+    uint8_t sp = 0;
+    while(sp < len && line[sp] != ' ') ++sp;
+    if(sp == 0 || sp >= len) return; // no label or no separator
+    for(uint8_t i = 0; i < serial_input_labels.size(); ++i)
+    {
+        if(serial_input_labels[i].size == sp
+           && std::memcmp(line, serial_input_labels[i].str, sp) == 0)
+        {
+            serial_input_values[i] = (float)atof(line + sp + 1);
+            return;
+        }
+    }
+}
+
+// Per-channel byte reassembler. Frames are bracketed: "[label value]". The '['
+// is a hard start marker (gives a clean resync point) and ']' ends+parses;
+// bytes outside brackets (noise, a trailing '\n', ...) are ignored. Runs in
+// main-loop context (from serial_listener.poll()), so atof is fine here. One
+// instance per channel; passed as the channel's callback context.
+struct serial_line_assembler
+{
+    char    buf[SERIAL_LINE_MAX];
+    uint8_t len    = 0;
+    bool    active = false; // currently inside a [...] frame
+};
+
+void serial_on_bytes(void* ctx, const uint8_t* data, size_t n)
+{
+    serial_line_assembler* a = (serial_line_assembler*)ctx;
+    for(size_t i = 0; i < n; ++i)
+    {
+        char c = (char)data[i];
+        if(c == '[') // start of frame (also recovers from a dropped ']')
+        {
+            a->active = true;
+            a->len    = 0;
+        }
+        else if(c == ']')
+        {
+            if(a->active && a->len > 0)
+                serial_parse_line(a->buf, a->len);
+            a->active = false;
+            a->len    = 0;
+        }
+        else if(a->active)
+        {
+            if(a->len < sizeof(a->buf))
+                a->buf[a->len++] = c;
+            else
+                a->active = false; // overflow -> drop, resync at next '['
+        }
+        // bytes outside a frame are ignored
+    }
+}
+
+// Control object (mirrors the ADC/MIDI control model): a received serial value
+// drives the Faust zone via the shared update_method.
+struct serial_in : public adc
+{
+    uint8_t index = 0;
+    serial_in() = default;
+    serial_in(adc::type_t  t,
+              float         init_,
+              float         min_,
+              float         max_,
+              float         step_,
+              scale::scale_t scale_ = scale::scale_t::lin,
+              uint8_t        index_ = 0)
+        : adc::adc(t, init_, min_, max_, step_, scale_, 0), index(index_)
+    {}
+
+    void update() override
+    {
+        update_method(serial_input_values[index], value_ptr, min, max, step,
+                      previous_state, scale_type);
+        //hw.PrintLine("value at %d == %d", index, int((*value_ptr) * 1000)  );
+    }
+};
+
+#if defined(POLY)
+// Polyphonic variant: read the received value once and fan it out to all N
+// voices' zones (mirrors shared_digi_input / shared_adc). set_value_ptr() and
+// setup() are paired by DaisyControlUI::addADCEntry, so the counter walks the N
+// targets at registration; update() reads serial_input_values[index] once
+// (counter == 0) and distributes the shared value -- no per-voice re-read.
+template <size_t N>
+struct shared_serial_in : public serial_in
+{
+    std::array<float*, N> targets;
+    std::array<float, N>  prev_states = {};
+    uint8_t               counter = 0;
+    float                 val = 0.0f;
+
+    shared_serial_in() = default;
+    shared_serial_in(adc::type_t t, float init_, float min_, float max_, float step_,
+                     scale::scale_t scale_ = scale::scale_t::lin, uint8_t index_ = 0)
+        : serial_in(t, init_, min_, max_, step_, scale_, index_), val(init_)
+    {}
+
+    void set_value_ptr(float* zone) override
+    {
+        if(counter < N) targets[counter] = zone;
+    }
+    void setup() override
+    {
+        *targets[counter] = init;
+        counter = (counter + 1) % N;
+    }
+    void update() override
+    {
+        if(counter == 0) val = serial_input_values[index];
+        update_method(val, targets[counter], min, max, step, prev_states[counter],
+                      scale_type);
+        counter = (counter + 1) % N;
+    }
+};
+#endif
+
+// Send a control value out as one bracketed frame "[label value]" (blocking,
+// fire-and-forget). The brackets frame the message for the receiver's
+// reassembler. 'channel' is the DaisyUartListener channel the control's TX pin
+// resolved to.
+inline void serial_send(uint8_t channel, const char* label, float value)
+{
+    char line[SERIAL_LINE_MAX];
+    int  n = snprintf(line, sizeof(line), "[%s %f]", label, value);
+    if(n > 0)
+        serial_listener.transmit(channel, (const uint8_t*)line, (size_t)n);
+}
+
+// Output control (a bargraph tagged [tx:Dx]). Lives in output_list so
+// DaisyControlUI's bargraph handler assigns its zone via set_value_ptr(); the
+// value is actually transmitted (throttled, send-on-change) by serial_tx_poll()
+// from the main loop -- never from the audio callback, where a blocking UART
+// write would overrun the block.
+struct serial_out : public control
+{
+    const char* label     = nullptr;
+    uint8_t     channel    = 0;
+    float       last_sent  = 0.0f;
+    bool        sent_once  = false;
+
+    serial_out() = default;
+    void update() override {} // no-op: sending happens in serial_tx_poll()
+};
+
+#if defined(POLY)
+// Polyphonic variant: keep voice 0's zone and transmit it once (mirrors
+// shared_dac). update() stays a no-op; serial_tx_poll() does the sending.
+template <size_t N>
+struct shared_serial_out : public serial_out
+{
+    uint8_t counter = 0;
+    shared_serial_out() = default;
+    void set_value_ptr(float* zone) override
+    {
+        if(counter == 0) value_ptr = zone;
+        counter = (counter + 1) % N;
+    }
+};
+using serial_out_t = shared_serial_out<NVOICES>;
+#else
+using serial_out_t = serial_out;
+#endif
+
+// Filled by init_serial_outputs() (parser-emitted): per-control label + channel.
+// serial_tx_poll() iterates this; it works on either element type because both
+// expose the serial_out base fields.
+std::array<serial_out_t, SERIAL_TX_OUTPUTS> serial_output_list;
+void init_serial_outputs();
+
+// Transmit changed output values from the MAIN LOOP, capped at
+// SERIAL_TX_INTERVAL_MS (<= 50 Hz) and only when a value moved past
+// SERIAL_TX_EPSILON. Keeps the bus and the loop idle when nothing changes.
+inline void serial_tx_poll()
+{
+    static uint32_t last_ms = 0;
+    uint32_t        now     = daisy::System::GetNow();
+    if(now - last_ms < SERIAL_TX_INTERVAL_MS) return;
+    last_ms = now;
+    for(auto& o : serial_output_list)
+    {
+        if(o.value_ptr == nullptr) continue;
+        float v = *o.value_ptr;
+        if(!o.sent_once || fabsf(v - o.last_sent) > SERIAL_TX_EPSILON)
+        {
+            serial_send(o.channel, o.label, v);
+            o.last_sent = v;
+            o.sent_once = true;
+        }
+    }
+}
+
+// Create the ring buffers + assemblers and call serial_listener.addChannel()
+// for each UART used. Emitted by the parser (or hand-written for a manual test)
+// and inlined at the UI CONTROL TAG below.
+void serial_setup_channels();
+#endif // SERIAL
 
 
 // Do not remove following tag, as it is used by python to inline code
@@ -667,6 +1063,20 @@ struct shared_digi_output : public digi_output
 #include "faust/gui/UI.h"
 #include "faust/gui/DaisyControlUI.h"
 #include "faust/dsp/dsp.h"
+
+#ifdef USE_SOUNDFILE
+// Generated by faust2daisy : defines the Soundfile struct, 'defaultsound' and
+// all inlined sample data. Must be included before the DSP class (which
+// references Soundfile and defaultsound).
+#include "daisy_soundfile.hpp"
+#endif
+
+#ifdef USE_SD_SOUNDFILE
+// Runtime SD card soundfile loader (faust2daisy -sd) : defines the Soundfile
+// struct, 'defaultsound' and the FatFS loader. Must be included before the
+// DSP class (which references Soundfile and defaultsound).
+#include "daisy_sd_soundfile.hpp"
+#endif
 
 #ifdef MIDICTRL
 #include "faust/midi/daisy-midi.h"
@@ -725,6 +1135,7 @@ using namespace std;
     #endif
 #endif
 
+
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -769,6 +1180,11 @@ static DaisyControlUI control_UI;
 static void AudioCallback(daisy::AudioHandle::InputBuffer in, 
     daisy::AudioHandle::OutputBuffer out, size_t count)
 {
+    #if defined PATCHSM 
+        hw.ProcessAllControls();
+    #elif defined PATCH 
+        platform.ProcessAllControls();
+    #endif 
     // Update control inputs
     control_UI.update_adcs();
     
@@ -777,29 +1193,59 @@ static void AudioCallback(daisy::AudioHandle::InputBuffer in,
 
     // Update control outputs 
     control_UI.update_dacs();
+
 }
 
 int main(void)
 {
-
     // Initialize Daisy 
+#ifdef PATCH 
+    platform.Init();
+    platform.SetAudioBlockSize(MY_BUFFER_SIZE);
+    platform.SetAudioSampleRate(DAISY_SAMPLE_RATE);
+#else
     hw.Init();
     hw.SetAudioBlockSize(MY_BUFFER_SIZE);
     hw.SetAudioSampleRate(DAISY_SAMPLE_RATE);
+#endif
+
+    // For debug only
+    daisy::System::Delay(500);
+    hw.StartLog();
+    daisy::System::Delay(500);
+
+
+#ifdef SERIAL
+    init_serial_input_labels(); // fill the label -> value routing table
+    init_serial_outputs();      // fill the tx control label/channel table
+    serial_setup_channels();    // configure UARTs + start circular-DMA listening
+#endif
+
+#ifdef PWM
+    pwm_setup(); // init PWM timers + channels, wire up pwm_output_list
+#endif
 
 #ifdef MIDICTRL
     daisy_midi midi_handler;
 #endif
 
-    // For debug only
-    //daisy::System::Delay(500);
-    //hw.StartLog();
-    daisy::System::Delay(500);
-    
+#ifdef USE_SD_SOUNDFILE
+    // Load the soundfiles with the D-cache OFF. The SDMMC DMA fills an AXI-SRAM
+    // buffer whose cache is managed by libDaisy's sd_diskio.c using clean/
+    // invalidate rounded to 32 bytes; because the WAV data is not sector-aligned
+    // (chunks before 'data'), the read buffer is handed to DMA at unaligned
+    // offsets, leaving stale cache lines -> corrupted samples in SDRAM. Running
+    // the whole load uncached avoids any SDMMC-DMA cache coherency issue.
+    // Re-enabled after buildUserInterface (before audio starts).
+    SCB_DisableDCache();
+    // Mount the SD card and prepare 'defaultsound' before the DSP is built.
+    sd_soundfile_init();
+#endif
+
 /*
     DSP Initialization
 */
-#ifdef USE_SDRAM 
+#ifdef USE_SDRAM
     memory_manager.init();
     mydsp::fManager = &memory_manager;
     DSP.memoryCreate();
@@ -815,14 +1261,85 @@ int main(void)
     DSP.buildUserInterface(&control_UI);
     control_UI.setup_controls();
 
+#ifdef USE_SD_SOUNDFILE
+    // Soundfiles are now loaded; re-enable the D-cache for normal audio
+    // operation (the SDRAM arena is read-only from here on, so cached reads are
+    // coherent). Invalidate first so the audio callback sees SDRAM, not stale
+    // lines from the uncached load phase.
+    SCB_EnableDCache();
+
+#ifdef SD_SOUNDFILE_DEBUG
+    // Optional diagnostic: print the loaded soundfile's metadata and first
+    // samples over USB-serial, so they can be compared against the host file.
+    // Built with `faust2daisy -sd -sd-debug`. Open a terminal on /dev/ttyACM*.
+    hw.StartLog(false);
+    for (int t = 0; t < 50; t++) { // ~5 s so a terminal can attach after reset
+        if (sd_debug_last) {
+            Soundfile* s = sd_debug_last;
+            float** b = static_cast<float**>(s->fBuffers);
+            hw.PrintLine("SF mounted=%d ch=%d parts=%d len=%d sr=%d",
+                         (int)faust_sd_mounted, s->fChannels, s->fParts,
+                         s->fLength[0], s->fSR[0]);
+            hw.PrintLine("ch0 (x1e6): %d %d %d %d %d %d %d %d",
+                         (int)(b[0][0]*1e6f),(int)(b[0][1]*1e6f),(int)(b[0][2]*1e6f),(int)(b[0][3]*1e6f),
+                         (int)(b[0][4]*1e6f),(int)(b[0][5]*1e6f),(int)(b[0][6]*1e6f),(int)(b[0][7]*1e6f));
+            hw.PrintLine("ch1 (x1e6): %d %d %d %d %d %d %d %d",
+                         (int)(b[1][0]*1e6f),(int)(b[1][1]*1e6f),(int)(b[1][2]*1e6f),(int)(b[1][3]*1e6f),
+                         (int)(b[1][4]*1e6f),(int)(b[1][5]*1e6f),(int)(b[1][6]*1e6f),(int)(b[1][7]*1e6f));
+            // Full-buffer checksum (sum of all samples as int16) to verify the
+            // SDRAM data matches the host file regardless of the cache flush.
+            int32_t sum = 0;
+            for (int c = 0; c < s->fChannels; c++)
+                for (int i = 0; i < s->fLength[0]; i++)
+                    sum += (int32_t)(b[c][i] * 32768.0f);
+            hw.PrintLine("checksum(sum i16)=%d", (int)sum);
+        } else {
+            hw.PrintLine("SF not loaded (defaultsound), mounted=%d", (int)faust_sd_mounted);
+        }
+        daisy::System::Delay(100);
+    }
+#endif
+
+    // Startup SD status on the onboard LED (repeated 3x):
+    //   1 blink  = SD card did not mount (format FAT32? card inserted?)
+    //   2 blinks = mounted but no soundfile loaded (file missing/unsupported)
+    //   3 blinks = soundfile(s) loaded OK
+    {
+        int sd_code = !faust_sd_mounted ? 1 : (sd_total_frames == 0 ? 2 : 3);
+        for (int rep = 0; rep < 3; rep++) {
+            for (int b = 0; b < sd_code; b++) {
+                hw.SetLed(true);  daisy::System::Delay(150);
+                hw.SetLed(false); daisy::System::Delay(150);
+            }
+            daisy::System::Delay(500);
+        }
+    }
+#endif
+
     if(adc_list.size() > 0)
+    {
         hw.adc.Start();
-    hw.StartAudio(AudioCallback);
+    }
+
+    #ifdef PATCH 
+        platform.StartAudio(AudioCallback);
+    #else 
+        hw.StartAudio(AudioCallback);
+    #endif
 
     // MIDI handling loop
     while(1) {
         #ifdef MIDICTRL
             midi_handler.processMidi();
+        #endif
+        //daisy::System::Delay(5);
+        #ifdef PATCH 
+            platform.DisplayControls(false);
+        #endif
+
+        #ifdef SERIAL
+            serial_listener.poll(); // drain RX channels -> reassemble -> route
+            serial_tx_poll();       // transmit changed outputs (<=50Hz, on change)
         #endif
     }
 }

--- a/architecture/daisy/faust_daisy_parser.py
+++ b/architecture/daisy/faust_daisy_parser.py
@@ -1,10 +1,37 @@
 import json
-import sys 
+import os
+import sys
 import re
+
+## ADC's of Patch SM. 
+## This is necessary since the PatchSM class of libdaisy is more abstracted to fit CV requirementts
+# So we don't directly read ADC's, but read CV from PatchSM object, with those indexes.
+patchsm_pin_map = {
+    "C5": 0,
+    "C4": 1,
+    "C3": 2,
+    "C2": 3,
+    "C6": 4,
+    "C7": 5,
+    "C8": 6,
+    "C9": 7, 
+    "A2": 8,
+    "A3": 9, 
+    "D9": 10, 
+    "D8": 11,
+}    
+
+# Allow importing sibling modules regardless of the invocation cwd.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import daisy_soundfile_gen
+import daisy_uart_pins
+import daisy_pwm_pin
+import daisy_pins
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
+# Regex definitions for parsing the Faust DSP JSON layout and configuration files
 freg = re.compile("(fZone)")
 ireg = re.compile("(iZone)")
 voicereg = re.compile("nvoices:([0-9]+)")
@@ -13,8 +40,9 @@ itemreg = re.compile(".?(slider|button|checkbox|bargraph|nentry)")
 polyreg = re.compile("(freq|key|gain|vel|velocity|gate)")
 midiparse_reg = re.compile("(keyon|keyoff|key|ctrl)\\s+([0-9]+)\\s*([0-9]+)?")
 configparse_reg = re.compile("([a-zA-Z_]*):([AD][0-9]+)")
-dac_index_reg = re.compile("[AD]([0-9]+)")
+dac_index_reg = re.compile("[ACD]([0-9]+)")
 
+# Argument parsing
 project_dir = sys.argv[1]
 mem_threshold = int(sys.argv[2]) 
 nvoices = int(sys.argv[3])
@@ -22,6 +50,9 @@ use_sdram = int(sys.argv[4])
 archfile = sys.argv[5]
 config_file = sys.argv[6]
 
+# Soundfile mode : "qspi" (inline samples in QSPI, default) or "sd" (load from
+# the SD card /soundfiles folder at runtime).
+soundfile_mode = sys.argv[7] if len(sys.argv) > 7 else "qspi"
 
 arch = ""
 with open(archfile, 'r') as file:
@@ -47,6 +78,15 @@ config_layout = None
 config_ui = None
 config_midi = None
 midi_pins = {}
+# Default chip so 'chip' is always defined, even when no config file is passed
+# (config_file == "0"); the config below overrides it when present.
+chip = "seed"
+
+# Serial (UART) control link. Per-control pins come from [rx:Dx] / [tx:Dx]
+# metadata and are resolved by daisy_uart_pins; only the baud rate is global
+# (one bus speed for all channels).
+serial_baud = 115200
+
 if(config_file.isdigit() == False):
     f = open(config_file)
     conf_str = f.read()
@@ -67,6 +107,15 @@ if(config_file.isdigit() == False):
         elif(name == "patch"):
             print("PATCH=true")
             print("POD=false")
+    
+    if("serial" in config_layout):
+        config_serial_list = config_layout["serial"]
+        config_serial = {}
+        for elem in config_serial_list:
+            for key, value in elem.items():
+                config_serial[key] = value
+        if("baud" in config_serial):
+            serial_baud = int(config_serial["baud"])
     
     if("midi" in config_layout):
         config_midi_list = config_layout["midi"]
@@ -95,7 +144,6 @@ def get_control_type(item):
 
 def is_poly(label):
     return polyreg.match(label)
-
 
 class adc:
     def __init__(self):
@@ -127,8 +175,17 @@ class digi_out:
         self.step = 0
         self.pin_index = 0
         self.label = ""
-        self.pwm = False
-        self.pwm_mode = "inv"
+        self.softpwm = False  # [mode:softpwm] -> software PWM, else on/off
+
+class pwm_out:
+    def __init__(self):
+        self.label = ""
+        self.pin = ""
+        self.min = 0
+        self.max = 1
+        self.timer = ""      # "TIM_3" | "TIM_4" | "TIM_5"
+        self.channel = 0     # 1..4
+        self.index = 0
 
 class dac:
     def __init__(self):
@@ -169,6 +226,22 @@ class polyctrl:
         self.step = 0
         self.scale = "lin"
 
+class serial:
+    def __init__(self):
+        self.type = "serial"
+        self.label = ""
+        self.control_type = "slider"
+        self.init = 0
+        self.min = 0
+        self.max = 0
+        self.step = 0
+        self.scale = "lin"
+        self.pin = ""        # Daisy pin label, e.g. "D14"
+        self.direction = "rx"  # "rx" (receive) or "tx" (transmit)
+        self.index = 0         # index within serials_in / serials_out
+        self.channel = 0       # DaisyUartListener channel this control belongs to
+
+
 options = None
 for elem in meta:
     if("options" in elem):
@@ -188,9 +261,6 @@ poly = False
 if(nvoices > 1):
     poly = True
 
-
-
-
 class ui_scanner:
     def __init__(self):
         self.uicount = 0
@@ -202,6 +272,8 @@ class ui_scanner:
         self.digi_in_count = 0
         self.digi_out_count = 0
         self.dac_count = 0
+        self.serial_in_count = 0
+        self.serial_out_count = 0
         self.dac = [False, False]
         self.adcs = []
         self.dacs = []
@@ -209,10 +281,19 @@ class ui_scanner:
         self.polys = []
         self.digis_in = []
         self.digis_out = []
+        
+        self.serials_in = []
+        self.serials_out = []
+        self.serials_out_used = {} #
+        self.serials_in_used = {}
+
+        self.pwm_out_count = 0
+        self.pwms_out = []
+
         self.inputs = []
         self.outputs = []
         self.scale = "lin"
-        self.pwm = "off"
+        self.mode = ""  # gpio output rendering mode ("softpwm" or "")
         self.poly_keys = {
             "key": False,
             "freq": False,
@@ -239,9 +320,9 @@ class ui_scanner:
         label = node["label"]
         # For ADC DAC : type, index, label
         # For MIDI : type, miditype, key, channel, label  
-        reslist = [] 
+        reslist = []
         self.scale = "lin"
-        self.pwm = "off"
+        self.mode = ""
         if("meta" in node):
             for meta in node["meta"]:
                 for k, v in meta.items():
@@ -254,20 +335,36 @@ class ui_scanner:
                         if(config_res != None):
                             key = config_res[0]
                             value = config_res[1]
-
                     # Then create the meta to write
                     if(key == "adc"):
                         reslist.append("adc")
                         reslist.append(value)
+                        reslist.append(label)
                     elif(key == "dac"):
                         reslist.append("dac")
                         reslist.append(value)
-                        #dac_index_reg = re.compile("[AD]([0-9]+)")
                         dac_index_res = dac_index_reg.search(value)
-                        self.dac[dac_index_res.group(1)] = True;
+                        if(chip == "seed"):
+                            if(dac_index_res.group(1) == "7"):
+                                self.dac[0] = True
+                            elif(dac_index_res.group(1) == "8"):
+                                self.dac[1] = True
+                        elif(chip == "patchsm"):
+                            if(dac_index_res.group(1) == "1"):
+                                self.dac[0] = True
+                            elif(dac_index_res.group(1) == "10"):
+                                self.dac[1] = True
                     elif(key == "gpio"):
                         reslist.append("gpio")
                         reslist.append(value)
+                    elif(key == "rx" or key == "tx"):
+                        # Serial (UART) control: [rx:Dx] receives into an input
+                        # control, [tx:Dx] transmits an output control. 'value'
+                        # is the Daisy pin label.
+                        reslist.append("serial")
+                        reslist.append(key)    # direction: "rx" or "tx"
+                        reslist.append(value)  # pin label, e.g. "D14"
+                        reslist.append(label)  # control name
                     elif(key == "midi"):
                         reslist.append("midi")
                         res = midiparse_reg.search(meta[key])
@@ -290,8 +387,15 @@ class ui_scanner:
                     # Missing scales, and custom
                     elif(key == "scale"):
                         self.scale = meta[key]
+                    elif(key == "mode"):
+                        # Output rendering modifier on a [gpio:] output
+                        # (currently: "softpwm").
+                        self.mode = meta[key]
                     elif(key == "pwm"):
-                        self.pwm = meta[key]
+                        # Hardware PWM primary key: [pwm:PIN].
+                        reslist.append("pwm")
+                        reslist.append(value)
+
                     count += 1
             metaname = f"{label}_metadata"
             reslist.append(metaname)
@@ -310,10 +414,6 @@ class ui_scanner:
 
                     if(poly == True and is_poly(item_label)):
                         self.polys.append(polyctrl())
-                        #if(item_label == "freq"):
-                        #    item_label = "key"
-                        #elif(item_label == "gain" or item_label == "velocity"):
-                        #    item_label = "vel"
                         if(item_label == "vel" or item_label == "velocity"):
                             item_label = "vel"
                             self.poly_keys["vel"] = True
@@ -378,6 +478,8 @@ class ui_scanner:
                         self.outputs.append(output())
                         self.outputs[-1].type = "dac"
                         self.outputs[-1].index = self.dac_count
+                        self.dac_count += 1
+
                     elif(metares[0] == "gpio"):
                         if(item_type == "button" or item_type == "checkbox"):
                             self.digis_in.append(digi_in())
@@ -403,12 +505,77 @@ class ui_scanner:
                             self.digis_out[-1].max = 1
                             self.digis_out[-1].step = 1
                             self.digis_out[-1].init = 0
-                            self.digis_out[-1].pwm = self.pwm
+                            self.digis_out[-1].softpwm = (self.mode == "softpwm")
 
                             self.outputs.append(output())
                             self.outputs[-1].type = "digi_out"
                             self.outputs[-1].index = self.digi_out_count
                             self.digi_out_count += 1
+
+                    elif(metares[0] == "pwm"):
+                        # Hardware PWM output ([pwm:PIN] on a bargraph).
+                        if(item_type != "bargraph"):
+                            eprint("faust2daisy: [pwm:] is only valid on a bargraph (got %s)" % item_type)
+                            sys.exit(1)
+                        try:
+                            info = daisy_pwm_pin.resolve_pwm(chip, metares[1])
+                        except ValueError as e:
+                            eprint("faust2daisy pwm error: %s" % e)
+                            sys.exit(1)
+                        po = pwm_out()
+                        po.pin     = metares[1]
+                        po.label   = item_label
+                        po.min     = elem["min"]
+                        po.max     = elem["max"]
+                        po.timer   = info["timer"]
+                        po.channel = info["channel"]
+                        po.index   = self.pwm_out_count
+                        self.pwms_out.append(po)
+                        self.outputs.append(output())
+                        self.outputs[-1].type = "pwm"
+                        self.outputs[-1].index = self.pwm_out_count
+                        self.pwm_out_count += 1
+
+                    elif(metares[0] == "serial"):
+                        direction = metares[1]  # "rx" or "tx"
+                        pin       = metares[2]
+                        label     = metares[3]
+                        if(direction == "rx"):
+                            # Receive into an input control (slider/button/...).
+                            s = serial()
+                            s.label     = label
+                            s.pin       = pin
+                            s.direction = "rx"
+                            if(item_type == "button" or item_type == "checkbox"):
+                                s.control_type = item_type
+                                s.min = 0; s.max = 1; s.step = 1; s.init = 0
+                            else: # slider / nentry
+                                s.control_type = "slider"
+                                s.min = elem["min"]; s.max = elem["max"]
+                                s.step = elem["step"]; s.init = elem["init"]
+                            s.scale = self.scale
+                            s.index = self.serial_in_count
+                            self.serials_in.append(s)
+                            self.inputs.append(input())
+                            self.inputs[-1].type = "serial"
+                            self.inputs[-1].index = self.serial_in_count
+                            self.serial_in_count += 1
+                        else: # "tx" : transmit a bargraph value out. Lives in
+                              # output_list (so DaisyControlUI assigns its zone);
+                              # serial_tx_poll() sends it (throttled, on change).
+                            s = serial()
+                            s.label     = label
+                            s.pin       = pin
+                            s.direction = "tx"
+                            s.control_type = item_type
+                            s.min = elem["min"]; s.max = elem["max"]
+                            s.scale = self.scale
+                            s.index = self.serial_out_count
+                            self.serials_out.append(s)
+                            self.outputs.append(output())
+                            self.outputs[-1].type = "serial"
+                            self.outputs[-1].index = self.serial_out_count
+                            self.serial_out_count += 1
 
                     elif(metares[0] == "midi"):
                         self.midis.append(midi())
@@ -428,15 +595,18 @@ class ui_scanner:
                             self.midis[-1].max = 1
                             self.midis[-1].step = 1
                             self.midis[-1].init = 0
+                            self.adc_count += 1
                         elif(item_type == "slider" or item_type == "nentry"):
                             self.midis[-1].min = elem["min"]
                             self.midis[-1].max = elem["max"]
                             self.midis[-1].step = elem["step"]
                             self.midis[-1].init = elem["init"]
                             self.midis[-1].scale = self.scale
+                            self.adc_count += 1
+
 
                 if("items" in elem):
-                    self.recursive_lookup(elem) 
+                    self.recursive_lookup(elem, config_ui) 
     
 
     def exists_or_add(self, keys, index, cnt):
@@ -444,6 +614,43 @@ class ui_scanner:
             return keys[index]
         keys[index] = cnt
         return -1
+
+    def check_pin_conflicts(self):
+        # Each physical pin must be claimed by at most one control, EXCEPT
+        # serial (UART) pins: several [rx:PIN] controls share one RX pin, and
+        # several [tx:PIN] controls share one TX pin, so serial may repeat a
+        # pin. Any pin shared with a non-serial feature is a conflict.
+        # Pins are resolved to their physical MCU pin (daisy_pins) so aliases
+        # collide too (Seed A0 == D15, dac A7 == adc D22, ...); an unknown label
+        # falls back to comparing the label itself.
+        usage = {}  # physical pin -> list of (label, feature)
+
+        def add(pin, feature):
+            if pin is None or pin == "":
+                return
+            label = str(pin)
+            key = daisy_pins.physical(chip, label) or ("?" + label)
+            usage.setdefault(key, []).append((label, feature))
+
+        for a in self.adcs:        add(a.pin_index, "adc/cv-in")
+        for d in self.digis_in:    add(d.pin_index, "gpio-in")
+        for d in self.digis_out:   add(d.pin_index, "gpio-out")
+        for d in self.dacs:        add(d.channel,   "dac/cv-out")
+        for p in self.pwms_out:    add(p.pin,       "pwm")
+        for s in self.serials_in:  add(s.pin,       "serial")
+        for s in self.serials_out: add(s.pin,       "serial")
+
+        for key in sorted(usage):
+            claims = usage[key]
+            has_non_serial = any(f != "serial" for (_, f) in claims)
+            if len(claims) >= 2 and has_non_serial:
+                phys = key if not key.startswith("?") else "(unresolved)"
+                parts = ", ".join("%s [%s]" % (lbl, f) for (lbl, f) in claims)
+                eprint("faust2daisy pin conflict: physical pin %s is claimed by "
+                       "%d controls -- %s. Each pin may be used once; only "
+                       "serial rx/tx pins may be shared."
+                       % (phys, len(claims), parts))
+                sys.exit(1)
 
     def write(self, arch, layout, nvoices, config_midi):
         ccs_cnt = 0
@@ -462,6 +669,8 @@ class ui_scanner:
             if(elem.type == "keyoff"):
                 keyoffs_cnt += 1
 
+        if( len(self.midis) > 0):
+            print("MIDI=true")
 
         cc_used = {}
         key_used = {}
@@ -473,11 +682,13 @@ class ui_scanner:
         controlstr = f"#define N_INPUTS {n_inputs} \n"
         controlstr += f"#define N_OUTPUTS {n_outputs} \n\n"
         
-        if(config_midi["type"] == "uart"):
+        if(config_midi is None):
+            pass
+        elif(config_midi["type"] == "uart"):
             if("rx_pin" in config_midi):
-                controlstr += f"#define RX_PIN {config_midi["rx_pin"]} \n"
+                controlstr += f"#define RX_PIN {config_midi['rx_pin']} \n"
             if("tx_pin" in config_midi):
-                controlstr += f"#define TX_PIN {config_midi["tx_pin"]} \n"
+                controlstr += f"#define TX_PIN {config_midi['tx_pin']} \n"
         elif(config_midi["type"] == "usb"):
             if("peripheral" in config_midi and config_midi["peripheral"] == "external"):
                 controlstr += "#define MIDI_USB_PERIPH daisy::MidiUsbTransport::Config::Periph::EXTERNAL \n"
@@ -528,7 +739,7 @@ class ui_scanner:
                         midistr += f"\tmidi_input(adc::type_t::{elem.control_type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, &(midi_keyon[{ref_idx}])), \n"
                     elif(elem.type == "keyoff"):
                         ref_idx = self.exists_or_add(keyoff_used, elem.key, midicnt)
-                        midistr += f"\tmidi_input(adc::type_t::{elem.control_type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, &(midi_keyoffs[{ref_idx}])), \n"
+                        midistr += f"\tmidi_input(adc::type_t::{elem.control_type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, &(midi_keyoff[{ref_idx}])), \n"
                 if(res == -1):
                     midicnt += 1
 
@@ -614,34 +825,165 @@ class ui_scanner:
         controlstr += "#endif // MIDICTRL \n\n" 
 
 
-        ## Generate ADCs 
+        ## Serial (UART) controls : group by USART peripheral into channels.
+        if(len(self.serials_in) > 0 or len(self.serials_out) > 0):
+            print("SERIAL=true")
+            print(f"SERIAL_RX_INPUTS={len(self.serials_in)}")
+
+            # instance -> {"rx": entry, "tx": entry, "idx": channel index}
+            channels = {}
+            channel_order = []
+
+            def _serial_channel(direction, pin):
+                try:
+                    entry = daisy_uart_pins.resolve_uart(chip, pin, direction)
+                except ValueError as e:
+                    eprint(f"faust2daisy serial error: {e}")
+                    sys.exit(1)
+                inst = entry["instance"]
+                if inst not in channels:
+                    channels[inst] = {"rx": None, "tx": None,
+                                      "idx": len(channel_order)}
+                    channel_order.append(inst)
+                channels[inst][direction] = entry
+                return channels[inst]["idx"]
+
+            for s in self.serials_in:
+                s.channel = _serial_channel("rx", s.pin)
+            for s in self.serials_out:
+                s.channel = _serial_channel("tx", s.pin)
+
+            # serial_in control objects + label routing table
+            if(len(self.serials_in) > 0):
+                # Shared (poly) variant fans one received value out to all voices.
+                serial_in_t = "serial_in" if nvoices < 2 else f"shared_serial_in<{nvoices}>"
+                controlstr += f"static std::array<{serial_in_t}, {len(self.serials_in)}> serial_input_list = {{\n"
+                labels = "void init_serial_input_labels()\n{\n"
+                count = 0
+                for s in self.serials_in:
+                    controlstr += f"\t{serial_in_t}(adc::type_t::{s.control_type}, {s.init}, {s.min}, {s.max}, {s.step}, scale::scale_t::{s.scale}, {count} ),\n"
+                    labels += f"\tserial_input_labels[{count}] = string_view{{\"{s.label}\", {len(s.label)} }};\n"
+                    count += 1
+                controlstr += "};\n\n"
+                labels += "}\n\n"
+                controlstr += labels
+            else:
+                controlstr += "void init_serial_input_labels() {}\n\n"
+
+            # serial_setup_channels(): one UART channel per peripheral, RX and/or
+            # TX, each RX channel with its own DMA ring + line assembler.
+            setup = "void serial_setup_channels()\n{\n"
+            for inst in channel_order:
+                ch  = channels[inst]
+                idx = ch["idx"]
+                rx  = ch["rx"]
+                tx  = ch["tx"]
+                if rx is not None:
+                    setup += f"\tstatic uint8_t DMA_BUFFER_MEM_SECTION serial_ring_{idx}[SERIAL_RING_SIZE];\n"
+                    setup += f"\tstatic serial_line_assembler serial_asm_{idx};\n"
+                setup += "\t{\n"
+                setup += "\t\tDaisyUartListener::ChannelConfig c = {};\n"
+                setup += f"\t\tc.instance = {inst}; c.baud = {serial_baud};\n"
+                if rx is not None:
+                    setup += f"\t\tc.dmaRxRequest = {rx['dma_req']};\n"
+                    setup += f"\t\tc.rxPort = {rx['port']}; c.rxPin = {rx['pin']}; c.rxAltFunc = {rx['af']};\n"
+                    setup += f"\t\tc.ring = serial_ring_{idx}; c.ringSize = sizeof(serial_ring_{idx});\n"
+                    setup += f"\t\tc.onReceive = serial_on_bytes; c.context = &serial_asm_{idx};\n"
+                if tx is not None:
+                    setup += f"\t\tc.txPort = {tx['port']}; c.txPin = {tx['pin']}; c.txAltFunc = {tx['af']};\n"
+                setup += "\t\tserial_listener.addChannel(c);\n"
+                setup += "\t}\n"
+            setup += "}\n\n"
+            controlstr += setup
+
+            # tx controls: init_serial_outputs() fills the template-defined
+            # serial_output_list[] (label + channel) for serial_tx_poll().
+            print(f"SERIAL_TX_OUTPUTS={len(self.serials_out)}")
+            outs = "void init_serial_outputs()\n{\n"
+            for s in self.serials_out:
+                outs += f"\tserial_output_list[{s.index}].label = \"{s.label}\"; serial_output_list[{s.index}].channel = {s.channel};\n"
+            outs += "}\n\n"
+            controlstr += outs
+
+        ## Generate ADCs
             
         if(nvoices < 2):
             controlstr += f"static std::array<adc, {len(self.adcs)}> adc_list = {{ \n"
         else:
             controlstr += f"static std::array<shared_adc<{nvoices}>, {len(self.adcs)}> adc_list = {{ \n"
         if(len(self.adcs) > 0):
+            prefix = ""
             for elem in self.adcs:
                 if(nvoices < 2):
-                    controlstr += f"\tadc(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, {elem.pin_index}), \n"
+                    if(chip == "seed"):
+                        controlstr += f"\tadc(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, {elem.pin_index}), \n"
+                    elif(chip == "patchsm"):
+                        pin = patchsm_pin_map.get(elem.pin_index)
+                        if(pin == None): 
+                            eprint(f"Error : the analog pin {elem.pin_index} does not exist in PatchSM")
+                            sys.exit(1)
+                        controlstr += f"\tadc(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, {pin}), \n"
                 else: 
-                    controlstr += f"\tshared_adc<{nvoices}>(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, {elem.pin_index}), \n"
+                    if(chip == "seed"): 
+                        controlstr += f"\tshared_adc<{nvoices}>(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, {elem.pin_index}), \n"
+                    elif(chip == "patchsm"):
+                        pin = patchsm_pin_map.get(elem.pin_index)
+                        if(pin == None): 
+                            eprint(f"Error : the analog pin {elem.pin_index} does not exist in PatchSM")
+                            sys.exit(1)
+                        controlstr += f"\tshared_adc<{nvoices}>(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, scale::scale_t::{elem.scale}, {pin}), \n"
         controlstr += "}; \n"
-        controlstr += f"std::array<daisy::AdcChannelConfig, {len(self.adcs)}> adc_config_list; \n\n"
+
+        # Assign each ADC to a hardware DMA channel. With a platform config (e.g.
+        # Daisy Patch), order the channels by the platform control number
+        # (CV_in:N / knob:N) so that DMA channel i corresponds to physical knob
+        # i+1. This matches the platform's own control order (libDaisy
+        # DisplayControls, platform.controls[]...), which reads by channel index.
+        # Without a config we keep the Faust emission order (identity mapping).
+        def _platform_channel(pin):
+            if config_ui is None:
+                return None
+            target = "adc:" + str(pin)
+            for elem in config_ui:
+                for k, v in elem.items():
+                    if v == target:
+                        m = re.search(r":([0-9]+)$", k)
+                        if m:
+                            return int(m.group(1)) - 1
+            return None
+
+        platform_channels = []
+        if config_ui is not None and chip == "seed":
+            platform_channels = [_platform_channel(e.pin_index) for e in self.adcs]
+        # Use the platform order only if it is a clean 1:1 mapping (every ADC
+        # resolved and no duplicates); otherwise fall back to emission order so
+        # we never create gaps/collisions in the channel list.
+        if (len(platform_channels) != len(self.adcs)
+                or any(pc is None for pc in platform_channels)
+                or len(set(platform_channels)) != len(platform_channels)):
+            platform_channels = list(range(len(self.adcs)))
+        n_channels = (max(platform_channels) + 1) if len(platform_channels) > 0 else 0
+
+        controlstr += f"static std::array<uint8_t, {len(self.adcs)}> adc_platform_channel = {{ {', '.join(str(pc) for pc in platform_channels)} }}; \n"
+        controlstr += f"std::array<daisy::AdcChannelConfig, {n_channels}> adc_config_list; \n\n"
 
         if(nvoices < 2):
             controlstr += f"static std::array<digi_input, {len(self.digis_in)}> digi_input_list {{\n"
         else: 
             controlstr += f"static std::array<shared_digi_input<{nvoices}>, {len(self.digis_in)}> digi_input_list {{\n"
         if(len(self.digis_in) > 0):
+            prefix = ""
+            eprint("CHIP = ", chip)
+            if(chip == "patchsm"): 
+                prefix = "daisy::patch_sm::DaisyPatchSM::"
             for elem in self.digis_in:
                 if(nvoices < 2):
-                    controlstr += f"\tdigi_input(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, {elem.pin_index}), \n"
+                    controlstr += f"\tdigi_input(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, {prefix}{elem.pin_index}), \n"
                 else:
-                    controlstr += f"\tshared_digi_input<{nvoices}>(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, {elem.pin_index}), \n"
+                    controlstr += f"\tshared_digi_input<{nvoices}>(adc::type_t::{elem.type}, {elem.init}, {elem.min}, {elem.max}, {elem.step}, {prefix}{elem.pin_index}), \n"
         controlstr += "}; \n\n"
 
-        input_len = (len(self.adcs) + len(self.midis) + len(self.digis_in)) 
+        input_len = (len(self.adcs) + len(self.midis) + len(self.digis_in) + len(self.serials_in))
         if(poly):
             input_len = (input_len + len(self.polys)) * nvoices
         inputstr = f"static std::array<control *, {input_len}> input_list = {{ \n"
@@ -658,6 +1000,8 @@ class ui_scanner:
                     inputstr += f"\t&adc_list[{elem.index}], \n"
                 elif(elem.type == "digi_in"):
                     inputstr += f"\t&digi_input_list[{elem.index}], \n"
+                elif(elem.type == "serial"):
+                    inputstr += f"\t&serial_input_list[{elem.index}], \n"
                 elif(elem.type == "poly"):
                     inputstr += f"\tpoly_inputs[{voice_counter}].get_{self.polys[poly_index].label}(), \n"
                     poly_index = (poly_index + 1) % len(self.polys)
@@ -672,6 +1016,8 @@ class ui_scanner:
                     inputstr += f"\t&adc_list[{elem.index}], \n"
                 elif(elem.type == "digi_in"):
                     inputstr += f"\t&digi_input_list[{elem.index}], \n"
+                elif(elem.type == "serial"):
+                    inputstr += f"\t&serial_input_list[{elem.index}], \n"
         
         inputstr += "}; \n\n"
         controlstr += inputstr
@@ -682,7 +1028,10 @@ class ui_scanner:
             controlstr += "constexpr bool dacs_used = true; \n"
         else:
             controlstr += "constexpr bool dacs_used = false; \n"
-            controlstr += "static const daisy::DacHandle::Channel dac_chnls = daisy::DacHandle::Channel::BOTH; // dummy \n"
+            if(chip == "seed"):
+                controlstr +=  "static const daisy::DacHandle::Channel dac_chnls = daisy::DacHandle::Channel::BOTH; // dummy \n" 
+            else: 
+                controlstr += "static constexpr uint8_t dac_chnls = daisy::patch_sm::CV_OUT_BOTH; // dummy \n"
 
         if(nvoices < 2):
             controlstr += f"static std::array<dac, {len(self.dacs)}> dac_list = {{ \n"
@@ -690,35 +1039,90 @@ class ui_scanner:
             controlstr += f"static std::array<shared_dac<{nvoices}>, {len(self.dacs)}> dac_list = {{ \n"
         if(len(self.dacs) > 0):
             for elem in self.dacs:
-                if(elem.channel == 1):
-                    last_chn = "daisy::DacHandle::Channel::ONE"
-                elif(elem.channel == 2):
-                    last_chn = "daisy::DacHandle::Channel::TWO"
-                if(nvoices < 2):
-                    controlstr += f"\tdac({last_chn}, {elem.min}, {elem.max}, scale::scale_t::{elem.scale} ), \n"
-                else:
-                    controlstr += f"\tshared_dac<{nvoices}>({last_chn}, {elem.min}, {elem.max}, scale::scale_t::{elem.scale} ), \n"
+                if(chip == "seed"): 
+                    if(elem.channel == "A7"):
+                        last_chn = "daisy::DacHandle::Channel::ONE" 
+                    elif(elem.channel == "A8"):
+                        last_chn = "daisy::DacHandle::Channel::TWO" 
+                    else: 
+                        eprint("DACs channels for Daisy Seed must be A7 or A8")
+                        sys.exit(1)
+                    if(nvoices < 2):
+                        controlstr += f"\tdac({last_chn}, {elem.min}, {elem.max}, scale::scale_t::{elem.scale} ), \n"
+                    else:
+                        controlstr += f"\tshared_dac<{nvoices}>({last_chn}, {elem.min}, {elem.max}, scale::scale_t::{elem.scale} ), \n"
+                elif(chip == "patchsm"):
+                    if(elem.channel == "C1"): 
+                        last_chn = "daisy::patch_sm::CV_OUT_1"
+                    elif(elem.channel == "C10"):
+                        last_chn = "daisy::patch_sm::CV_OUT_2"
+                    else:
+                        eprint("DACs channels for Daisy PatchSM must be C1 or C10")
+                        sys.exit(1)
+                    if(nvoices < 2):
+                        controlstr += f"\tdac({last_chn}, {elem.min}, {elem.max}, scale::scale_t::{elem.scale} ), \n"
+                    else:
+                        controlstr += f"\tshared_dac<{nvoices}>({last_chn}, {elem.min}, {elem.max}, scale::scale_t::{elem.scale} ), \n"
 
         controlstr += "}; \n"
         if(len(self.dacs) > 0):
             if(len(self.dacs) == 2):
-                controlstr += "daisy::DacHandle::Channel dac_chnls = daisy::DacHandle::Channel::BOTH; \n"
+                if(chip == "seed"): 
+                    controlstr += "static constexpr daisy::DacHandle::Channel dac_chnls = daisy::DacHandle::Channel::BOTH; \n" 
+                elif(chip == "patchsm"):
+                    controlstr += "static constexpr uint8_t dac_chnls = daisy::patch_sm::CV_OUT_BOTH; // dummy \n"
             else:
-                controlstr += f"daisy::DacHandle::Channel dac_chnls = {last_chn}; \n"
+                if(chip == "seed"):
+                    controlstr += f"static constexpr daisy::DacHandle::Channel dac_chnls = {last_chn}; \n"
+                elif(chip == "patchsm"):
+                    controlstr += f"static constexpr uint8_t dac_chnls = {last_chn}; \n"
             
-        
-
         if(nvoices < 2):
             controlstr += f"static std::array<digi_output, {len(self.digis_out)}> digi_output_list = {{ \n"
         else:
             controlstr += f"static std::array<shared_digi_output<{nvoices}>, {len(self.digis_out)}> digi_output_list = {{ \n"
+        prefix = ""
+        if(chip == "patchsm"): 
+            prefix = "daisy::patch_sm::DaisyPatchSM::"
         for elem in self.digis_out:
+            softpwm = "true" if elem.softpwm else "false"
             if(nvoices < 2):
-                controlstr += f"\tdigi_output({elem.pin_index}, digi_output::pwm_t::{elem.pwm}), \n"
+                controlstr += f"\tdigi_output({prefix}{elem.pin_index}, {softpwm}), \n"
             else:
-                controlstr += f"\tshared_digi_output<{nvoices}>({elem.pin_index}, digi_output::pwm_t::{pwm}), \n"
+                controlstr += f"\tshared_digi_output<{nvoices}>({prefix}{elem.pin_index}, {softpwm}), \n"
         controlstr += "}; \n\n"
-            
+
+        ## Hardware PWM outputs : group [pwm:PIN] controls by timer, one
+        ## PWMHandle per timer, and wire each channel to pwm_output_list.
+        if(len(self.pwms_out) > 0):
+            print("PWM=true")
+            print(f"PWM_OUTPUTS={len(self.pwms_out)}")
+            pwm_prefix = "daisy::patch_sm::DaisyPatchSM::" if chip == "patchsm" else ""
+            pwm_timers = []
+            for po in self.pwms_out:
+                if po.timer not in pwm_timers:
+                    pwm_timers.append(po.timer)
+            for t in pwm_timers:
+                controlstr += f"static daisy::PWMHandle pwm_handle_{t.lower()};\n"
+            controlstr += "\nvoid pwm_setup()\n{\n"
+            for t in pwm_timers:
+                controlstr += "\t{\n"
+                controlstr += "\t\tdaisy::PWMHandle::Config cfg;\n"
+                controlstr += f"\t\tcfg.periph = daisy::PWMHandle::Config::Peripheral::{t};\n"
+                controlstr += "\t\tcfg.prescaler = 0; cfg.period = 8192;\n"
+                controlstr += f"\t\tpwm_handle_{t.lower()}.Init(cfg);\n"
+                controlstr += "\t}\n"
+            for po in self.pwms_out:
+                h = f"pwm_handle_{po.timer.lower()}"
+                controlstr += "\t{\n"
+                controlstr += "\t\tdaisy::PWMHandle::Channel::Config chcfg;\n"
+                controlstr += f"\t\tchcfg.pin = {pwm_prefix}{po.pin};\n"
+                controlstr += f"\t\t{h}.Channel{po.channel}().Init(chcfg);\n"
+                controlstr += f"\t\tpwm_output_list[{po.index}].channel = &{h}.Channel{po.channel}();\n"
+                controlstr += f"\t\tpwm_output_list[{po.index}].min = {po.min};\n"
+                controlstr += f"\t\tpwm_output_list[{po.index}].max = {po.max};\n"
+                controlstr += "\t}\n"
+            controlstr += "}\n\n"
 
         outputstr = f"static std::array<control *, {len(self.outputs)}> output_list = {{ \n"
         for elem in self.outputs:
@@ -726,14 +1130,21 @@ class ui_scanner:
                 outputstr += f"\t&(dac_list[{elem.index}]), \n"
             elif(elem.type == "digi_out"):
                 outputstr += f"\t&(digi_output_list[{elem.index}]), \n"
+            elif(elem.type == "serial"):
+                outputstr += f"\t&(serial_output_list[{elem.index}]), \n"
+            elif(elem.type == "pwm"):
+                outputstr += f"\t&(pwm_output_list[{elem.index}]), \n"
         outputstr += "}; \n\n"
 
-        controlstr += outputstr 
+        controlstr += outputstr
         return arch.replace(control_tag, controlstr)
 
 if("ui" in dsp_layout):
     scan = ui_scanner()
-    scan.recursive_lookup(dsp_layout["ui"][0], config_ui)
+    for elem in dsp_layout["ui"]:
+        scan.recursive_lookup(elem, config_ui)
+        #scan.recursive_lookup(dsp_layout["ui"][0], config_ui)
+    scan.check_pin_conflicts()
     arch = scan.write(arch, dsp_layout, nvoices, config_midi)
     
 
@@ -755,6 +1166,32 @@ if(use_sdram):
     
     sdram_content = "#define FAUST_SDRAM_SIZE_BYTES " + str(total_bytes) + "\n";
     arch = arch.replace(sdram_tag, sdram_content);
+
+
+### Soundfile primitive support
+# Look for "soundfile" widgets in the UI. If any, parse the referenced WAV
+# files and inline them into daisy_soundfile.hpp, then tell the bash script
+# (via USE_SOUNDFILE) to add the matching #define.
+soundfiles = daisy_soundfile_gen.scan_soundfiles(dsp_layout)
+if len(soundfiles) > 0:
+    if soundfile_mode == "sd":
+        # Samples are loaded from the SD card at runtime: nothing to inline,
+        # just enable the SD reader in the architecture.
+        print("USE_SD_SOUNDFILE=true")
+        # Size the SDRAM arena to the referenced WAVs (if available at build
+        # time); otherwise the architecture default is used.
+        search_dirs = list(dict.fromkeys(
+            [os.path.dirname(os.path.abspath(project_dir)), os.getcwd()]))
+        arena = daisy_soundfile_gen.compute_sd_arena_bytes(soundfiles, search_dirs)
+        if arena is not None:
+            print("SD_SOUNDFILE_BYTES=%d" % arena)
+    else:
+        # WAV files are resolved relative to the DSP source directory and the cwd.
+        search_dirs = list(dict.fromkeys(
+            [os.path.dirname(os.path.abspath(project_dir)), os.getcwd()]))
+        header_path = project_dir + "/daisy_soundfile.hpp"
+        if daisy_soundfile_gen.generate_header(soundfiles, search_dirs, header_path):
+            print("USE_SOUNDFILE=true")
 
 
 arch_dest = project_dir + "/daisy_arch.cpp"

--- a/architecture/daisy/patch.json
+++ b/architecture/daisy/patch.json
@@ -13,7 +13,7 @@
         "CV_in:1": "adc:A0",
         "CV_in:2": "adc:A1",
         "CV_in:3": "adc:A6",
-        "CV_int:4": "adc:A3",
+        "CV_in:4": "adc:A3",
         "CV_out:1": "dac:A8",
         "CV_out:2": "dac:A7",
         "gate_in:1": "gpio:D20",

--- a/architecture/daisy/sd_upload.py
+++ b/architecture/daisy/sd_upload.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# ---------------------------------------------------------------------
+# faust2daisy : host-side soundfile uploader
+#
+# Streams the WAV files referenced by a Faust DSP to the Daisy SD card, into a
+# "/soundfiles" folder, talking to the sd_uploader firmware over USB-serial
+# (CDC). Standard library only (no pyserial dependency): the serial port is
+# driven directly through termios in raw mode.
+#
+# Usage:
+#   sd_upload.py <dsp.json> <search_dir>[,<search_dir>...] [--port /dev/ttyACMx] [--no-clear]
+# ---------------------------------------------------------------------
+
+import os
+import sys
+import glob
+import time
+import select
+import termios
+
+# Allow importing the sibling module regardless of the invocation cwd.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import daisy_soundfile_gen as sfgen
+
+CHUNK = 32768            # must match CHUNK in sd_uploader.cpp
+ACK_TIMEOUT = 15.0       # seconds to wait for a device reply
+
+
+def eprint(*args):
+    print(*args, file=sys.stderr)
+
+
+def fail(msg):
+    eprint("faust2daisy sd-upload error : %s" % msg)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------
+# Serial port (raw termios, no pyserial)
+# ---------------------------------------------------------------------
+
+def find_port():
+    for pattern in ("/dev/ttyACM*", "/dev/cu.usbmodem*", "/dev/tty.usbmodem*"):
+        matches = sorted(glob.glob(pattern))
+        if matches:
+            return matches[0]
+    return None
+
+
+def open_port(dev):
+    fd = os.open(dev, os.O_RDWR | os.O_NOCTTY)
+    attrs = termios.tcgetattr(fd)
+    iflag, oflag, cflag, lflag, ispeed, ospeed, cc = attrs
+    # Raw mode: no input/output processing, no echo, no canonical line handling.
+    iflag = 0
+    oflag = 0
+    lflag = 0
+    cflag = (cflag | termios.CLOCAL | termios.CREAD | termios.CS8) & ~termios.CSIZE | termios.CS8
+    cc = list(cc)
+    cc[termios.VMIN] = 0
+    cc[termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, [iflag, oflag, cflag, lflag, ispeed, ospeed, cc])
+    termios.tcflush(fd, termios.TCIOFLUSH)
+    return fd
+
+
+def write_all(fd, data):
+    mv = memoryview(data)
+    while mv:
+        n = os.write(fd, mv[:65536])
+        if n <= 0:
+            fail("serial write failed")
+        mv = mv[n:]
+
+
+def read_line(fd, timeout=ACK_TIMEOUT):
+    buf = bytearray()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        remaining = deadline - time.time()
+        r, _, _ = select.select([fd], [], [], max(0.0, remaining))
+        if not r:
+            continue
+        b = os.read(fd, 1)
+        if not b:
+            continue
+        if b == b'\n':
+            return buf.decode(errors='replace').strip()
+        if b != b'\r':
+            buf += b
+    return None
+
+
+def expect_ok(fd, context):
+    line = read_line(fd)
+    if line is None:
+        fail("timed out waiting for device reply (%s)" % context)
+    if not line.startswith("OK"):
+        fail("device reported '%s' (%s)" % (line, context))
+
+
+# ---------------------------------------------------------------------
+# Resolve the WAV files referenced by the DSP
+# ---------------------------------------------------------------------
+
+def collect_files(json_path, search_dirs):
+    with open(json_path) as f:
+        import json
+        layout = json.load(f)
+    soundfiles = sfgen.scan_soundfiles(layout)
+    files = []
+    seen = set()
+    for label, url in soundfiles:
+        for name in sfgen.parse_url(url):
+            resolved = sfgen.resolve_file(name, search_dirs)
+            if resolved is None:
+                fail("file '%s' (from soundfile '%s') not found in: %s"
+                     % (name, label, ", ".join(search_dirs)))
+            key = os.path.basename(resolved)
+            if key not in seen:
+                seen.add(key)
+                files.append((key, resolved))
+    return files
+
+
+def main():
+    args = sys.argv[1:]
+    port = None
+    do_clear = True
+    positional = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--port":
+            i += 1
+            port = args[i]
+        elif a == "--no-clear":
+            do_clear = False
+        else:
+            positional.append(a)
+        i += 1
+
+    if len(positional) < 2:
+        fail("usage: sd_upload.py <dsp.json> <search_dir>[,<dir>...] [--port DEV] [--no-clear]")
+
+    json_path = positional[0]
+    search_dirs = positional[1].split(",")
+
+    files = collect_files(json_path, search_dirs)
+    if not files:
+        print("No soundfiles referenced by the DSP, nothing to upload.")
+        return
+
+    if port is None:
+        port = find_port()
+        if port is None:
+            fail("no serial port found (looked for /dev/ttyACM*, /dev/cu.usbmodem*). "
+                 "Is the SD uploader firmware running and the Daisy connected?")
+
+    print("Uploading %d soundfile(s) to /soundfiles via %s" % (len(files), port))
+    fd = open_port(port)
+    try:
+        # Handshake with retries (the device may still be re-enumerating right
+        # after the uploader firmware was flashed). Also confirms the SD mount.
+        acked = False
+        for _ in range(10):
+            termios.tcflush(fd, termios.TCIFLUSH)
+            write_all(fd, b"PING\n")
+            line = read_line(fd, timeout=1.5)
+            if line is not None:
+                if not line.startswith("OK"):
+                    fail("device reported '%s' (ping / SD mount). "
+                         "Is an SD card inserted?" % line)
+                acked = True
+                break
+        if not acked:
+            fail("no response from device on %s. Is the SD uploader firmware "
+                 "running?" % port)
+
+        if do_clear:
+            write_all(fd, b"CLEAR\n")
+            expect_ok(fd, "clear /soundfiles")
+            print("  cleared /soundfiles")
+
+        for name, path in files:
+            data = open(path, "rb").read()
+            write_all(fd, ("FILE %d %s\n" % (len(data), name)).encode())
+            expect_ok(fd, "open %s" % name)
+            offset = 0
+            while offset < len(data):
+                chunk = data[offset:offset + CHUNK]
+                write_all(fd, chunk)
+                expect_ok(fd, "%s @%d" % (name, offset))
+                offset += len(chunk)
+            print("  uploaded %s (%d bytes)" % (name, len(data)))
+
+        write_all(fd, b"DONE\n")
+        expect_ok(fd, "done")
+    finally:
+        os.close(fd)
+    print("SD upload complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/architecture/daisy/sd_uploader.cpp
+++ b/architecture/daisy/sd_uploader.cpp
@@ -1,0 +1,262 @@
+/************************************************************************
+ FAUST Architecture File - Daisy SD card soundfile uploader
+ Copyright (C) 2020-2026 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+/*
+ * A small firmware that turns the Daisy into a USB-serial (CDC) endpoint for
+ * uploading soundfiles to the SD card. It is flashed temporarily by
+ * `faust2daisy -upload-sd`, which then streams the WAV files referenced by a
+ * DSP into the "/soundfiles" folder. It never touches anything else on the card.
+ *
+ * Protocol (host -> device, line terminated by '\n'; device replies one line):
+ *   PING               -> "OK"
+ *   CLEAR              -> delete every file in /soundfiles (create it if needed), "OK"
+ *   FILE <size> <name> -> open /soundfiles/<name> for writing, "OK"
+ *                         then the host streams <size> raw bytes, in chunks of
+ *                         CHUNK; the device replies "OK" after every CHUNK (and
+ *                         after the final remainder) for flow control.
+ *   DONE               -> "OK"
+ *   on any failure the device replies "ERR <reason>".
+ */
+
+#include "daisy_seed.h"
+#include "fatfs.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+using namespace daisy;
+
+static DaisySeed      hw;
+static SdmmcHandler   sdmmc;
+static FatFSInterface fsi;
+static FIL            file;
+static FRESULT        mount_res = FR_NOT_READY; // last f_mount result (for diagnostics)
+
+// Flow-control chunk size: the host waits for an "OK" after each CHUNK bytes.
+static constexpr uint32_t CHUNK = 32768;
+
+// USB RX ring buffer (filled in the USB IRQ callback, drained in main()).
+// Must comfortably hold one in-flight chunk plus USB buffering.
+static constexpr uint32_t RING_SIZE = 1 << 16; // 64 KB, power of two
+static uint8_t            ring[RING_SIZE];
+static volatile uint32_t  ring_head = 0; // written by IRQ
+static volatile uint32_t  ring_tail = 0; // read by main
+
+static void UsbRx(uint8_t* buf, uint32_t* len)
+{
+    uint32_t n = *len;
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t next = (ring_head + 1) & (RING_SIZE - 1);
+        if (next == ring_tail) break; // overflow (should not happen with flow control)
+        ring[ring_head] = buf[i];
+        ring_head       = next;
+    }
+}
+
+static inline bool ring_empty()
+{
+    return ring_head == ring_tail;
+}
+
+static inline uint8_t ring_pop()
+{
+    uint8_t b = ring[ring_tail];
+    ring_tail = (ring_tail + 1) & (RING_SIZE - 1);
+    return b;
+}
+
+static void reply(const char* s)
+{
+    hw.usb_handle.TransmitInternal((uint8_t*)s, strlen(s));
+}
+
+// Block until a full '\n'-terminated line is received. '\r' is ignored.
+static void read_line(char* out, size_t maxlen)
+{
+    size_t i = 0;
+    while (true) {
+        while (ring_empty()) {}
+        uint8_t b = ring_pop();
+        if (b == '\n') {
+            out[i] = 0;
+            return;
+        }
+        if (b == '\r') continue;
+        if (i < maxlen - 1) out[i++] = b;
+    }
+}
+
+// Delete every regular file in /soundfiles, creating the folder if absent.
+static FRESULT clear_soundfiles()
+{
+    FRESULT fr = f_mkdir("soundfiles");
+    if (fr != FR_OK && fr != FR_EXIST) return fr;
+
+    DIR     dir;
+    FILINFO fno;
+    fr = f_opendir(&dir, "soundfiles");
+    if (fr != FR_OK) return fr;
+
+    while (true) {
+        fr = f_readdir(&dir, &fno);
+        if (fr != FR_OK || fno.fname[0] == 0) break; // error or end of dir
+        if (fno.fattrib & AM_DIR) continue;          // keep sub-directories
+        char path[300];
+        snprintf(path, sizeof(path), "soundfiles/%s", fno.fname);
+        f_unlink(path);
+    }
+    f_closedir(&dir);
+    return FR_OK;
+}
+
+// Receive 'size' bytes from the host and write them to the open file, replying
+// "OK" after every CHUNK (and after the final remainder). Returns true on success.
+// SD write buffer. MUST be static (AXI SRAM), not on the stack: on the STM32H7
+// the stack is in DTCMRAM, which the SDMMC IDMA cannot access -> writes fail.
+// 32-byte aligned so the D-cache clean/invalidate in sd_diskio.c does not touch
+// neighbouring data.
+static uint8_t __attribute__((aligned(32))) sd_write_buf[512];
+
+static bool receive_file(uint32_t size)
+{
+    uint32_t remaining = size;
+    uint32_t chunk_acc = 0;
+    uint8_t* tmp       = sd_write_buf;
+
+    // Empty file: nothing to stream, but acknowledge the (single) chunk.
+    if (size == 0) {
+        reply("OK\n");
+        return true;
+    }
+
+    while (remaining > 0) {
+        uint32_t want = (remaining < sizeof(sd_write_buf)) ? remaining : sizeof(sd_write_buf);
+        uint32_t k    = 0;
+        while (k < want) {
+            if (ring_empty()) continue; // wait for more USB data
+            tmp[k++] = ring_pop();
+        }
+        UINT    bw = 0;
+        FRESULT wr = f_write(&file, tmp, k, &bw);
+        if (wr != FR_OK || bw != k) {
+            char msg[48];
+            snprintf(msg, sizeof(msg), "ERR write=%d bw=%u/%u\n", (int)wr,
+                     (unsigned)bw, (unsigned)k);
+            reply(msg);
+            return false;
+        }
+        remaining -= k;
+        chunk_acc += k;
+        if (remaining == 0 || chunk_acc >= CHUNK) {
+            f_sync(&file);
+            reply("OK\n");
+            chunk_acc = 0;
+        }
+    }
+    return true;
+}
+
+int main(void)
+{
+    hw.Init();
+
+    // Mount the SD card, trying a ladder of clock speeds and bus widths
+    // (fastest first). Boards with longer SD traces, e.g. the Daisy Patch,
+    // often need a slower clock and/or 1-bit mode (FR_DISK_ERR at 25 MHz).
+    FatFSInterface::Config fsi_cfg;
+    fsi_cfg.media = FatFSInterface::Config::MEDIA_SD;
+    const SdmmcHandler::Speed speeds[] = {SdmmcHandler::Speed::STANDARD,
+                                          SdmmcHandler::Speed::MEDIUM_SLOW,
+                                          SdmmcHandler::Speed::SLOW};
+    const SdmmcHandler::BusWidth widths[] = {SdmmcHandler::BusWidth::BITS_4,
+                                             SdmmcHandler::BusWidth::BITS_1};
+    bool done = false;
+    for (unsigned si = 0; si < 3 && !done; si++) {
+        for (unsigned wi = 0; wi < 2 && !done; wi++) {
+            SdmmcHandler::Config sd_cfg;
+            sd_cfg.Defaults();
+            sd_cfg.speed           = speeds[si];
+            sd_cfg.width           = widths[wi];
+            sd_cfg.clock_powersave = false;
+            sdmmc.Init(sd_cfg);
+            fsi.Init(fsi_cfg);
+            mount_res = f_mount(&fsi.GetSDFileSystem(), "/", 1);
+            if (mount_res == FR_OK) done = true;
+        }
+    }
+    bool mounted = (mount_res == FR_OK);
+
+    hw.usb_handle.Init(UsbHandle::FS_INTERNAL);
+    System::Delay(500);
+    hw.usb_handle.SetReceiveCallback(UsbRx, UsbHandle::FS_INTERNAL);
+
+    char line[300];
+    while (1) {
+        read_line(line, sizeof(line));
+
+        if (strncmp(line, "PING", 4) == 0) {
+            // The "ladder" tag confirms this is the speed/width-ladder uploader
+            // (so a stale firmware can be told apart from the current one).
+            if (mounted) {
+                reply("OK ladder\n");
+            } else {
+                char msg[48];
+                snprintf(msg, sizeof(msg), "ERR nomount=%d ladder\n", (int)mount_res);
+                reply(msg);
+            }
+        } else if (strncmp(line, "CLEAR", 5) == 0) {
+            if (!mounted) {
+                char msg[40];
+                snprintf(msg, sizeof(msg), "ERR nomount=%d\n", (int)mount_res);
+                reply(msg);
+            } else {
+                reply(clear_soundfiles() == FR_OK ? "OK\n" : "ERR clear\n");
+            }
+        } else if (strncmp(line, "FILE ", 5) == 0) {
+            if (!mounted) {
+                reply("ERR nomount\n");
+                continue;
+            }
+            // Parse "FILE <size> <name>".
+            char*    p    = line + 5;
+            uint32_t size = strtoul(p, &p, 10);
+            while (*p == ' ') p++;
+            if (*p == 0) {
+                reply("ERR name\n");
+                continue;
+            }
+            char path[300];
+            snprintf(path, sizeof(path), "soundfiles/%s", p);
+            if (f_open(&file, path, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK) {
+                reply("ERR open\n");
+                continue;
+            }
+            reply("OK\n");
+            bool ok = receive_file(size);
+            f_close(&file);
+            (void)ok; // receive_file already replied on error
+        } else if (strncmp(line, "DONE", 4) == 0) {
+            reply("OK\n");
+        } else if (line[0] != 0) {
+            reply("ERR cmd\n");
+        }
+    }
+}

--- a/architecture/daisy/soundfile.hpp
+++ b/architecture/daisy/soundfile.hpp
@@ -1,0 +1,200 @@
+#ifndef SOUNDFILE 
+#define SOUNDFILE 
+
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "daisy.h"  // for DaisySeed / SDRAM_DSP_MEM
+
+// ─── WAV format constants ──────────────────────────────────────────────
+static constexpr uint16_t kWavFmtPcm   = 0x0001;
+static constexpr uint16_t kWavFmtFloat = 0x0003;
+static constexpr uint16_t kWavFmtExt   = 0xFFFE;  // extensible, check subformat
+
+// ─── Result codes ─────────────────────────────────────────────────────
+enum class WavResult : uint8_t {
+    ok = 0,
+    err_open,
+    err_not_riff,
+    err_not_wave,
+    err_no_fmt,
+    err_no_data,
+    err_unsupported_format,
+    err_alloc,
+};
+
+// ─── Parsed header ────────────────────────────────────────────────────
+struct wav_header {
+    uint16_t format_tag;    // 0x0001 PCM, 0x0003 float, 0xFFFE extensible
+    uint16_t num_channels;
+    uint32_t sample_rate;
+    uint16_t bits_per_sample;
+    uint32_t num_frames;    // total sample frames (samples / channels)
+    uint32_t data_offset;   // byte offset of raw PCM in file
+    uint32_t data_size;     // byte length of data chunk
+};
+
+// ─── Main struct ──────────────────────────────────────────────────────
+struct wav_player {
+    wav_header  header;
+    uint8_t*    data     = nullptr;  // SDRAM pointer
+    uint32_t    position = 0;        // current read frame
+    bool        loaded   = false;
+
+    // Load from FatFS path into SDRAM.  Pass your SdmmcHandler + FatFsInterface.
+    WavResult load(const char* path) {
+        FIL     fil;
+        FRESULT fr = f_open(&fil, path, FA_READ);
+        if (fr != FR_OK) return WavResult::err_open;
+
+        WavResult res = _parse_header(fil);
+        if (res != WavResult::ok) { f_close(&fil); return res; }
+
+        // Allocate in SDRAM – caller must have called DSY_SDRAM_BSS or similar
+        data = reinterpret_cast<uint8_t*>(
+            DSY_SDRAM_BSS + _sdram_alloc(header.data_size)
+        );
+        if (!data) { f_close(&fil); return WavResult::err_alloc; }
+
+        UINT bytes_read = 0;
+        f_lseek(&fil, header.data_offset);
+        f_read(&fil, data, header.data_size, &bytes_read);
+        f_close(&fil);
+
+        position = 0;
+        loaded   = (bytes_read == header.data_size);
+        return loaded ? WavResult::ok : WavResult::err_alloc;
+    }
+
+    // Read next stereo float frame (mono sources are duplicated).
+    // Returns false when EOF.
+    bool read_frame(float& left, float& right) {
+        if (!loaded || position >= header.num_frames) return false;
+
+        const uint32_t bytes_per_sample = header.bits_per_sample / 8u;
+        const uint32_t frame_bytes      = bytes_per_sample * header.num_channels;
+        const uint8_t* p                = data + position * frame_bytes;
+
+        float ch[2] = { 0.f, 0.f };
+        const uint32_t read_ch = (header.num_channels < 2u) ? 1u : 2u;
+
+        for (uint32_t c = 0; c < read_ch; ++c) {
+            ch[c] = _decode_sample(p + c * bytes_per_sample);
+        }
+
+        left  = ch[0];
+        right = (header.num_channels > 1) ? ch[1] : ch[0];
+        ++position;
+        return true;
+    }
+
+    void rewind()  { position = 0; }
+    bool at_end()  const { return position >= header.num_frames; }
+
+    // ── Internals ────────────────────────────────────────────────────
+    WavResult _parse_header(FIL& fil) {
+        uint8_t buf[44];
+        UINT    br = 0;
+        f_read(&fil, buf, 12, &br);
+
+        if (memcmp(buf,     "RIFF", 4) != 0) return WavResult::err_not_riff;
+        if (memcmp(buf + 8, "WAVE", 4) != 0) return WavResult::err_not_wave;
+
+        bool got_fmt  = false;
+        bool got_data = false;
+
+        while (!got_data) {
+            uint8_t  chunk_id[4];
+            uint32_t chunk_size = 0;
+            if (f_read(&fil, chunk_id,    4, &br) != FR_OK || br != 4) break;
+            if (f_read(&fil, &chunk_size, 4, &br) != FR_OK || br != 4) break;
+
+            if (memcmp(chunk_id, "fmt ", 4) == 0) {
+                uint8_t fmt[40] = {};
+                UINT to_read    = chunk_size < 40u ? chunk_size : 40u;
+                f_read(&fil, fmt, to_read, &br);
+                if (chunk_size > 40u) f_lseek(&fil, f_tell(&fil) + (chunk_size - 40u));
+
+                header.format_tag     = _u16le(fmt);
+                header.num_channels   = _u16le(fmt + 2);
+                header.sample_rate    = _u32le(fmt + 4);
+                header.bits_per_sample= _u16le(fmt + 14);
+
+                // Validate format
+                const uint16_t tag = header.format_tag;
+                const uint16_t bps = header.bits_per_sample;
+
+                if (tag == kWavFmtFloat && bps != 32) return WavResult::err_unsupported_format;
+                if (tag == kWavFmtPcm  && bps != 16 && bps != 24 && bps != 32)
+                    return WavResult::err_unsupported_format;
+                if (tag != kWavFmtPcm && tag != kWavFmtFloat && tag != kWavFmtExt)
+                    return WavResult::err_unsupported_format;
+
+                got_fmt = true;
+
+            } else if (memcmp(chunk_id, "data", 4) == 0) {
+                if (!got_fmt) return WavResult::err_no_fmt;
+
+                header.data_offset = f_tell(&fil);
+                header.data_size   = chunk_size;
+                header.num_frames  = chunk_size /
+                    (header.num_channels * (header.bits_per_sample / 8u));
+                got_data = true;
+
+            } else {
+                // Skip unknown chunk (LIST, bext, etc.)
+                f_lseek(&fil, f_tell(&fil) + chunk_size);
+            }
+        }
+        return got_data ? WavResult::ok : WavResult::err_no_data;
+    }
+
+    float _decode_sample(const uint8_t* p) const {
+        const uint16_t tag = header.format_tag;
+        const uint16_t bps = header.bits_per_sample;
+
+        if (tag == kWavFmtFloat) {
+            float v; memcpy(&v, p, 4); return v;
+        }
+        // PCM integer → float [-1, 1)
+        if (bps == 16) {
+            int16_t s; memcpy(&s, p, 2);
+            return static_cast<float>(s) * (1.f / 32768.f);
+        }
+        if (bps == 24) {
+            // Little-endian sign-extend from 3 bytes
+            int32_t s = static_cast<int32_t>(p[0])
+                      | static_cast<int32_t>(p[1]) <<  8
+                      | static_cast<int32_t>(p[2]) << 16;
+            if (s & 0x00800000) s |= 0xFF000000;  // sign extend
+            return static_cast<float>(s) * (1.f / 8388608.f);
+        }
+        if (bps == 32) {
+            int32_t s; memcpy(&s, p, 4);
+            return static_cast<float>(s) * (1.f / 2147483648.f);
+        }
+        return 0.f;
+    }
+
+    // Tiny little-endian readers
+    static uint16_t _u16le(const uint8_t* p) {
+        return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+    }
+    static uint32_t _u32le(const uint8_t* p) {
+        return static_cast<uint32_t>(p[0])
+             | static_cast<uint32_t>(p[1]) <<  8
+             | static_cast<uint32_t>(p[2]) << 16
+             | static_cast<uint32_t>(p[3]) << 24;
+    }
+
+    // Simple bump allocator offset into DSY SDRAM region.
+    // In real use, replace with your own SDRAM arena / pool.
+    static uint32_t _sdram_alloc(uint32_t size) {
+        static uint32_t cursor = 0;
+        uint32_t offset = cursor;
+        cursor += (size + 3u) & ~3u;  // 4-byte align
+        return offset;
+    }
+};
+
+#endif 

--- a/architecture/faust/gui/DaisyControlUI.h
+++ b/architecture/faust/gui/DaisyControlUI.h
@@ -33,6 +33,19 @@ architecture section is not modified.
 #include "faust/gui/DecoratorUI.h"
 //#include "faust/gui/ValueConverter.h"
 
+#if defined(USE_SOUNDFILE) || defined(USE_SD_SOUNDFILE)
+// Soundfile resolver, declared here so DaisyControlUI::addSoundfile can use it
+// without including the (generated / SD) header that defines it.
+//  - USE_SOUNDFILE    : daisy_soundfile.hpp, samples inlined at build time.
+//  - USE_SD_SOUNDFILE : daisy_sd_soundfile.hpp, samples loaded from SD at boot.
+struct Soundfile;
+#ifdef USE_SOUNDFILE
+extern Soundfile* daisy_lookup_soundfile(const char* url);
+#else
+extern Soundfile* sd_load_soundfile(const char* url);
+#endif
+#endif
+
 /*******************************************************************************
  * DaisyControlUI : Faust User Interface
  ******************************************************************************/
@@ -146,7 +159,19 @@ class DaisyControlUI : public GenericUI
         void openHorizontalBox(const char* label) {  }
         void openVerticalBox(const char* label) {  }
         void closeBox(){}
-    
+
+#if defined(USE_SOUNDFILE) || defined(USE_SD_SOUNDFILE)
+        // -- soundfiles : resolve to an inlined (QSPI) or SD-loaded Soundfile.
+        void addSoundfile(const char* label, const char* url, Soundfile** sf_zone) override
+        {
+#ifdef USE_SOUNDFILE
+            *sf_zone = daisy_lookup_soundfile(url);
+#else
+            *sf_zone = sd_load_soundfile(url);
+#endif
+        }
+#endif
+
         // -- active widgets
         void addButton(const char* label, FAUSTFLOAT* zone)
         {
@@ -260,10 +285,22 @@ class DaisyControlUI : public GenericUI
         void setup_controls()
         {
             #ifdef SEED
+            // Assign DMA channels using the platform channel map: channel
+            // adc_platform_channel[i] holds ADC i. On a platform (e.g. Patch)
+            // this orders the hardware channels by physical control number so
+            // that reading channel k (libDaisy DisplayControls, platform
+            // controls...) gives control k; on Seed it is the identity order.
+            // Pre-fill every slot first so a sparse mapping leaves no
+            // unconfigured (invalid) channel.
+            for(size_t k = 0; k < adc_config_list.size(); ++k)
+            {
+                adc_config_list[k].InitSingle(adc_list[0].pin);
+            }
             for(size_t i = 0; i < adc_list.size(); ++i)
             {
-                adc_config_list[i].InitSingle(adc_list[i].pin);
-                adc_list[i].channel = i;
+                uint8_t ch = adc_platform_channel[i];
+                adc_config_list[ch].InitSingle(adc_list[i].pin);
+                adc_list[i].channel = ch;
             }
 
             hw.adc.Init(adc_config_list.data(), adc_config_list.size());

--- a/architecture/faust/midi/daisy-midi.h
+++ b/architecture/faust/midi/daisy-midi.h
@@ -62,6 +62,7 @@ class daisy_midi {
                 for(auto & it : locked)
                     it = false;
             #endif
+
         }
     
         virtual ~daisy_midi()
@@ -142,7 +143,6 @@ class daisy_midi {
             locked[idx] = false;
             generations[idx] = 0;
         }
-        
 
         void voice_stealing(int chan, uint8_t note, uint8_t velocity)
         {
@@ -163,7 +163,6 @@ class daisy_midi {
             }
             generations[free] = 0;
         }
-
 
         void voice_blocking(int chan, uint8_t note, uint8_t velocity)
         {

--- a/tools/faust2appls/faust2daisy
+++ b/tools/faust2appls/faust2daisy
@@ -27,6 +27,11 @@ POD=false
 SEED=false
 PATCHSM=false
 USE_SDRAM=false
+USE_SOUNDFILE=false
+USE_SD_SOUNDFILE=false
+UPLOAD_SD=false
+SOUNDFILE_MODE=qspi
+SD_DEBUG=false
 SR=48000
 SRSTR="SAI_48KHZ"
 BS=16
@@ -38,6 +43,16 @@ UART=false
 RX_PIN=0
 TX_PIN=0
 POLY_MODE="VOICE_STEALING"
+
+# Serial (UART) control link, set by faust_daisy_parser.py when the DSP uses
+# [rx:Dx] / [tx:Dx] control metadata.
+SERIAL=false
+SERIAL_RX_INPUTS=0
+SERIAL_TX_OUTPUTS=0
+
+# Hardware PWM outputs, set by faust_daisy_parser.py when the DSP uses [pwm:PIN].
+PWM=false
+PWM_OUTPUTS=0
 
 echoHelp ()
 {
@@ -62,6 +77,9 @@ echoHelp ()
     option "-sr <num>"
     option "-bs <num>"
     option -source
+    option -sd "to load soundfiles from the SD card at runtime instead of inlining to QSPI"
+    option -sd-debug "to print loaded soundfile info over USB serial at startup"
+    option -upload-sd "to upload soundfiles to the SD card (does not build the DSP, just the uploader)"
     option "Faust options"
     echo ""
     exit
@@ -113,23 +131,28 @@ do
     elif [ $p = "-tx-pin" ]; then 
         shift 
         TX_PIN=$1
-    #patch
     elif [ $p = "-patch" ]; then
         JSON_CONFIG="$FAUSTARCH/daisy/patch.json"
         PATCH=true
         SEED=true
-        #UART=true
-        JSON_CONFIG="$FAUSTARCH/daisy/patch.json"
     elif [ $p = "-pod" ]; then
         JSON_CONFIG="$FAUSTARCH/daisy/pod.json"
         POD=true
         SEED=true
-        #UART=true
-        JSON_CONFIG="$FAUSTARCH/daisy/pod.json"
     elif [ $p = "-seed" ]; then 
         SEED=true
     elif [ $p = "-patchsm" ]; then
         PATCHSM=true
+    # -upload-sd
+    elif [ $p = "-upload-sd" ]; then
+        UPLOAD_SD=true
+    # -sd : load soundfiles from the SD card at runtime instead of inlining to QSPI
+    elif [ $p = "-sd" ]; then
+        SOUNDFILE_MODE=sd
+    # -sd-debug : print loaded soundfile info over USB serial at startup
+    elif [ $p = "-sd-debug" ]; then
+        SOUNDFILE_MODE=sd
+        SD_DEBUG=true
     # -sdram
     elif [ $p = "-sdram" ]; then
         USE_SDRAM=true
@@ -197,27 +220,67 @@ for p in $FILE; do
     rm -rf "$SRCDIR/$dspName"
     mkdir "$SRCDIR/$dspName"
 
+    # SD card upload mode : flash a temporary uploader firmware, then stream the
+    # WAV files referenced by the DSP into the /soundfiles folder on the card.
+    # Does not build/flash the DSP itself.
+    if [ $UPLOAD_SD == true ]; then
+        echo "SD upload mode : building soundfile uploader firmware"
+        faust "$p" -json -o "$SRCDIR/$dspName/ex_faust.cpp" || exit
+        UPDIR="$SRCDIR/$dspName/_sd_uploader"
+        mkdir -p "$UPDIR"
+        cp "$FAUSTARCH/daisy/sd_uploader.cpp" "$UPDIR/"
+        cp "$FAUSTARCH/daisy/Makefile.sd_uploader" "$UPDIR/Makefile"
+        (cd "$UPDIR" && make) || exit
+        # Flash the uploader, retrying until DFU succeeds. Proceeding with a
+        # stale uploader still on the board (DFU not entered) is the common trap,
+        # so do not continue to the upload until this actually flashes.
+        echo "To flash the uploader, put the Daisy in DFU mode: hold BOOT, tap RESET, release BOOT."
+        while true; do
+            read -p "Press ENTER when the Daisy is in DFU mode (or type 's' to skip flashing): " resp
+            if [ "$resp" = "s" ]; then
+                echo "Skipping flash; using whatever firmware is already on the board."
+                break
+            fi
+            if (cd "$UPDIR" && make program-dfu); then
+                echo "Uploader flashed."
+                break
+            fi
+            echo "Flash failed (Daisy not in DFU mode?). Try again."
+        done
+        echo "Waiting for Daisy to re-enumerate as USB serial..."
+        sleep 3
+        python3 "$FAUSTARCH/daisy/sd_upload.py" "$SRCDIR/$dspName.dsp.json" "$SRCDIR" || exit
+        echo "Soundfiles uploaded to /soundfiles. Flash your DSP separately."
+        continue
+    fi
+
     GENERATED_ARCH="$SRCDIR/$dspName/daisy_arch.cpp"
     
     MEM_THRESH_UNIT=$(($MEM_THRESH/4))
 
     if [ "$JSON_CONFIG" = "0" ]; then 
-        eval "$(python3 "$FAUSTARCH/daisy/generate_config.py" "$SRCDIR/$dspName" $PATCHSM $UART $RX_PIN $TX_PIN)"
+        #eval "$(python3 "$FAUSTARCH/daisy/generate_config.py" "$SRCDIR/$dspName" $PATCHSM $UART $RX_PIN $TX_PIN)"
+        out="$(python3 "$FAUSTARCH/daisy/generate_config.py" "$SRCDIR/$dspName" $PATCHSM $UART $RX_PIN $TX_PIN)" || {
+            echo "generate_config.py failed" >&2; exit 1; }
+        eval "$out"
     fi
 
-    # compile faust to c++
     echo "Compile Faust to C++":
 
     cp -r "$FAUSTARCH/daisy/Makefile" "$SRCDIR/$dspName/"
     if [ $USE_SDRAM == true ]; then 
-        # Have to compile it twice to provide json to python, before inlining generated code 
+        # We have to compile it twice to provide json to python, before inlining generated code 
         faust -i -a "$ARCHFILE" $OPTIONS "$f" -json -mem1 -it -fpga-mem-th $MEM_THRESH_UNIT -o "$SRCDIR/$dspName/ex_faust.cpp" || exit
-        eval "$(python3 "$FAUSTARCH/daisy/faust_daisy_parser.py" "$SRCDIR/$dspName" $MEM_THRESH $NVOICES 1 $ARCHFILE $JSON_CONFIG)"
+        out="$(python3 "$FAUSTARCH/daisy/faust_daisy_parser.py" "$SRCDIR/$dspName" $MEM_THRESH $NVOICES 1 $ARCHFILE $JSON_CONFIG $SOUNDFILE_MODE)" || {
+            echo "faust_daisy_parser.py failed" >&2; exit 1; }
+        eval "$out"
         faust -A "$SRCDIR/$dspName" -i -a "$GENERATED_ARCH" $OPTIONS "$f" -mem1 -it -fpga-mem-th $MEM_THRESH_UNIT -o "$SRCDIR/$dspName/ex_faust.cpp" || exit
-    else 
-        # Have to compile it twice to provide json to python, before inlining generated code 
+    else
+        # We have to compile it twice to provide json to python, before inlining generated code
         faust -i  -a "$ARCHFILE" $OPTIONS "$f" -json  -o "$SRCDIR/$dspName/ex_faust.cpp" || exit
-        eval "$(python3 "$FAUSTARCH/daisy/faust_daisy_parser.py" "$SRCDIR/$dspName" $MEM_THRESH $NVOICES 0 $ARCHFILE $JSON_CONFIG)"
+        out="$(python3 "$FAUSTARCH/daisy/faust_daisy_parser.py" "$SRCDIR/$dspName" $MEM_THRESH $NVOICES 0 $ARCHFILE $JSON_CONFIG $SOUNDFILE_MODE)" || {
+            echo "faust_daisy_parser.py failed" >&2; exit 1; }
+        eval "$out"
         faust -A "$SRCDIR/$dspName" -i  -a "$GENERATED_ARCH" $OPTIONS "$f" -o "$SRCDIR/$dspName/ex_faust.cpp" || exit
     fi
 
@@ -260,6 +323,40 @@ for p in $FILE; do
         echo "#define USE_SDRAM" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
     fi
 
+    # for Soundfile (set by faust_daisy_parser.py when the DSP uses soundfiles)
+    if [ $USE_SOUNDFILE == true ]; then
+        echo "#define USE_SOUNDFILE" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+    fi
+
+    # Serial (UART) control link (set by faust_daisy_parser.py via SERIAL=true /
+    # SERIAL_RX_INPUTS=N when the DSP uses [rx:Dx] / [tx:Dx] metadata).
+    if [ $SERIAL == true ]; then
+        echo "#define SERIAL" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+        echo "#define SERIAL_RX_INPUTS $SERIAL_RX_INPUTS" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+        echo "#define SERIAL_TX_OUTPUTS $SERIAL_TX_OUTPUTS" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+    fi
+
+    # Hardware PWM (set by faust_daisy_parser.py via PWM=true / PWM_OUTPUTS=N
+    # when the DSP uses [pwm:PIN] metadata).
+    if [ $PWM == true ]; then
+        echo "#define PWM" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+        echo "#define PWM_OUTPUTS $PWM_OUTPUTS" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+    fi
+
+    # for SD-card soundfiles (set by faust_daisy_parser.py in -sd mode)
+    if [ $USE_SD_SOUNDFILE == true ]; then
+        echo "#define USE_SD_SOUNDFILE" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+        # Size the SDRAM arena to the referenced WAVs when the parser could
+        # measure them (otherwise the architecture default of 32 MB is used).
+        if [ -n "$SD_SOUNDFILE_BYTES" ]; then
+            echo "#define FAUST_SD_SOUNDFILE_BYTES $SD_SOUNDFILE_BYTES" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+        fi
+        # -sd-debug : enable the USB-serial dump of the loaded soundfile.
+        if [ $SD_DEBUG == true ]; then
+            echo "#define SD_SOUNDFILE_DEBUG" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
+        fi
+    fi
+
     # for Sample Rate
     echo "#define DAISY_SAMPLE_RATE daisy::SaiHandle::Config::SampleRate::$SRSTR" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
     echo "#define MY_SAMPLE_RATE $SR" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
@@ -273,29 +370,55 @@ for p in $FILE; do
 
     echo "#include \"per/sai.h\"" | cat - "$SRCDIR/$dspName/ex_faust.cpp" > temp && mv temp "$SRCDIR/$dspName/ex_faust.cpp"
 
+    # Soundfiles inline their samples as QSPI-resident const data, which only
+    # fits when the program runs from QSPI. Warn if -qspi was not requested
+    # (small soundfiles may still fit in internal flash; large ones will
+    # overflow the FLASH region at link time).
+    if [ $USE_SOUNDFILE == true ] && [ $APP_TYPE != BOOT_QSPI ]; then
+        echo "WARNING: this DSP uses soundfiles. Audio data lives in QSPI flash;"
+        echo "         build with -qspi unless the sound is small enough for the"
+        echo "         128 KB internal flash."
+    fi
+
+    # SD-card soundfile mode needs the FatFS middleware linked into the DSP and
+    # the runtime loader header copied next to the generated sources.
+    SF_MAKE=""
+    if [ $USE_SD_SOUNDFILE == true ]; then
+        SF_MAKE="USE_FATFS=1"
+        cp "$FAUSTARCH/daisy/daisy_sd_soundfile.hpp" "$SRCDIR/$dspName/"
+        echo "SD soundfile mode : the DSP loads /soundfiles/*.wav at startup."
+        echo "                    Upload them first with 'faust2daisy -upload-sd $f'."
+    fi
+
+    # Serial (UART) control link : copy the listener header next to the
+    # generated sources (ex_faust.cpp #include "daisy_uart_listener.hpp").
+    if [ $SERIAL == true ]; then
+        cp "$FAUSTARCH/daisy/daisy_uart_listener.hpp" "$SRCDIR/$dspName/"
+    fi
+
     # compile and install plugin or keep the source folder
     if [ $SOURCE == false ]; then
         export $APP_TYPE
         cd "$SRCDIR/$dspName"
         pwd
         echo "Building Faust program"
-        (make APP_TYPE=$APP_TYPE) || exit 
+        (make APP_TYPE=$APP_TYPE $SF_MAKE) || exit
 
-        if [ $APP_TYPE == BOOT_NONE ]; then 
+        if [ $APP_TYPE == BOOT_NONE ]; then
             read -p "Press ENTER when Daisy is in DFU mode"
-            (make program-dfu)  || true
-        else 
+            (make program-dfu $SF_MAKE)  || true
+        else
             read -r -p "Do you want to flash Daisy bootloader ? [y/n] : " response
-            case "$response" in 
+            case "$response" in
                 [yY])
                     read -p "Press ENTER when Daisy is in DFU mode to flash bootloader"
-                    (make program-boot) || true 
+                    (make program-boot) || true
                     sleep 1s # Make sure bootloader is operational
                 ;;
                 *)
             esac
-            read -p "Press Daisy RESET button, then press ENTER (approximately 1 sec after RESET)" 
-            (make program-dfu APP_TYPE=$APP_TYPE)  || true 
+            read -p "Press Daisy RESET button, then press ENTER (approximately 1 sec after RESET)"
+            (make program-dfu APP_TYPE=$APP_TYPE $SF_MAKE)  || true
         fi
 
         cd ..


### PR DESCRIPTION
## Features 
* Soundfile primitive support: WAV files (PCM 16/24/32 bit, float 32 bit). Two modes:
  * default (`-qspi`): parsed at build time and inlined into QSPI flash, no runtime
    file I/O or dynamic allocation.
  * `-sd`: loaded from the SD card (`/soundfiles`) into SDRAM at startup. Files are
    uploaded with `faust2daisy -upload-sd` (temporary CDC uploader firmware).
  * Daisy Patch supported 
  * Daisy PatchSM supported 
 * Serial control through UART pins (both RX and TX are implemented), passing messages in the format "amp 0.72551" 
 * Hardware PWM output (defaults to 29Khz) wiht `pwm:D1`. 
 * PIN conflict checking on parser side (for example using `[adc:A0]` and `[gpio:D15]` on daisy seed won't work, since it would conflict, same pin)

## Fix 
* Midi input was not initialized 
* Python parser script DAC interpretation was wrong 
* MIDI CC was not working properly for checkboxes and buttons. Now it is working as Faust documentation says : returns 1 if CC is 127, returns 0 if CC is 0
* Python parser crashed on a DSP with UI controls when no configuration file was provided
* Fixed Patch screen bar ordering 
