### PR TITLE
Fix heap underrun in pathToContent when the file cannot be opened

### DIFF
--- a/compiler/generator/Text.hh
+++ b/compiler/generator/Text.hh
@@ -163,6 +163,16 @@ inline std::string pathToContent(const std::string& path)
     int size = int(file.tellg());
     file.seekg(0, file.beg);
 
+    // A file that cannot be opened (or is empty) reports size -1 (or 0): the
+    // code below would then allocate 'new char[0]' and write buffer[-1],
+    // corrupting the heap. This happens in practice for every string-based
+    // factory: generateJSON() falls back to pathToContent(gMasterDocument)
+    // because the parser cleared gInputString, and gMasterDocument holds the
+    // factory name, which is not an existing file.
+    if (size <= 0) {
+        return "";
+    }
+
     // And allocate buffer to that a single line can be read...
     char* buffer = new char[size + 1];
     file.read(buffer, size);


### PR DESCRIPTION
`pathToContent()` does not check the size it gets from `tellg()`. For a file that cannot be opened `tellg()` returns -1, and for an empty file 0, so the function allocated `new char[size + 1]` == `new char[0]` and then wrote `buffer[-1]`, one byte before the start of the heap block, before reading past the buffer to build the returned string.

This is not a corner case: every string-based factory hits it. The parser clears `gInputString` once the source is scanned (`sourcereader.cpp`, `parseString`), so `WASMCodeContainer::generateJSON` falls back to `pathToContent(gGlobal->gMasterDocument)`, and for string input `gMasterDocument` holds the factory name, which is not a file on disk.

Consequences seen in practice:

- On Windows debug builds the CRT detects the guard-byte write and raises a heap-corruption report. On a headless CI runner its message box hangs the process.
- Elsewhere the write lands in allocator slack and the JSON silently embeds garbage heap bytes as the DSP source.

Returns an empty string for an unreadable or empty file instead.
