### PR TITLE
poly-dsp.h: Steal the oldest vocie, not the least frequently used one

### DIFF
--- a/architecture/faust/dsp/poly-dsp.h
+++ b/architecture/faust/dsp/poly-dsp.h
@@ -624,7 +624,7 @@ class mydsp_poly : public dsp_voice_group, public dsp_poly {
         // Allocate a voice with a given type
         int allocVoice(int voice, int type)
         {
-            fVoiceTable[voice]->fDate++;
+            fVoiceTable[voice]->fDate = fDate++;
             fVoiceTable[voice]->fCurNote = type;
             return voice;
         }


### PR DESCRIPTION
Noticed while holding down five 5 keys on a [nvoices:4] patch, and letting each one go individually -- sometimes the first note played got released, sometimes it was a different one.

Looks like the code was tracking and checking usage instead of fDate being a clock. Instantiation also seems to indicate the variable was for a clock rather than tracking usage, and "steal the oldest voice" seems more reasonable and more in line with the intention rather than the least frequently used voice.