### PR TITLE
Set the JIT target before initJIT(), not after

### DIFF
--- a/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
+++ b/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
@@ -729,8 +729,16 @@ LIBFAUST_API llvm_dsp_factory* createDSPFactoryFromString(const string& name_app
                 llvm_dynamic_dsp_factory_aux* factory_aux =
                     static_cast<llvm_dynamic_dsp_factory_aux*>(createFactory(
                         name_app, dsp_content, argv1.size() - 1, argv1.data(), error_msg, true));
-                if (factory_aux && factory_aux->initJIT(error_msg)) {
+                // setTarget() must precede initJIT(): initJIT() reads fTarget to
+                // pick the triple and mcpu, and an empty fTarget makes it fall
+                // back to sys::getHostCPUName(). Setting it afterwards left the
+                // JIT host-tuned whatever target the caller asked for. The
+                // bitcode/IR entry points already pass the target through the
+                // factory constructor, i.e. before initJIT().
+                if (factory_aux) {
                     factory_aux->setTarget(target);
+                }
+                if (factory_aux && factory_aux->initJIT(error_msg)) {
                     factory_aux->setOptlevel(opt_level);
                     factory_aux->setClassName(getParam(argc, argv, "-cn", "mydsp"));
                     factory_aux->setName(name_app);
@@ -766,8 +774,11 @@ LIBFAUST_API llvm_dsp_factory* createDSPFactoryFromSignals(const string& name_ap
 
         llvm_dynamic_dsp_factory_aux* factory_aux = static_cast<llvm_dynamic_dsp_factory_aux*>(
             createFactory(name_app, signals, argv1.size() - 1, argv1.data(), error_msg));
-        if (factory_aux && factory_aux->initJIT(error_msg)) {
+        // See the note above: setTarget() must precede initJIT().
+        if (factory_aux) {
             factory_aux->setTarget(target);
+        }
+        if (factory_aux && factory_aux->initJIT(error_msg)) {
             factory_aux->setOptlevel(opt_level);
             factory_aux->setClassName(getParam(argc, argv, "-cn", "mydsp"));
             factory_aux->setName(name_app);


### PR DESCRIPTION
`createDSPFactoryFromString()` and `createDSPFactoryFromSignals()` call `setTarget(target)` *after* `initJIT()`:

```cpp
// llvm_dynamic_dsp_aux.cpp
if (factory_aux && factory_aux->initJIT(error_msg)) {
    factory_aux->setTarget(target);
```

But `initJIT()` is what reads `fTarget` to derive the triple and mcpu:

```cpp
string triple, cpu;
splitTarget(fTarget, triple, cpu);
fModule->setTargetTriple(triple);
builder.setMCPU((cpu == "") ? sys::getHostCPUName() : StringRef(cpu));
```

At that point `fTarget` is still empty, so `splitTarget()` yields an empty triple and mcpu and the builder falls back to `sys::getHostCPUName()`. The factory is JIT-compiled for the host CPU regardless of the `target` argument; the value only takes effect for later queries such as `getTarget()` and the object-code path.

The bitcode and IR entry points in the same file already pass the target through the `llvm_dynamic_dsp_factory_aux` constructor, i.e. before `initJIT()`:

```cpp
llvm_dynamic_dsp_factory_aux* factory_aux =
    new llvm_dynamic_dsp_factory_aux(sha_key, module, context, target, opt_level);
if (factory_aux->initJIT(error_msg)) {
```

which suggests the ordering in the two source-based paths is an oversight rather than a deliberate difference.

## Reproducing

Compile any DSP through `createDSPFactoryFromString()` with a non-empty target, then write the factory out with `writeDSPFactoryToBitcodeFile()`. The module's target triple is LLVM's host default rather than the one requested:

```
target triple = "x86_64-pc-linux-gnu"     // requested "x86_64-unknown-linux-gnu:x86-64"
```

With the patch applied it is `x86_64-unknown-linux-gnu`.

## The patch

Hoist `setTarget()` above `initJIT()` in both paths. No behavior change when the target is empty.