### PR TITLE
tlib: order Tree containers with an explicit comparator

### DIFF
--- a/compiler/documentator/doc.cpp
+++ b/compiler/documentator/doc.cpp
@@ -320,8 +320,8 @@ static void printDocMetadata(const Tree expr, ostream& docout)
 {
     if (gGlobal->gMetaDataSet.count(expr)) {
         string    sep  = "";
-        set<Tree> mset = gGlobal->gMetaDataSet[expr];
-        for (set<Tree>::iterator j = mset.begin(); j != mset.end(); j++) {
+        TreeSet   mset = gGlobal->gMetaDataSet[expr];
+        for (TreeSet::iterator j = mset.begin(); j != mset.end(); j++) {
             docout << sep << unquote(tree2str(*j));
             sep = ", ";
         }

--- a/compiler/draw/sigToGraph.cpp
+++ b/compiler/draw/sigToGraph.cpp
@@ -38,7 +38,7 @@
 
 using namespace std;
 
-static void   recdraw(Tree sig, set<Tree>& drawn, ostream& fout);
+static void   recdraw(Tree sig, TreeSet& drawn, ostream& fout);
 static string nodeattr(Type t);
 static string edgeattr(Type t);
 static string sigLabel(Tree sig);
@@ -48,7 +48,7 @@ static string sigLabel(Tree sig);
  */
 void sigToGraph(Tree L, ostream& fout)
 {
-    set<Tree> alreadyDrawn;
+    TreeSet alreadyDrawn;
 
     fout << "strict digraph loopgraph {\n"
          << "    rankdir=LR; node [fontsize=10];" << endl;
@@ -70,7 +70,7 @@ void sigToGraph(Tree L, ostream& fout)
 /**
  * Draw recursively a signal
  */
-static void recdraw(Tree sig, set<Tree>& drawn, ostream& fout)
+static void recdraw(Tree sig, TreeSet& drawn, ostream& fout)
 {
     // cerr << ++gGlobal->TABBER << "ENTER REC DRAW OF " << sig << "$" << *sig << endl;
     tvec subsig;

--- a/compiler/generator/assemblyscript/assemblyscript_code_container.cpp
+++ b/compiler/generator/assemblyscript/assemblyscript_code_container.cpp
@@ -342,7 +342,7 @@ void AssemblyScriptCodeContainer::produceMetadata(int tabs)
             *fOut << "m.declare(\"" << *(i.first) << "\", " << **(i.second.begin()) << ");";
             tab(tabs + 1, *fOut);
         } else {
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     *fOut << "m.declare(\"" << *(i.first) << "\", " << **j << ");";
                 } else {

--- a/compiler/generator/c/c_code_container.cpp
+++ b/compiler/generator/c/c_code_container.cpp
@@ -765,7 +765,7 @@ void CCodeContainer::produceMetadata(int tabs)
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author
             // and sub-levels become "contributor"
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(tabs + 1, *fOut);
                     *fOut << "m->declare(m->metaInterface, \"" << *(i.first) << "\", " << **j

--- a/compiler/generator/code_container.cpp
+++ b/compiler/generator/code_container.cpp
@@ -157,7 +157,7 @@ bool CodeContainer::getLoopProperty(Tree sig, CodeLoop*& l)
     return fLoopProperty.get(sig, l);
 }
 
-void CodeContainer::listAllLoopProperties(Tree sig, set<CodeLoop*>& L, set<Tree>& visited)
+void CodeContainer::listAllLoopProperties(Tree sig, set<CodeLoop*>& L, TreeSet& visited)
 {
     if (visited.count(sig) == 0) {
         visited.insert(sig);
@@ -204,7 +204,7 @@ void CodeContainer::closeLoop(Tree sig)
 
     // fix the missing dependencies
     set<CodeLoop*> L;
-    set<Tree>      V;
+    TreeSet        V;
     listAllLoopProperties(sig, L, V);
     for (CodeLoop* l : L) {
         fCurLoop->fBackwardLoopDependencies.insert(l);

--- a/compiler/generator/code_container.hh
+++ b/compiler/generator/code_container.hh
@@ -176,7 +176,7 @@ class CodeContainer : public virtual Garbageable {
     void printHeader(std::ostream& dst)
     {
         // defines the metadata we want to print as comments at the begin of in the file
-        std::set<Tree> selectedKeys;
+        TreeSet selectedKeys;
         selectedKeys.insert(tree("name"));
         selectedKeys.insert(tree("author"));
         selectedKeys.insert(tree("copyright"));
@@ -281,8 +281,8 @@ class CodeContainer : public virtual Garbageable {
     void setLoopProperty(Tree sig, CodeLoop* l);   ///< Store the loop used to compute a signal
     bool getLoopProperty(Tree sig, CodeLoop*& l);  ///< Returns the loop used to compute a signal
     void listAllLoopProperties(
-        Tree            sig, std::set<CodeLoop*>&,
-        std::set<Tree>& visited);  ///< Returns all the loop used to compute a signal
+        Tree     sig, std::set<CodeLoop*>&,
+        TreeSet& visited);  ///< Returns all the loop used to compute a signal
 
     void printGraphDotFormat(std::ostream& fout);
 
@@ -383,7 +383,7 @@ class CodeContainer : public virtual Garbageable {
                 std::string res2 = unquote(str2.str());
                 json->declare(res1.c_str(), res2.c_str());
             } else {
-                for (std::set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+                for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                     if (j == i.second.begin()) {
                         std::stringstream str1, str2;
                         str1 << *(i.first);

--- a/compiler/generator/compile.cpp
+++ b/compiler/generator/compile.cpp
@@ -128,7 +128,7 @@ static string wdel(const string& s)
 void Compiler::generateMetaData()
 {
     // Add global metadata
-    for (map<Tree, set<Tree>>::iterator i = gGlobal->gMetaDataSet.begin();
+    for (TreeMap<TreeSet>::iterator i = gGlobal->gMetaDataSet.begin();
          i != gGlobal->gMetaDataSet.end(); i++) {
         if (i->first != tree("author")) {
             stringstream str1, str2;
@@ -138,7 +138,7 @@ void Compiler::generateMetaData()
             string res2 = unquote(str2.str());
             fJSON.declare(res1.c_str(), res2.c_str());
         } else {
-            for (set<Tree>::iterator j = i->second.begin(); j != i->second.end(); j++) {
+            for (TreeSet::iterator j = i->second.begin(); j != i->second.end(); j++) {
                 if (j == i->second.begin()) {
                     stringstream str1, str2;
                     str1 << *(i->first);

--- a/compiler/generator/compile_scal.cpp
+++ b/compiler/generator/compile_scal.cpp
@@ -273,7 +273,7 @@ void ScalarCompiler::conditionStatistics(Tree l)
 
 void ScalarCompiler::conditionStatistics(Tree l)
 {
-    map<Tree, int>
+    TreeMap<int>
         fConditionStatistics;  // used with the new X,Y:enable --> sigEnable(X*Y,Y>0) primitive
     for (const auto& p : fConditionProperty) {
         for (Tree lc = p.second; !isNil(lc); lc = tl(lc)) {

--- a/compiler/generator/compile_scal.hh
+++ b/compiler/generator/compile_scal.hh
@@ -49,7 +49,7 @@ class ScalarCompiler : public Compiler {
     property<std::pair<std::string, std::string> >
         fInstanceInitProperty;  // property added to solve 20101208 kjetil bug
 
-    std::map<Tree, Tree>
+    TreeMap<Tree>
         fConditionProperty;  // used with the new X,Y:enable --> sigControl(X*Y,Y>0) primitive
 
     static std::map<std::string, int>  fIDCounters;
@@ -57,7 +57,7 @@ class ScalarCompiler : public Compiler {
     OccMarkup*                         fOccMarkup;
     int                                fMaxIota;
     std::map<std::string, std::string> fIotaCache;
-    std::map<Tree, int>                fScheduleOrder;
+    TreeMap<int>                       fScheduleOrder;
 
    public:
     ScalarCompiler(const std::string& name, const std::string& super, int numInputs, int numOutputs)

--- a/compiler/generator/cpp/cpp_code_container.cpp
+++ b/compiler/generator/cpp/cpp_code_container.cpp
@@ -135,7 +135,7 @@ void CPPCodeContainer::produceMetadata(int tabs)
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author
             // and sub-levels become "contributor"
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(tabs + 1, *fOut);
                     *fOut << "m->declare(\"" << *(i.first) << "\", " << **j << ");";

--- a/compiler/generator/csharp/csharp_code_container.cpp
+++ b/compiler/generator/csharp/csharp_code_container.cpp
@@ -233,7 +233,7 @@ void CSharpCodeContainer::produceClass()
             tab(n + 2, *fOut);
             *fOut << "MetaData.Declare(\"" << *(i.first) << "\", " << **(i.second.begin()) << ");";
         } else {
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(n + 2, *fOut);
                     *fOut << "MetaData.Declare(\"" << *(i.first) << "\", " << **j << ");";

--- a/compiler/generator/dlang/dlang_code_container.cpp
+++ b/compiler/generator/dlang/dlang_code_container.cpp
@@ -90,7 +90,7 @@ void DLangCodeContainer::produceMetadata(int tabs)
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author
             // and sub-levels become "contributor"
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(tabs + 1, *fOut);
                     *fOut << "m.declare(\"" << *(i.first) << "\", " << **j << ");";

--- a/compiler/generator/instructions_compiler.cpp
+++ b/compiler/generator/instructions_compiler.cpp
@@ -287,7 +287,7 @@ void InstructionsCompiler::conditionStatistics(Tree l)
 
 void InstructionsCompiler::conditionStatistics(Tree l)
 {
-    map<Tree, int>
+    TreeMap<int>
         fConditionStatistics;  // used with the new X,Y:enable --> sigEnable(X*Y,Y != 0) primitive
     for (const auto& p : fConditionProperty) {
         for (Tree lc = p.second; !isNil(lc); lc = tl(lc)) {

--- a/compiler/generator/instructions_compiler.hh
+++ b/compiler/generator/instructions_compiler.hh
@@ -49,7 +49,7 @@ class InstructionsCompiler : public virtual Garbageable {
     property<std::pair<std::string, std::string>> fInstanceInitProperty;
     property<std::string>                         fTableProperty;
 
-    std::map<Tree, Tree>
+    TreeMap<Tree>
         fConditionProperty;  // used with the new X,Y:enable --> sigControl(X*Y,Y>0) primitive
 
     Tree       fSharingKey;

--- a/compiler/generator/interpreter/interpreter_code_container.cpp
+++ b/compiler/generator/interpreter/interpreter_code_container.cpp
@@ -359,7 +359,7 @@ FIRMetaBlockInstruction* InterpreterCodeContainer<REAL>::produceMetadata(string&
             }
             block->push(new FIRMetaInstruction(str1.str(), unquote(str2.str())));
         } else {
-            for (set<Tree>::iterator j = it.second.begin(); j != it.second.end(); j++) {
+            for (TreeSet::iterator j = it.second.begin(); j != it.second.end(); j++) {
                 if (j == it.second.begin()) {
                     stringstream str1, str2;
                     str1 << *(it.first);

--- a/compiler/generator/java/java_code_container.cpp
+++ b/compiler/generator/java/java_code_container.cpp
@@ -207,7 +207,7 @@ void JAVACodeContainer::produceClass()
             tab(n + 2, *fOut);
             *fOut << "m.declare(\"" << *(i.first) << "\", " << **(i.second.begin()) << ");";
         } else {
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(n + 2, *fOut);
                     *fOut << "m.declare(\"" << *(i.first) << "\", " << **j << ");";

--- a/compiler/generator/jsfx/jsfx_code_container.cpp
+++ b/compiler/generator/jsfx/jsfx_code_container.cpp
@@ -374,7 +374,7 @@ void JSFXCodeContainer::produceMetadata(int tabs)
     // key numbers
     for (const auto& i : gGlobal->gMetaDataSet) {
         if (i.first == tree("options")) {
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 stringstream ss;
                 ss << **j;
                 string s;
@@ -403,7 +403,7 @@ void JSFXCodeContainer::produceMetadata(int tabs)
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author
             // and sub-levels become "contributor"
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     *fOut << "desc: " << *(i.first) << " " << **j << "\n";
                 } else {

--- a/compiler/generator/julia/julia_code_container.cpp
+++ b/compiler/generator/julia/julia_code_container.cpp
@@ -291,7 +291,7 @@ void JuliaCodeContainer::produceMetadata(int tabs)
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author
             // and sub-levels become "contributor"
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(tabs + 1, *fOut);
                     *fOut << "declare!(m, \"" << *(i.first) << "\", " << **j << ");";

--- a/compiler/generator/klass.cpp
+++ b/compiler/generator/klass.cpp
@@ -88,7 +88,7 @@ void Klass::openLoop(Tree recsymbol, const string& size)
     // cerr << "\nOPEN REC LOOP(" << *recsymbol << ", " << size << ") ----> " << fTopLoop << endl;
 }
 
-void Klass::listAllLoopProperties(Tree sig, set<Loop*>& L, set<Tree>& visited)
+void Klass::listAllLoopProperties(Tree sig, set<Loop*>& L, TreeSet& visited)
 {
     if (visited.count(sig) == 0) {
         visited.insert(sig);
@@ -116,7 +116,7 @@ void Klass::closeLoop(Tree sig)
 
     // fix the missing dependencies
     set<Loop*> L;
-    set<Tree>  V;
+    TreeSet    V;
     listAllLoopProperties(sig, L, V);
     for (Loop* l : L) {
         fTopLoop->fBackwardLoopDependencies.insert(l);

--- a/compiler/generator/klass.hh
+++ b/compiler/generator/klass.hh
@@ -137,8 +137,8 @@ class Klass {
     void setLoopProperty(Tree sig, Loop* l);   ///< Store the loop used to compute a signal
     bool getLoopProperty(Tree sig, Loop*& l);  ///< Returns the loop used to compute a signal
     void listAllLoopProperties(
-        Tree            sig, std::set<Loop*>&,
-        std::set<Tree>& visited);  ///< Returns all the loop used to compute a signal
+        Tree     sig, std::set<Loop*>&,
+        TreeSet& visited);  ///< Returns all the loop used to compute a signal
 
     const std::string& getClassName() const
     {

--- a/compiler/generator/occurrences.hh
+++ b/compiler/generator/occurrences.hh
@@ -58,7 +58,7 @@ class Occurrences : public virtual Garbageable {
 class OccMarkup : public virtual Garbageable {
     Tree                 fRootTree;    ///< occurrences computed within this tree
     Tree                 fPropKey;     ///< key used to store occurrences property
-    std::map<Tree, Tree> fConditions;  ///< condition associated to each tree
+    TreeMap<Tree>        fConditions;  ///< condition associated to each tree
 
     void         incOcc(Tree env, int v, int r, int d, Tree xc,
                         Tree t);                    ///< inc the occurrence of t in context v,r
@@ -67,7 +67,7 @@ class OccMarkup : public virtual Garbageable {
 
    public:
     OccMarkup() : fRootTree(nullptr), fPropKey(nullptr) {}
-    OccMarkup(std::map<Tree, Tree> conditions)
+    OccMarkup(TreeMap<Tree> conditions)
         : fRootTree(nullptr), fPropKey(nullptr), fConditions(conditions)
     {
     }

--- a/compiler/generator/rust/rust_code_container.cpp
+++ b/compiler/generator/rust/rust_code_container.cpp
@@ -646,7 +646,7 @@ void RustCodeContainer::produceMetadata(int n)
         } else {
             // But the "author" meta data is accumulated, the upper level becomes the main author
             // and sub-levels become "contributor"
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); j++) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); j++) {
                 if (j == i.second.begin()) {
                     tab(n + 1, *fOut);
                     *fOut << "m.declare(\"" << *(i.first) << "\", r" << **j << ");";

--- a/compiler/generator/sdf3/signal2SDF.cpp
+++ b/compiler/generator/sdf3/signal2SDF.cpp
@@ -45,7 +45,7 @@ using namespace std;
 void Signal2SDF::sigToSDF(Tree L, ostream& fout)
 {
     const string graphName = gGlobal->gMasterName;  // name of .dsp file
-    set<Tree>    alreadyDrawn;
+    TreeSet      alreadyDrawn;
     while (!isNil(L)) {
         self(hd(L));
         // recLog(hd(L), alreadyDrawn);

--- a/compiler/generator/sdf3/signal2SDF.hh
+++ b/compiler/generator/sdf3/signal2SDF.hh
@@ -39,7 +39,7 @@ class Signal2SDF : public TreeTraversal {
     bool           fVisitGen{false};
     int            fIndent{0};  // current indentation during trace
     std::string    fMessage;    // trace message
-    std::set<Tree> fVisited;    // avoid visiting a tree twice
+    TreeSet        fVisited;    // avoid visiting a tree twice
 
     std::map<std::string, Actor>   actorList;
     std::map<std::string, Channel> chList;

--- a/compiler/global.cpp
+++ b/compiler/global.cpp
@@ -2014,7 +2014,7 @@ void global::printDeclareHeader(ostream& dst)
             dst << replaceCharList(key.str(), rep, '_');
             dst << " " << **(i.second.begin()) << ";" << endl;
         } else {
-            for (set<Tree>::iterator j = i.second.begin(); j != i.second.end(); ++j) {
+            for (TreeSet::iterator j = i.second.begin(); j != i.second.end(); ++j) {
                 if (j == i.second.begin()) {
                     dst << "declare " << *(i.first) << " " << **j << ";" << endl;
                 } else {

--- a/compiler/global.hh
+++ b/compiler/global.hh
@@ -85,8 +85,8 @@ struct comp_str {
     bool operator()(Tree s1, Tree s2) const { return (strcmp(tree2str(s1), tree2str(s2)) < 0); }
 };
 
-typedef std::map<Tree, std::set<Tree>, comp_str> MetaDataSet;
-typedef std::map<Tree, std::set<Tree>>           FunMDSet;  // foo -> {(file/foo/key,value)...}
+typedef std::map<Tree, TreeSet, comp_str> MetaDataSet;
+typedef TreeMap<TreeSet>                  FunMDSet;  // foo -> {(file/foo/key,value)...}
 
 // Global outside of the global context
 extern std::vector<std::string> gWarningMessages;
@@ -366,7 +366,7 @@ struct global {
     bool gLstMdocTagsSwitch;      // mdoc listing management
     bool gLstDistributedSwitch;   // mdoc listing management
 
-    std::unordered_map<Tree, std::set<Tree>> gDependencies;
+    std::unordered_map<Tree, TreeSet> gDependencies;
 
     bool gAutoDifferentiate;
 
@@ -402,7 +402,7 @@ struct global {
     // Tree is used to identify the same nodes during Box tree traversal,
     // but gBoxCounter is then used to generate unique IDs
 
-    std::map<Tree, std::pair<int, std::string>> gBoxTable;
+    TreeMap<std::pair<int, std::string>>        gBoxTable;
     int                                         gBoxCounter;
     // To keep the box tree traversing trace
     std::vector<std::string> gBoxTrace;
@@ -412,7 +412,7 @@ struct global {
     // ------------
     // Tree is used to identify the same nodes during Signal tree traversal,
     // but gSignalCounter is then used to generate unique IDs
-    std::map<Tree, std::pair<int, std::string>> gSignalTable;
+    TreeMap<std::pair<int, std::string>>        gSignalTable;
     int                                         gSignalCounter;
     // To keep the signal tree traversing trace
     std::vector<std::string> gSignalTrace;
@@ -652,11 +652,11 @@ struct global {
     Occur*                      gOccurrences;
     bool                        gFoldingFlag;     // true with complex block-diagrams
     std::stack<Tree>            gPendingExp;      // Expressions that need to be drawn
-    std::set<Tree>              gDrawnExp;        // Expressions drawn or scheduled so far
+    TreeSet                     gDrawnExp;        // Expressions drawn or scheduled so far
     const char*                 gDevSuffix;       // .svg or .ps used to choose output device
     std::string                 gSchemaFileName;  // name of schema file beeing generated
     Tree                        gInverter[6];
-    std::map<Tree, std::string> gBackLink;  // link to enclosing file for sub schema
+    TreeMap<std::string>        gBackLink;  // link to enclosing file for sub schema
 
     // FIR
     std::map<Typed::VarType, BasicTyped*>
@@ -669,7 +669,7 @@ struct global {
         gTablesSize;  // Global tables size in bytes: class name, <table name, size>
 
     // Colorize
-    std::map<Tree, int> gColorMap;
+    TreeMap<int>        gColorMap;
     int                 gNextFreeColor;
 
     // To keep current local

--- a/compiler/libcode.cpp
+++ b/compiler/libcode.cpp
@@ -1045,7 +1045,7 @@ static void generateCodeAux1(unique_ptr<ostream>& helpers, unique_ptr<ifstream>&
 static void printHeader(ostream& dst)
 {
     // defines the metadata we want to print as comments at the begin of in the C++ file
-    set<Tree> selectedKeys;
+    TreeSet selectedKeys;
     selectedKeys.insert(tree("name"));
     selectedKeys.insert(tree("author"));
     selectedKeys.insert(tree("copyright"));

--- a/compiler/normalize/aterm.cpp
+++ b/compiler/normalize/aterm.cpp
@@ -25,7 +25,7 @@
 
 using namespace std;
 
-typedef map<Tree, mterm> SM;
+typedef TreeMap<mterm> SM;
 
 aterm::aterm()
 {

--- a/compiler/normalize/aterm.hh
+++ b/compiler/normalize/aterm.hh
@@ -42,7 +42,7 @@
  */
 
 class aterm : public virtual Garbageable {
-    std::map<Tree, mterm> fSig2MTerms;  ///< mapping between signatures and corresponding mterms
+    TreeMap<mterm> fSig2MTerms;  ///< mapping between signatures and corresponding mterms
 
    public:
     aterm();        ///< create an empty aterm (equivalent to 0)

--- a/compiler/normalize/mterm.cpp
+++ b/compiler/normalize/mterm.cpp
@@ -28,7 +28,7 @@
 
 using namespace std;
 
-typedef map<Tree, int> MP;
+typedef TreeMap<int> MP;
 
 mterm::mterm() : fCoef(sigInt(0))
 {

--- a/compiler/normalize/mterm.hh
+++ b/compiler/normalize/mterm.hh
@@ -42,7 +42,7 @@
 
 class mterm : public virtual Garbageable {
     Tree                fCoef;     ///< constant part of the term (usually 1 or -1)
-    std::map<Tree, int> fFactors;  ///< non constant terms and their power
+    TreeMap<int>        fFactors;  ///< non constant terms and their power
 
    public:
     mterm();                ///< create a 0 mterm

--- a/compiler/parallelize/code_loop.hh
+++ b/compiler/parallelize/code_loop.hh
@@ -79,7 +79,7 @@ class CodeLoop : public virtual Garbageable {
     int                  fUseCount;    ///< how many loops depend on this one
     std::list<CodeLoop*> fExtraLoops;  ///< extra loops that where in sequences
 
-    std::set<Tree>      fRecDependencies;  ///< Loops having recursive dependencies must be merged
+    TreeSet             fRecDependencies;  ///< Loops having recursive dependencies must be merged
     std::set<CodeLoop*> fBackwardLoopDependencies;  ///< Loops that must be computed before this one
     std::set<CodeLoop*> fForwardLoopDependencies;   ///< Loops that will be computed after this one
 

--- a/compiler/parser/sourcereader.cpp
+++ b/compiler/parser/sourcereader.cpp
@@ -75,7 +75,7 @@ extern const char* FAUSTfilename;
 
 static bool standardArgList(Tree args)
 {
-	map<Tree, int> L;
+	TreeMap<int> L;
 	while (isList(args)) {
 		if (!isBoxIdent(hd(args))) return false;
 		if (++L[hd(args)] > 1) return false;
@@ -434,8 +434,8 @@ Tree SourceReader::expandRec(Tree ldef, set<string>& visited, Tree lresult)
 
 Tree formatDefinitions(Tree rldef)
 {
-    map<Tree, list<Tree>> dic;
-    map<Tree, list<Tree> >::iterator p;
+    TreeMap<list<Tree>> dic;
+    TreeMap<list<Tree>>::iterator p;
     Tree ldef2 = gGlobal->nil;
     Tree file;
 

--- a/compiler/signals/recursivness.cpp
+++ b/compiler/signals/recursivness.cpp
@@ -141,7 +141,7 @@ static int position(Tree env, Tree t, int p)
  * @param sig the signal to analyze
  * @return the set of symbols
  */
-static Tree symlistVisit(Tree sig, set<Tree>& visited)
+static Tree symlistVisit(Tree sig, TreeSet& visited)
 {
     Tree S;
 
@@ -180,7 +180,7 @@ Tree symlist(Tree sig)
     Tree S;
 
     if (!gGlobal->gSymListProp->get(sig, S)) {
-        set<Tree> visited;
+        TreeSet visited;
         S = symlistVisit(sig, visited);
         gGlobal->gSymListProp->set(sig, S);
     }

--- a/compiler/tlib/property.hh
+++ b/compiler/tlib/property.hh
@@ -157,7 +157,7 @@ class property<double> : public Garbageable {
 template <class P>
 class property2 : public Garbageable {
     Tree                      fOuterKey;
-    typedef std::map<Tree, P> Inner;
+    typedef TreeMap<P>        Inner;
 
     struct Slot {
         Tree   fB;      // the single 'b' seen so far ; unused once fInner is non-null
@@ -257,7 +257,7 @@ class property2<Tree> : public Garbageable {
     struct Entry {
         Tree                  fB;      // the single 'b' seen so far ; unused once fInner set
         Tree                  fValue;  // its value ; unused once fInner set
-        std::map<Tree, Tree>* fInner = nullptr;  // non-null once a 2nd distinct 'b' is seen
+        TreeMap<Tree>*        fInner = nullptr;  // non-null once a 2nd distinct 'b' is seen
     };
     std::unordered_map<Tree, Entry> fOuter;
 
@@ -280,7 +280,7 @@ class property2<Tree> : public Garbageable {
             e.fValue = value;
         } else {
             // Second distinct 'b' for this 'a' : only now pay for a small nested map.
-            e.fInner          = new std::map<Tree, Tree>();
+            e.fInner          = new TreeMap<Tree>();
             (*e.fInner)[e.fB] = e.fValue;
             (*e.fInner)[b]    = value;
         }

--- a/compiler/tlib/tree.hh
+++ b/compiler/tlib/tree.hh
@@ -71,6 +71,7 @@
 
 #include <cstddef>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -108,16 +109,17 @@ typedef CTree* Tree;
 
 typedef std::vector<Tree> tvec;
 
-namespace std {
-
-// The std::less <CTree*>comparison function is redefined to provide an unique and stable ordering
-// for all CTree instances and so maintain determinism.
-template <>
-struct less<CTree*> {
+// Orders trees by creation order instead of by address, so that iterating an ordered
+// container of trees is reproducible from one run to the next. Use TreeSet/TreeMap rather
+// than std::set<Tree>/std::map<Tree, T>, which order by address.
+struct treeorder {
     bool operator()(const CTree* lhs, const CTree* rhs) const;
 };
 
-}  // namespace std
+typedef std::set<Tree, treeorder> TreeSet;
+
+template <class T>
+using TreeMap = std::map<Tree, T, treeorder>;
 
 /**
  * A CTree = (Node x [CTree]) is the association of a content Node and a list of subtrees
@@ -165,7 +167,7 @@ class TLIB_API CTree : public Garbageable {
     // memoization keyed by a fresh Tree per call, e.g. substitute()/liftn()) : with a flat buffer
     // that node's O(n) lookup made the whole compile quadratic. std::map keeps every node bounded
     // at O(log n) regardless of how many properties it accumulates. See TLIB.md for the numbers.
-    typedef std::map<Tree, Tree> plist;
+    typedef TreeMap<Tree> plist;
 
    protected:
     // fields
@@ -293,14 +295,10 @@ class TLIB_API CTree : public Garbageable {
     }
 };
 
-// The comparison function relies on lhs->serial() which provides an unique and stable ordering
-// for all CTree instances and so maintain determinism.
-namespace std {
-inline bool less<CTree*>::operator()(const CTree* lhs, const CTree* rhs) const
+inline bool treeorder::operator()(const CTree* lhs, const CTree* rhs) const
 {
     return lhs->serial() < rhs->serial();
 }
-};  // namespace std
 
 //---------------------------------API---------------------------------------
 // To build trees

--- a/compiler/transform/sigRecursiveDependencies.cpp
+++ b/compiler/transform/sigRecursiveDependencies.cpp
@@ -59,9 +59,9 @@
  *
  * @param underVisit, stack of projections under visit (prevent infinite loops)
  * @param sig
- * @return std::set<Tree> set of dependencies of sig
+ * @return TreeSet set of dependencies of sig
  */
-static std::set<Tree> sigDependencies(std::vector<Tree>& underVisit, Tree sig)
+static TreeSet sigDependencies(std::vector<Tree>& underVisit, Tree sig)
 {
     int  i;
     Tree rec, id, le;
@@ -70,7 +70,7 @@ static std::set<Tree> sigDependencies(std::vector<Tree>& underVisit, Tree sig)
         return gGlobal->gDependencies[sig];
     } else if (isProj(sig, &i, rec)) {
         // 2) sig is a projection, its dependencies are itself and the dependecies of its definition
-        std::set<Tree> deps;
+        TreeSet deps;
         if (std::find(underVisit.begin(), underVisit.end(), sig) == underVisit.end()) {
             // we mark the projection under visit and compute the dependencies of its definition
             underVisit.push_back(sig);
@@ -85,9 +85,9 @@ static std::set<Tree> sigDependencies(std::vector<Tree>& underVisit, Tree sig)
     } else {
         // 3) sig is not a projection but is any other expression,
         // its dependencies are the dependencies of its branches
-        std::set<Tree> deps;
+        TreeSet deps;
         for (Tree b : sig->branches()) {
-            std::set<Tree> depsb = sigDependencies(underVisit, b);
+            TreeSet depsb = sigDependencies(underVisit, b);
             deps.insert(depsb.begin(), depsb.end());
         }
         gGlobal->gDependencies[sig] = deps;
@@ -99,9 +99,9 @@ static std::set<Tree> sigDependencies(std::vector<Tree>& underVisit, Tree sig)
  * @brief compute the set of recursive dependencies of a signal
  *
  * @param sig
- * @return std::set<Tree>
+ * @return TreeSet
  */
-std::set<Tree> signalDependencies(Tree sig)
+TreeSet signalDependencies(Tree sig)
 {
     std::vector<Tree> underVisit;
     return sigDependencies(underVisit, sig);
@@ -117,7 +117,7 @@ std::set<Tree> signalDependencies(Tree sig)
  */
 bool isSignalRecursive(Tree proj)
 {
-    std::set<Tree> deps   = signalDependencies(getProjDefinition(proj));
+    TreeSet        deps   = signalDependencies(getProjDefinition(proj));
     bool           answer = deps.find(proj) != deps.end();
 #if 0
     if (answer) {
@@ -147,7 +147,7 @@ bool isSignalRecursive(Tree proj)
  */
 bool isDependingOn(Tree sig, Tree proj)
 {
-    std::set<Tree> deps   = signalDependencies(sig);
+    TreeSet        deps   = signalDependencies(sig);
     bool           answer = deps.find(proj) != deps.end();
     return answer;
 }
@@ -192,7 +192,7 @@ Tree getProjFinalDefinition(Tree proj)
  */
 void printDependencies(const std::string& msg, Tree sig)
 {
-    std::set<Tree> deps = signalDependencies(sig);
+    TreeSet deps = signalDependencies(sig);
     std::cerr << msg << " dependencies of " << ppsig(sig, 20) << " are: (";
     for (Tree d : deps) {
         std::cerr << *d << " ";

--- a/compiler/transform/sigRecursiveDependencies.hh
+++ b/compiler/transform/sigRecursiveDependencies.hh
@@ -40,9 +40,9 @@
  * @brief compute the set of dependencies of a signal
  *
  * @param sig
- * @return std::set<Tree>
+ * @return TreeSet
  */
-std::set<Tree> signalDependencies(Tree sig);
+TreeSet signalDependencies(Tree sig);
 
 /**
  * @brief true if signal is a recursive projection that depends on itself, false otherwise

--- a/compiler/transform/signalFIRCompiler.hh
+++ b/compiler/transform/signalFIRCompiler.hh
@@ -684,15 +684,15 @@ struct SignalFIRCompiler : public SignalVisitor {
 
     std::stack<ValueInst*> fValueStack;  // Compiler's value stack used during signal traversal
 
-    std::map<Tree, DelayLine> fDelays;  // Mapping between signals and their delay buffers
-    std::map<Tree, TableData> fTables;  // Mapping between signals and their associated tables
-                                        // std::map<Tree, TableData> fWaveforms;    // (Commented
-                                        // out) Similar to tables but for waveforms
-    std::map<Tree, inputControl>  fInputControls;   // UI input controls (buttons, sliders, etc.)
-    std::map<Tree, outputControl> fOutputControls;  // UI output controls (bargraphs)
-    int                           fNumInputs  = 0;  // Number of DSP input signals
-    int                           fNumOutputs = 0;  // Number of DSP output signals
-    Tree                          fOutputSig;       // The root signal tree to compile
+    TreeMap<DelayLine> fDelays;  // Mapping between signals and their delay buffers
+    TreeMap<TableData> fTables;  // Mapping between signals and their associated tables
+                                 // TreeMap<TableData> fWaveforms;    // (Commented
+                                 // out) Similar to tables but for waveforms
+    TreeMap<inputControl>  fInputControls;   // UI input controls (buttons, sliders, etc.)
+    TreeMap<outputControl> fOutputControls;  // UI output controls (bargraphs)
+    int                    fNumInputs  = 0;  // Number of DSP input signals
+    int                    fNumOutputs = 0;  // Number of DSP output signals
+    Tree                   fOutputSig;       // The root signal tree to compile
 
     SignalFIRCompiler() = default;
 

--- a/compiler/transform/signalRenderer.hh
+++ b/compiler/transform/signalRenderer.hh
@@ -541,12 +541,12 @@ struct SignalRenderer : public SignalVisitor {
     }
 
     std::stack<Node>                fValueStack;     // Interpreter stack of values
-    std::map<Tree, DelayLine<int>>  fIntDelays;      // Delay lines for integer signals
-    std::map<Tree, DelayLine<REAL>> fRealDelays;     // Delay lines for REAL signals
-    std::map<Tree, TableData<int>>  fIntTables;      // Table for integer signals
-    std::map<Tree, TableData<REAL>> fRealTables;     // Table for REAL signals
-    std::map<Tree, inputControl>    fInputControls;  // Inputs controls (sliders, nentries, buttons)
-    std::map<Tree, outputControl>   fOutputControls;  // Output controls (bargraphs)
+    TreeMap<DelayLine<int>>         fIntDelays;      // Delay lines for integer signals
+    TreeMap<DelayLine<REAL>>        fRealDelays;     // Delay lines for REAL signals
+    TreeMap<TableData<int>>         fIntTables;      // Table for integer signals
+    TreeMap<TableData<REAL>>        fRealTables;     // Table for REAL signals
+    TreeMap<inputControl>           fInputControls;  // Inputs controls (sliders, nentries, buttons)
+    TreeMap<outputControl>          fOutputControls;  // Output controls (bargraphs)
     int                             fNumInputs  = 0;
     int                             fNumOutputs = 0;
     int                             fSampleRate = -1;

--- a/compiler/transform/treeTraversal.hh
+++ b/compiler/transform/treeTraversal.hh
@@ -51,7 +51,7 @@ class TreeTraversal : public Garbageable {
     explicit TreeTraversal(const std::string& msg = "TreeTraversal") : fMessage(msg) {}
     virtual ~TreeTraversal() = default;
 
-    std::map<Tree, int> fVisited;  // visiting counter
+    TreeMap<int> fVisited;  // visiting counter
 
     virtual void self(Tree t)
     {


### PR DESCRIPTION
### Problem

`compiler/tlib/tree.hh` specializes `std::less<CTree*>` to order trees by `serial()`, so that iterating an ordered container of trees is reproducible.

libc++ (20+) has a `__make_transparent` optimisation that rewrites `std::less<T>` to the transparent `std::less<>` when it recognises the comparator as the default one:

```cpp
// libc++ __functional/operations.h
template <class _Tp> struct __make_transparent<_Tp, less<_Tp> > { using type = less<>; };
```

It applies on the container **insert** path (`__tree::__find_equal`), but not on the lookup path (`__tree::__count_unique`, which calls `value_comp()`). Every `std::set<Tree>` / `std::map<Tree, T>` in the compiler is therefore **built in address order and queried in serial order**.

The result is a container whose lookups miss entries that are present. In `symlistVisit()` the `visited` set stops blocking revisits, so the walk re-descends into signals it has already marked and recurses until the 16 MB compiler thread stack is exhausted:

```
#14 symlistVisit+0x1ab [compiler/signals/recursivness.cpp @ 163]
#15 symlistVisit+0x147 [compiler/signals/recursivness.cpp @ 158]
...  ~69,900 frames, 240 bytes each -> 16.7 MB
```

with the same five `Tree` pointers cycling forever. Instrumenting the set at the point of divergence:

```
FIRST-DIVERGENCE sig=0x03525AE0 count=0 find=1 size=34
ORDER-CHECK: violations-if-ordered-by-ADDRESS=0  violations-if-ordered-by-SERIAL=10
SERIALS: n=34 distinct=34 duplicated=0
```

Whether it crashes depends on the addresses `malloc` happens to return, so it is intermittent — `process = (+ ~ _), (+ ~ _);` fails about half of the time.

`CTree::plist` is `std::map<Tree, Tree>`, so the property/memoization layer is affected too, not just `symlist`.

Specializing `std::less` for a program-defined type is undefined behaviour in any case: [namespace.std] allows adding a specialization only if it "meets the standard library requirements for the original template", and `std::less<T*>` is required to yield the implementation-defined strict total order over pointers. libc++ is entitled to assume `std::less<T>` means `<`.

### Fix

Replace the specialization with a named `treeorder` comparator, plus `TreeSet` / `TreeMap<T>` aliases, and use them wherever a container is keyed by `Tree`. A named comparator is not pattern-matched by `__make_transparent`, so both paths agree.

### Results

`examples/*.dsp` compiled with the LLVM backend, 3 runs each, comparing the emitted IR across runs (clang 22 / libc++, MSYS2 CLANG64):

| | before | after |
|---|---|---|
| compiled, identical IR on every run | 33 | 258 |
| segfault | 223 | 1 |
| non-deterministic IR | 8 | 0 |
| other errors | 32 | 37 |

The one remaining segfault (`physicalModeling/fds/2dKirchhoffThinPlate.dsp`) reproduces identically before the change — a genuinely deep signal graph, unrelated.

"Other errors" are environmental in both columns (`unable to open file instruments.lib`, `undefined symbol : process` on library-style files); the count rises only because files that used to crash now get far enough to report a real error.

Determinism is preserved: the ordering is still by `serial()`, and no example produced differing IR across runs after the change.

Built and tested on MSYS2 CLANG64, clang 22.1.8, LLVM backend.
