### PR TITLE
Include the memory model in the wasm DSP factory cache key

### DIFF
--- a/compiler/generator/wasm/wasm_dynamic_dsp_aux.cpp
+++ b/compiler/generator/wasm/wasm_dynamic_dsp_aux.cpp
@@ -26,6 +26,7 @@
 #include "wasm_dynamic_dsp_aux.hh"
 #include "Text.hh"
 #include "compatibility.hh"
+#include "libfaust.h"
 #include "lock_api.hh"
 
 using namespace std;
@@ -63,14 +64,16 @@ LIBFAUST_API wasm_dsp_factory* createWasmDSPFactoryFromString(const string& name
     if ((expanded_dsp_content = sha1FromDSP(name_app, dsp_content, argc, argv, sha_key)) == "") {
         return nullptr;
     } else {
+        // The target language changes the generated binary, so it is part of the cache key
+        const char* lang = (internal_memory ? "wasm-i" : "wasm-e");
+        sha_key          = generateSHA1(sha_key + lang);
         dsp_factory_table<SDsp_factory>::factory_iterator it;
         if (wasm_dsp_factory::gWasmFactoryTable.getFactory(sha_key, it)) {
             SDsp_factory sfactory = (*it).first;
             sfactory->addReference();
             return sfactory;
         } else {
-            vector<const char*> argv1 = {"faust", "-lang", (internal_memory ? "wasm-i" : "wasm-e"),
-                                         "-o", "binary"};
+            vector<const char*> argv1 = {"faust", "-lang", lang, "-o", "binary"};
             for (int i = 0; i < argc; i++) {
                 argv1.push_back(argv[i]);
             }


### PR DESCRIPTION
When switching from monophonic compile/runs to polyphonic ones, in Firefox/Zen, I was getting index out of bounds errors. This seems to fix it.

Claude explanation follows:

createWasmDSPFactoryFromString caches factories in gWasmFactoryTable under sha1(name + expanded code + normalized options), but the internal_memory argument -- which selects '-lang wasm-i' (module owns a one-instance internal memory) versus '-lang wasm-e' (module imports its memory from the host) -- was not part of the key. The two flags produce different binaries from the same source, so a cache hit could answer a request for one memory model with a factory built for the other.

The practical failure is the polyphonic one. The WebAssembly wrappers (faustwasm) compile a program twice: once with internal memory to read its metadata, once without so that N voices can be instantiated over one shared memory sized for N. If the first factory is still alive in the table when the second compile runs, the poly request is handed the wasm-i module; every voice is then placed at voiceSize * n inside a memory sized for one voice, and the first chord's third note faults with 'RuntimeError: index out of bounds' from setParamValue, killing the AudioWorklet for the session. This was reproduced deterministically in both Gecko and Chromium by running two concurrent compilations of the same polyphonic source, and observed in the wild as 'adding [nvoices:8] and saving goes silent until reload'.

Mixing the flag into the key makes the two builds distinct cache entries. Factory keys remain self-consistent (getSHAKey/getWasmDSPFactoryFromSHAKey round-trip), but wasm factory keys no longer equal the bare expandDSPFromString sha; that was already a collision, not a contract.

Note the JS-side wrappers can also avoid the collision by deleting the metadata-probe factory before their first await (faustwasm currently frees it only after 'await WebAssembly.compile', which is the window the race needs); that mitigation belongs in the faustwasm repository. This change removes the underlying ambiguity.